### PR TITLE
Abstract into post service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql"
-version = "5.0.5"
+version = "5.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c7c1f9bf1a875b047e97404d16313b3dde09ea06d0639800c9657138e38a441"
+checksum = "692d27c9d6fbb7afafd092706cbb3e4a2087297e10e1f0ca82b3f950f31d9258"
 dependencies = [
  "async-graphql-derive",
  "async-graphql-parser",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-axum"
-version = "5.0.5"
+version = "5.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7376168771050c81d948df67fdabccf0ed9a238e565c6ca8065af6eccc570d84"
+checksum = "d1d0502d50c842311407a919501536e1741442da26f664e3f3e5b93f8683edd3"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-derive"
-version = "5.0.5"
+version = "5.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381ed1575c53cfc864013932bb5a5df05c21802781dfa6dd27c57068eac9a80d"
+checksum = "ec10e63a513389190e9f8f32453bfcfeef271e25e841d61905985f838a5345eb"
 dependencies = [
  "Inflector",
  "async-graphql-parser",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-parser"
-version = "5.0.5"
+version = "5.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a7ec217e184ca3034c806957842afb28914f894b69cb5a76b4a57e64f44506"
+checksum = "c79500e9bed6b3cf5e1d3960264b7dbc275dd45b56a3f919c30f0cbbf3ea9cba"
 dependencies = [
  "async-graphql-value",
  "pest",
@@ -325,9 +325,9 @@ dependencies = [
 
 [[package]]
 name = "async-graphql-value"
-version = "5.0.5"
+version = "5.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e294ef57859c27d31a9bb23edf1db948f7534445df30115d8672314f65451858"
+checksum = "e14fde4382b75c27fafcaca59b423d4530f73e7f62f41bfa38e8f249026d22ed"
 dependencies = [
  "bytes",
  "indexmap",
@@ -496,14 +496,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5694b64066a2459918d8074c2ce0d5a88f409431994c2356617c8ae0c4721fc"
+checksum = "4e246206a63c9830e118d12c894f56a82033da1a2361f5544deeee3df85c99d9"
 dependencies = [
  "async-trait",
  "axum-core",
  "axum-macros",
- "base64 0.20.0",
+ "base64 0.21.0",
  "bitflags",
  "bytes",
  "futures-util",
@@ -551,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+checksum = "51227033e4d3acad15c879092ac8a228532707b5db5ff2628f638334f63e1b7a"
 dependencies = [
  "axum",
  "bytes",
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbcf61bed07d554bd5c225cd07bc41b793eab63e79c6f0ceac7e1aed2f1c670"
+checksum = "5fbf955307ff8addb48d2399393c9e2740dd491537ec562b66ab364fc4a38841"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -622,12 +622,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -4142,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "serde_html_form"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d051fb33111db0e81673ed8c55db741952a19ad81dc584960c8aec836498ba5"
+checksum = "53192e38d5c88564b924dbe9b60865ecbb71b81d38c4e61c817cffd3e36ef696"
 dependencies = [
  "form_urlencoded",
  "indexmap",
@@ -4506,9 +4500,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tantivy"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513d4e19dc483209aa0ff9dc40d831f5bfa529917ae836b6fc1f01113ec84dc7"
+checksum = "5bb26a6b22c84d8be41d99a14016d6f04d30d8d31a2ea411a8ab553af5cc490d"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -4823,9 +4817,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,6 +2320,7 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
+ "tracing-log",
 ]
 
 [[package]]

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -9,3 +9,4 @@ migration = { path = "migration" }
 sea-orm = "0.11.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
+tracing-log = "0.1.3"

--- a/kitsune-db/src/lib.rs
+++ b/kitsune-db/src/lib.rs
@@ -16,6 +16,7 @@
 
 use migration::{Migrator, MigratorTrait};
 use sea_orm::{Database, DatabaseConnection, DbErr};
+use tracing_log::LogTracer;
 
 pub mod column;
 pub mod custom;
@@ -30,6 +31,8 @@ pub mod link;
 /// - Connection could not be established
 /// - Running the migration failed
 pub async fn connect(db_url: &str) -> Result<DatabaseConnection, DbErr> {
+    LogTracer::init().ok();
+
     let conn = Database::connect(db_url).await?;
     Migrator::up(&conn, None).await?;
     Ok(conn)

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -17,7 +17,7 @@ metrics-util = "0.14.0"
 mimalloc = "0.1.34"
 prost = "0.11.6"
 serde = { version = "1.0.152", features = ["derive"] }
-tantivy = "0.19.1"
+tantivy = "0.19.2"
 tokio = { version = "1.25.0", features = ["full"] }
 tonic = "0.8.3"
 tonic-health = "0.8.0"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -9,21 +9,21 @@ homepage = "https://kitsune-soc.github.io"
 ammonia = "3.3.0"
 argon2 = { version = "0.4.1", features = ["std"] }
 askama = "0.11.1"
-async-graphql = { version = "5.0.5", features = [
+async-graphql = { version = "5.0.6", features = [
     "chrono",
     "email-validator",
     "tracing",
     "unblock",
     "uuid",
 ] }
-async-graphql-axum = "5.0.5"
+async-graphql-axum = "5.0.6"
 async-recursion = "1.0.2"
 async-trait = "0.1.64"
 autometrics = { version = "0.2.4", default-features = false, features = [
     "metrics",
 ] }
-axum = { version = "0.6.4", features = ["headers", "macros"] }
-axum-extra = { version = "0.4.2", features = ["query"] }
+axum = { version = "0.6.6", features = ["headers", "macros"] }
+axum-extra = { version = "0.5.0", features = ["query"] }
 axum-prometheus = "0.3.0"
 base64 = "0.21.0"
 blurhash-ng = "0.1.2"
@@ -69,7 +69,7 @@ serde_json = "1.0.93"
 sha2 = "0.10.6"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }
-tokio-util = { version = "0.7.4", features = ["compat"] }
+tokio-util = { version = "0.7.7", features = ["compat"] }
 tonic = "0.8.3"
 tower-http = { version = "0.3.5", features = ["cors", "fs", "trace"] }
 tracing = "0.1.37"

--- a/kitsune/src/http/graphql/mutation/post.rs
+++ b/kitsune/src/http/graphql/mutation/post.rs
@@ -1,28 +1,18 @@
 use crate::{
-    error::Error as ServerError,
     http::graphql::{
         types::{Post, Visibility},
         ContextExt,
     },
-    job::{
-        deliver::{create::CreateDeliveryContext, delete::DeleteDeliveryContext},
-        Job,
-    },
-    resolve::PostResolver,
-    sanitize::CleanHtmlExt,
-    search::SearchService,
+    job::{deliver::delete::DeleteDeliveryContext, Job},
+    service::{post::CreatePost, search::SearchService},
 };
 use async_graphql::{Context, Error, Object, Result};
 use chrono::Utc;
-use futures_util::FutureExt;
 use kitsune_db::{
     custom::JobState,
-    entity::{jobs, posts, posts_mentions, prelude::Posts},
+    entity::{jobs, posts, prelude::Posts},
 };
-use pulldown_cmark::{html, Options, Parser};
-use sea_orm::{
-    ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter, TransactionTrait,
-};
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
 use uuid::Uuid;
 
 #[derive(Default)]
@@ -38,92 +28,23 @@ impl PostMutation {
         visibility: Visibility,
     ) -> Result<Post> {
         let state = ctx.state();
-        let mut search_service = state.search_service.clone();
         let user_data = ctx.user_data()?;
 
-        let content = {
-            let parser = Parser::new_ext(&content, Options::all());
-            let mut buf = String::new();
-            html::push_html(&mut buf, parser);
-            buf.clean_html();
-            buf
-        };
+        let create_post = CreatePost::builder()
+            .author_id(user_data.account.id)
+            .sensitive(is_sensitive)
+            .content(content)
+            .visibility(visibility.into())
+            .build()
+            .unwrap();
 
-        // TODO: Cache this resolver somewhere
-        let mention_resolver = PostResolver::new(
-            state.db_conn.clone(),
-            state.fetcher.clone(),
-            state.webfinger.clone(),
-        );
-        let (mentioned_account_ids, content) = mention_resolver.resolve(&content).await?;
+        let post = state.service.post.create(create_post).await?;
 
-        let id = Uuid::now_v7();
-        let account_id = user_data.account.id;
-        let url = format!("https://{}/posts/{id}", state.config.domain);
-
-        state
-            .db_conn
-            .transaction(move |tx| {
-                async move {
-                    let post = posts::Model {
-                        id,
-                        account_id,
-                        in_reply_to_id: None,
-                        subject: None,
-                        content,
-                        is_sensitive,
-                        visibility: visibility.into(),
-                        is_local: true,
-                        url,
-                        created_at: Utc::now().into(),
-                        updated_at: Utc::now().into(),
-                    }
-                    .into_active_model()
-                    .insert(tx)
-                    .await?;
-
-                    for account_id in mentioned_account_ids {
-                        posts_mentions::Model {
-                            account_id,
-                            post_id: post.id,
-                        }
-                        .into_active_model()
-                        .insert(tx)
-                        .await?;
-                    }
-
-                    let job_context =
-                        Job::DeliverCreate(CreateDeliveryContext { post_id: post.id });
-
-                    jobs::Model {
-                        id: Uuid::now_v7(),
-                        state: JobState::Queued,
-                        run_at: Utc::now().into(),
-                        context: serde_json::to_value(job_context).unwrap(),
-                        fail_count: 0,
-                        created_at: Utc::now().into(),
-                        updated_at: Utc::now().into(),
-                    }
-                    .into_active_model()
-                    .insert(tx)
-                    .await?;
-
-                    if visibility == Visibility::Public || visibility == Visibility::Unlisted {
-                        search_service.add_to_index(post.clone()).await?;
-                    }
-
-                    Ok::<_, ServerError>(post)
-                }
-                .boxed()
-            })
-            .await
-            .map(Into::into)
-            .map_err(Error::from)
+        Ok(post.into())
     }
 
     pub async fn delete_post(&self, ctx: &Context<'_>, id: Uuid) -> Result<Uuid> {
         let state = ctx.state();
-        let mut search_service = state.search_service.clone();
         let user_data = ctx.user_data()?;
 
         let post = Posts::find_by_id(id)
@@ -145,8 +66,7 @@ impl PostMutation {
         .into_active_model()
         .insert(&state.db_conn)
         .await?;
-
-        search_service.remove_from_index(post).await?;
+        state.service.search.remove_from_index(post).await?;
 
         Ok(id)
     }

--- a/kitsune/src/http/graphql/types/account.rs
+++ b/kitsune/src/http/graphql/types/account.rs
@@ -3,10 +3,10 @@ use crate::http::graphql::ContextExt;
 use async_graphql::{ComplexObject, Context, Error, Result, SimpleObject};
 use chrono::{DateTime, Utc};
 use kitsune_db::entity::{
-    accounts,
+    accounts, posts,
     prelude::{Accounts, MediaAttachments, Posts},
 };
-use sea_orm::{EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, EntityTrait, QueryFilter};
 use uuid::Uuid;
 
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, SimpleObject)]
@@ -58,7 +58,7 @@ impl Account {
             .ok_or_else(|| Error::new("User not present"))?;
 
         Posts::find()
-            .belongs_to(&account)
+            .filter(posts::Column::AccountId.eq(account.id))
             .all(&ctx.state().db_conn)
             .await
             .map(|posts| posts.into_iter().map(Into::into).collect())

--- a/kitsune/src/http/handler/mastodon/api/v1/statuses/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/statuses/mod.rs
@@ -1,14 +1,9 @@
 use crate::{
     error::Result,
     http::extractor::{AuthExtractor, FormOrJson, MastodonAuthExtractor},
-    job::{
-        deliver::{create::CreateDeliveryContext, delete::DeleteDeliveryContext},
-        Job,
-    },
+    job::{deliver::delete::DeleteDeliveryContext, Job},
     mapping::IntoMastodon,
-    resolve::PostResolver,
-    sanitize::CleanHtmlExt,
-    search::SearchService,
+    service::{post::CreatePost, search::SearchService},
     state::Zustand,
 };
 use axum::{
@@ -18,20 +13,18 @@ use axum::{
     routing, Json, Router,
 };
 use chrono::Utc;
-use futures_util::FutureExt;
 use http::StatusCode;
 use kitsune_db::{
     custom::{JobState, Role, Visibility},
     entity::{
-        jobs, posts, posts_mentions,
+        jobs, posts,
         prelude::{Posts, UsersRoles},
         users_roles,
     },
 };
-use pulldown_cmark::{html, Options, Parser};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, EntityTrait, IntoActiveModel, ModelTrait, PaginatorTrait,
-    QueryFilter, TransactionTrait,
+    QueryFilter,
 };
 use serde::Deserialize;
 use uuid::Uuid;
@@ -53,7 +46,7 @@ struct CreateForm {
 
 #[debug_handler(state = Zustand)]
 async fn delete(
-    State(mut state): State<Zustand>,
+    State(state): State<Zustand>,
     AuthExtractor(user_data): MastodonAuthExtractor,
     Path(id): Path<Uuid>,
 ) -> Result<Response> {
@@ -88,7 +81,7 @@ async fn delete(
     .insert(&state.db_conn)
     .await?;
 
-    state.search_service.remove_from_index(post).await?;
+    state.service.search.remove_from_index(post).await?;
 
     Ok(StatusCode::OK.into_response())
 }
@@ -121,89 +114,25 @@ async fn post(
     AuthExtractor(user_data): MastodonAuthExtractor,
     FormOrJson(form): FormOrJson<CreateForm>,
 ) -> Result<Response> {
-    let mut search_service = state.search_service.clone();
-    let content = {
-        let parser = Parser::new_ext(&form.status, Options::all());
-        let mut buf = String::new();
-        html::push_html(&mut buf, parser);
-        buf.clean_html();
-        buf
-    };
+    // TODO: Use the post service
+    let mut create_post = CreatePost::builder()
+        .author_id(user_data.account.id)
+        .content(form.status)
+        .sensitive(form.sensitive)
+        .visibility(form.visibility)
+        .clone();
 
-    // TODO: Cache this resolver somewhere
-    let mention_resolver = PostResolver::new(
-        state.db_conn.clone(),
-        state.fetcher.clone(),
-        state.webfinger.clone(),
-    );
-    let (mentioned_account_ids, content) = mention_resolver.resolve(&content).await?;
-
-    let id = Uuid::now_v7();
-    let account_id = user_data.account.id;
-    let url = format!("https://{}/posts/{id}", state.config.domain);
+    if let Some(subject) = form.spoiler_text {
+        create_post.subject(subject);
+    }
+    if let Some(in_reply_to_id) = form.in_reply_to_id {
+        create_post.in_reply_to_id(in_reply_to_id);
+    }
 
     let status = state
-        .db_conn
-        .transaction(move |tx| {
-            async move {
-                let in_reply_to_id = if let Some(in_reply_to_id) = form.in_reply_to_id {
-                    (Posts::find_by_id(in_reply_to_id).count(tx).await? != 0)
-                        .then_some(in_reply_to_id)
-                } else {
-                    None
-                };
-
-                let post = posts::Model {
-                    id,
-                    account_id,
-                    in_reply_to_id,
-                    subject: form.spoiler_text,
-                    content,
-                    is_sensitive: form.sensitive,
-                    visibility: form.visibility,
-                    is_local: true,
-                    url,
-                    created_at: Utc::now().into(),
-                    updated_at: Utc::now().into(),
-                }
-                .into_active_model()
-                .insert(tx)
-                .await?;
-
-                for account_id in mentioned_account_ids {
-                    posts_mentions::Model {
-                        account_id,
-                        post_id: post.id,
-                    }
-                    .into_active_model()
-                    .insert(tx)
-                    .await?;
-                }
-
-                let job_context = Job::DeliverCreate(CreateDeliveryContext { post_id: post.id });
-
-                jobs::Model {
-                    id: Uuid::now_v7(),
-                    state: JobState::Queued,
-                    run_at: Utc::now().into(),
-                    context: serde_json::to_value(job_context).unwrap(),
-                    fail_count: 0,
-                    created_at: Utc::now().into(),
-                    updated_at: Utc::now().into(),
-                }
-                .into_active_model()
-                .insert(tx)
-                .await?;
-
-                if form.visibility == Visibility::Public || form.visibility == Visibility::Unlisted
-                {
-                    search_service.add_to_index(post.clone()).await?;
-                }
-
-                Ok(post)
-            }
-            .boxed()
-        })
+        .service
+        .post
+        .create(create_post.build().unwrap())
         .await?
         .into_mastodon(&state)
         .await?;

--- a/kitsune/src/http/handler/mastodon/api/v2/search.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/search.rs
@@ -1,4 +1,4 @@
-use crate::{error::Result, mapping::IntoMastodon, search::SearchService, state::Zustand};
+use crate::{error::Result, mapping::IntoMastodon, service::search::SearchService, state::Zustand};
 use axum::{
     debug_handler,
     extract::State,
@@ -42,10 +42,7 @@ struct SearchQuery {
 }
 
 #[debug_handler]
-async fn get(
-    State(mut state): State<Zustand>,
-    Query(query): Query<SearchQuery>,
-) -> Result<Response> {
+async fn get(State(state): State<Zustand>, Query(query): Query<SearchQuery>) -> Result<Response> {
     let indices = if let Some(r#type) = query.r#type {
         let index = match r#type {
             SearchType::Accounts => SearchIndex::Account,
@@ -61,7 +58,8 @@ async fn get(
     let mut search_result = SearchResult::default();
     for index in indices {
         let results = state
-            .search_service
+            .service
+            .search
             .search(
                 index,
                 query.query.clone(),

--- a/kitsune/src/http/handler/oauth/authorize.rs
+++ b/kitsune/src/http/handler/oauth/authorize.rs
@@ -1,6 +1,6 @@
 use super::TOKEN_VALID_DURATION;
 use crate::{
-    error::{Error, Result},
+    error::{ApiError, Error, Result},
     state::Zustand,
     util::generate_secret,
 };
@@ -89,7 +89,7 @@ pub async fn post(
         .filter(users::Column::Username.eq(form.username))
         .one(&state.db_conn)
         .await?
-        .ok_or(Error::UserNotFound)?;
+        .ok_or(ApiError::NotFound)?;
 
     let application = Oauth2Applications::find_by_id(query.client_id)
         .filter(oauth2_applications::Column::RedirectUri.eq(query.redirect_uri))

--- a/kitsune/src/http/handler/oauth/token.rs
+++ b/kitsune/src/http/handler/oauth/token.rs
@@ -1,6 +1,6 @@
 use super::TOKEN_VALID_DURATION;
 use crate::{
-    error::{Error, Result},
+    error::{ApiError, Error, Result},
     http::extractor::FormOrJson,
     util::{generate_secret, AccessTokenTtl},
 };
@@ -212,7 +212,7 @@ async fn password_grant(db_conn: DatabaseConnection, data: PasswordData) -> Resu
         .filter(users::Column::Username.eq(data.username))
         .one(&db_conn)
         .await?
-        .ok_or(Error::UserNotFound)?;
+        .ok_or(ApiError::NotFound)?;
 
     let is_valid = crate::blocking::cpu(move || {
         let password_hash = PasswordHash::new(&user.password)?;

--- a/kitsune/src/http/handler/users/followers.rs
+++ b/kitsune/src/http/handler/users/followers.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, Result},
+    error::{ApiError, Result},
     state::Zustand,
 };
 use axum::{
@@ -29,7 +29,7 @@ pub async fn get(
         .one(&state.db_conn)
         .await?
     else {
-        return Err(Error::UserNotFound);
+        return Err(ApiError::NotFound.into());
     };
 
     let follower_count = account.find_linked(Followers).count(&state.db_conn).await?;

--- a/kitsune/src/http/handler/users/following.rs
+++ b/kitsune/src/http/handler/users/following.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, Result},
+    error::{ApiError, Result},
     state::Zustand,
 };
 use axum::{
@@ -29,7 +29,7 @@ pub async fn get(
         .one(&state.db_conn)
         .await?
     else {
-        return Err(Error::UserNotFound);
+        return Err(ApiError::NotFound.into());
     };
 
     let following_count = account.find_linked(Following).count(&state.db_conn).await?;

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, Result},
+    error::{ApiError, Error, Result},
     mapping::IntoActivity,
     state::Zustand,
 };
@@ -48,7 +48,7 @@ pub async fn get(
         .one(&state.db_conn)
         .await?
     else {
-        return Err(Error::UserNotFound);
+        return Err(ApiError::NotFound.into());
     };
 
     let base_url = format!("https://{}{}", state.config.domain, original_uri.path());

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -53,7 +53,7 @@ pub async fn get(
 
     let base_url = format!("https://{}{}", state.config.domain, original_uri.path());
     let base_query = Posts::find()
-        .belongs_to(&account)
+        .filter(posts::Column::AccountId.eq(account.id))
         .filter(posts::Column::Visibility.is_in([Visibility::Public, Visibility::Unlisted]));
 
     if query.page {

--- a/kitsune/src/lib.rs
+++ b/kitsune/src/lib.rs
@@ -24,7 +24,7 @@ pub mod job;
 pub mod mapping;
 pub mod resolve;
 pub mod sanitize;
-pub mod search;
+pub mod service;
 pub mod state;
 pub mod util;
 pub mod webfinger;

--- a/kitsune/src/main.rs
+++ b/kitsune/src/main.rs
@@ -3,8 +3,13 @@
 
 use axum_prometheus::{AXUM_HTTP_REQUESTS_DURATION_SECONDS, SECONDS_DURATION_BUCKETS};
 use kitsune::{
-    activitypub::Fetcher, config::Configuration, http, job, search::GrpcSearchService,
-    state::Zustand, webfinger::Webfinger,
+    activitypub::Fetcher,
+    config::Configuration,
+    http, job,
+    resolve::PostResolver,
+    service::{post::PostService, search::GrpcSearchService},
+    state::{Service, Zustand},
+    webfinger::Webfinger,
 };
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use metrics_tracing_context::{MetricsLayer, TracingContextLayer};
@@ -77,12 +82,27 @@ async fn main() {
             .await
             .expect("Failed to connect to the search servers");
 
+    let fetcher = Fetcher::with_defaults(conn.clone(), search_service.clone(), redis_conn.clone());
+    let webfinger = Webfinger::with_redis_cache(redis_conn);
+
+    let post_resolver = PostResolver::new(conn.clone(), fetcher.clone(), webfinger.clone());
+    let post_service = PostService::builder()
+        .config(config.clone())
+        .db_conn(conn.clone())
+        .post_resolver(post_resolver)
+        .search_service(search_service.clone())
+        .build()
+        .unwrap();
+
     let state = Zustand {
         config: config.clone(),
-        db_conn: conn.clone(),
-        fetcher: Fetcher::with_defaults(conn, search_service.clone(), redis_conn.clone()),
-        search_service,
-        webfinger: Webfinger::with_redis_cache(redis_conn),
+        db_conn: conn,
+        fetcher,
+        service: Service {
+            search: search_service,
+            post: post_service,
+        },
+        webfinger,
     };
 
     tokio::spawn(self::http::run(state.clone(), config.port));

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, Result},
+    error::{ApiError, Result},
     state::Zustand,
 };
 use async_trait::async_trait;
@@ -34,12 +34,13 @@ impl IntoObject for media_attachments::Model {
     type Output = MediaAttachment;
 
     async fn into_object(self, _state: &Zustand) -> Result<Self::Output> {
-        let mime = Mime::from_str(&self.content_type).map_err(|_| Error::UnsupportedMediaType)?;
+        let mime =
+            Mime::from_str(&self.content_type).map_err(|_| ApiError::UnsupportedMediaType)?;
         let r#type = match mime.type_() {
             mime::AUDIO => MediaAttachmentType::Audio,
             mime::IMAGE => MediaAttachmentType::Image,
             mime::VIDEO => MediaAttachmentType::Video,
-            _ => return Err(Error::UnsupportedMediaType),
+            _ => return Err(ApiError::UnsupportedMediaType.into()),
         };
 
         Ok(MediaAttachment {

--- a/kitsune/src/mapping/mastodon.rs
+++ b/kitsune/src/mapping/mastodon.rs
@@ -122,7 +122,7 @@ impl IntoMastodon for posts::Model {
         let favourites_count = self.find_related(Favourites).count(&state.db_conn).await?;
 
         let mentions = PostsMentions::find()
-            .belongs_to(&self)
+            .filter(posts_mentions::Column::PostId.eq(self.id))
             .stream(&state.db_conn)
             .await?
             .map_err(Error::from)

--- a/kitsune/src/resolve/post.rs
+++ b/kitsune/src/resolve/post.rs
@@ -2,7 +2,7 @@ use crate::{
     activitypub::Fetcher,
     cache::Cache,
     error::{Error, Result},
-    search::SearchService,
+    service::search::SearchService,
     webfinger::Webfinger,
 };
 use kitsune_db::entity::{accounts, posts, prelude::Accounts};
@@ -12,6 +12,7 @@ use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use std::{borrow::Cow, collections::HashSet, mem};
 use uuid::Uuid;
 
+#[derive(Clone)]
 pub struct PostResolver<FS, FPC, FUC, WC> {
     db_conn: DatabaseConnection,
     fetcher: Fetcher<FS, FPC, FUC>,
@@ -127,7 +128,8 @@ where
 mod test {
     use super::PostResolver;
     use crate::{
-        activitypub::Fetcher, cache::NoopCache, search::NoopSearchService, webfinger::Webfinger,
+        activitypub::Fetcher, cache::NoopCache, service::search::NoopSearchService,
+        webfinger::Webfinger,
     };
     use kitsune_db::entity::prelude::Accounts;
     use pretty_assertions::assert_eq;

--- a/kitsune/src/service/mod.rs
+++ b/kitsune/src/service/mod.rs
@@ -1,0 +1,2 @@
+pub mod post;
+pub mod search;

--- a/kitsune/src/service/post.rs
+++ b/kitsune/src/service/post.rs
@@ -1,0 +1,179 @@
+use super::search::{GrpcSearchService, SearchService};
+use crate::{
+    cache::{Cache, RedisCache},
+    config::Configuration,
+    error::Result,
+    job::{deliver::create::CreateDeliveryContext, Job},
+    resolve::PostResolver,
+    sanitize::CleanHtmlExt,
+};
+use chrono::Utc;
+use derive_builder::Builder;
+use futures_util::FutureExt;
+use kitsune_db::{
+    custom::{JobState, Visibility},
+    entity::{accounts, jobs, posts, posts_mentions, prelude::Posts},
+};
+use pulldown_cmark::{html, Options, Parser};
+use sea_orm::{
+    ActiveModelTrait, DatabaseConnection, EntityTrait, IntoActiveModel, PaginatorTrait,
+    TransactionTrait,
+};
+use uuid::Uuid;
+
+#[derive(Clone, Builder)]
+pub struct CreatePost {
+    /// ID of the author
+    ///
+    /// This is not validated. Make sure this is a valid and verified value.
+    author_id: Uuid,
+
+    /// ID of the post this post is replying to
+    ///
+    /// This is validated. If you pass in an non-existent ID, it will be ignored.
+    #[builder(default, setter(strip_option))]
+    in_reply_to_id: Option<Uuid>,
+
+    /// Mark this post as sensitive
+    ///
+    /// Defaults to false
+    #[builder(default)]
+    sensitive: bool,
+
+    #[builder(default, setter(strip_option))]
+    /// Subject of the post
+    ///
+    /// This is optional
+    subject: Option<String>,
+
+    /// Content of the post
+    content: String,
+
+    #[builder(default = "Visibility::Public")]
+    /// Visibility of the post
+    ///
+    /// Defaults to public
+    visibility: Visibility,
+}
+
+impl CreatePost {
+    #[must_use]
+    pub fn builder() -> CreatePostBuilder {
+        CreatePostBuilder::default()
+    }
+}
+
+#[derive(Builder, Clone)]
+#[builder(pattern = "owned")]
+pub struct PostService<
+    S = GrpcSearchService,
+    FPC = RedisCache<str, posts::Model>,
+    FUC = RedisCache<str, accounts::Model>,
+    WC = RedisCache<str, String>,
+> {
+    config: Configuration,
+    db_conn: DatabaseConnection,
+    search_service: S,
+    post_resolver: PostResolver<S, FPC, FUC, WC>,
+}
+
+impl<S, FPC, FUC, WC> PostService<S, FPC, FUC, WC>
+where
+    S: SearchService,
+    FPC: Cache<str, posts::Model>,
+    FUC: Cache<str, accounts::Model>,
+    WC: Cache<str, String>,
+{
+    #[must_use]
+    pub fn builder() -> PostServiceBuilder<S, FPC, FUC, WC> {
+        PostServiceBuilder::default()
+    }
+
+    /// Create a new post and deliver it to the followers
+    ///
+    /// # Panics
+    ///
+    /// This should never ever panic. If it does, create a bug report.
+    pub async fn create(&self, create_post: CreatePost) -> Result<posts::Model> {
+        let content = {
+            let parser = Parser::new_ext(&create_post.content, Options::all());
+            let mut buf = String::new();
+            html::push_html(&mut buf, parser);
+            buf.clean_html();
+            buf
+        };
+
+        let (mentioned_account_ids, content) = self.post_resolver.resolve(&content).await?;
+
+        let id = Uuid::now_v7();
+        let url = format!("https://{}/posts/{id}", self.config.domain);
+
+        let post = self
+            .db_conn
+            .transaction(move |tx| {
+                async move {
+                    let in_reply_to_id = if let Some(in_reply_to_id) = create_post.in_reply_to_id {
+                        (Posts::find_by_id(in_reply_to_id).count(tx).await? != 0)
+                            .then_some(in_reply_to_id)
+                    } else {
+                        None
+                    };
+
+                    let post = posts::Model {
+                        id,
+                        account_id: create_post.author_id,
+                        in_reply_to_id,
+                        subject: create_post.subject,
+                        content,
+                        is_sensitive: create_post.sensitive,
+                        visibility: create_post.visibility,
+                        is_local: true,
+                        url,
+                        created_at: Utc::now().into(),
+                        updated_at: Utc::now().into(),
+                    }
+                    .into_active_model()
+                    .insert(tx)
+                    .await?;
+
+                    for account_id in mentioned_account_ids {
+                        posts_mentions::Model {
+                            account_id,
+                            post_id: post.id,
+                        }
+                        .into_active_model()
+                        .insert(tx)
+                        .await?;
+                    }
+
+                    let job_context =
+                        Job::DeliverCreate(CreateDeliveryContext { post_id: post.id });
+
+                    jobs::Model {
+                        id: Uuid::now_v7(),
+                        state: JobState::Queued,
+                        run_at: Utc::now().into(),
+                        context: serde_json::to_value(job_context).unwrap(),
+                        fail_count: 0,
+                        created_at: Utc::now().into(),
+                        updated_at: Utc::now().into(),
+                    }
+                    .into_active_model()
+                    .insert(tx)
+                    .await?;
+
+                    Ok(post)
+                }
+                .boxed()
+            })
+            .await?;
+
+        if create_post.visibility == Visibility::Public
+            || create_post.visibility == Visibility::Unlisted
+        {
+            self.search_service.add_to_index(post.clone()).await?;
+        }
+
+        Ok(post)
+    }
+}

--- a/kitsune/src/service/search.rs
+++ b/kitsune/src/service/search.rs
@@ -32,7 +32,7 @@ impl From<posts::Model> for SearchItem {
 }
 
 #[async_trait]
-pub trait SearchService: Send + 'static {
+pub trait SearchService {
     /// Add an item to the index
     async fn add_to_index<I>(&self, item: I) -> Result<()>
     where
@@ -63,7 +63,7 @@ pub trait SearchService: Send + 'static {
 #[async_trait]
 impl<T> SearchService for Arc<T>
 where
-    T: SearchService + Sync,
+    T: SearchService + Send + Sync,
 {
     async fn add_to_index<I>(&self, item: I) -> Result<()>
     where

--- a/kitsune/src/state.rs
+++ b/kitsune/src/state.rs
@@ -1,8 +1,21 @@
 use crate::{
-    activitypub::Fetcher, config::Configuration, search::GrpcSearchService, webfinger::Webfinger,
+    activitypub::Fetcher,
+    config::Configuration,
+    service::{post::PostService, search::GrpcSearchService},
+    webfinger::Webfinger,
 };
 use axum::extract::FromRef;
 use sea_orm::DatabaseConnection;
+
+/// Service collection
+///
+/// This contains all the "services" that Kitsune consists of.
+/// These are things like the search service, post service, etc.
+#[derive(Clone)]
+pub struct Service {
+    pub post: PostService,
+    pub search: GrpcSearchService,
+}
 
 /// Application state
 ///
@@ -13,6 +26,6 @@ pub struct Zustand {
     pub config: Configuration,
     pub db_conn: DatabaseConnection,
     pub fetcher: Fetcher,
-    pub search_service: GrpcSearchService,
+    pub service: Service,
     pub webfinger: Webfinger,
 }

--- a/kitsune/src/state.rs
+++ b/kitsune/src/state.rs
@@ -1,11 +1,12 @@
 use crate::{
     activitypub::Fetcher,
     config::Configuration,
-    service::{post::PostService, search::GrpcSearchService},
+    service::{post::PostService, search::SearchService},
     webfinger::Webfinger,
 };
 use axum::extract::FromRef;
 use sea_orm::DatabaseConnection;
+use std::sync::Arc;
 
 /// Service collection
 ///
@@ -14,7 +15,7 @@ use sea_orm::DatabaseConnection;
 #[derive(Clone)]
 pub struct Service {
     pub post: PostService,
-    pub search: GrpcSearchService,
+    pub search: Arc<dyn SearchService + Send + Sync>,
 }
 
 /// Application state

--- a/kitsune/src/webfinger.rs
+++ b/kitsune/src/webfinger.rs
@@ -7,20 +7,24 @@ use autometrics::autometrics;
 use http::HeaderValue;
 use kitsune_http_client::Client;
 use kitsune_type::webfinger::Resource;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 const CACHE_DURATION: Duration = Duration::from_secs(10 * 60); // 10 minutes
 
 #[derive(Clone)]
-pub struct Webfinger<C = RedisCache<str, String>> {
+pub struct Webfinger<C = Arc<dyn Cache<str, String> + Send + Sync>> {
     cache: C,
     client: Client,
 }
 
 impl Webfinger {
     #[must_use]
-    pub fn with_redis_cache(redis_conn: deadpool_redis::Pool) -> Self {
-        Self::new(RedisCache::new(redis_conn, "webfinger", CACHE_DURATION))
+    pub fn with_defaults(redis_conn: deadpool_redis::Pool) -> Self {
+        Self::new(Arc::new(RedisCache::new(
+            redis_conn,
+            "webfinger",
+            CACHE_DURATION,
+        )))
     }
 }
 


### PR DESCRIPTION
This PR moves post related logic into a service structure.  
The goal of this is to deduplicate a bunch of logic that is shared between the GraphQL and the Mastodon API.