### PR TITLE
Build feature for using a vendored protobuf compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,6 +2403,7 @@ name = "kitsune-search-proto"
 version = "0.1.0"
 dependencies = [
  "prost",
+ "protoc-bin-vendored",
  "serde",
  "tonic",
  "tonic-build",
@@ -3468,6 +3469,56 @@ checksum = "7de56acd5cc9642cac2a9518d4c8c53818905398fe42d33235859e0d542a7695"
 dependencies = [
  "prost",
 ]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ca8623e5633e298ad1f917d8be0a44bcf406bf3cde3b80e63003e49a3f27d"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fb9fc9cce84c8694b6ea01cc6296617b288b703719b725b8c9c65f7c5874435"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d2a07dcf7173a04d49974930ccbfb7fd4d74df30ecfc8762cf2f895a094516"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54fef0b04fcacba64d1d80eed74a20356d96847da8497a59b0a0a436c9165b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8782f2ce7d43a9a5c74ea4936f001e9e8442205c244f7a3d4286bd4c37bc924"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5de656c7ee83f08e0ae5b81792ccfdc1d04e7876b1d9a38e6876a9e09e02537"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9653c3ed92974e34c5a6e0a510864dab979760481714c172e0a34e437cb98804"
 
 [[package]]
 name = "ptr_meta"

--- a/kitsune-search/proto/Cargo.toml
+++ b/kitsune-search/proto/Cargo.toml
@@ -6,7 +6,16 @@ edition = "2021"
 [dependencies]
 prost = "0.11.7"
 serde = { version = "1.0.152", features = ["derive"] }
-tonic = { version = "0.8.3", default-features = false, features = ["codegen", "transport", "prost"] }
+tonic = { version = "0.8.3", default-features = false, features = [
+    "codegen",
+    "transport",
+    "prost",
+] }
 
 [build-dependencies]
+protoc-bin-vendored = { version = "3.0.0", optional = true }
 tonic-build = "0.8.4"
+
+[features]
+default = []
+vendored-protoc = ["protoc-bin-vendored"]

--- a/kitsune-search/proto/build.rs
+++ b/kitsune-search/proto/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    #[cfg(feature = "vendored-protoc")]
+    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
+
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[derive(::serde::Serialize)]")


### PR DESCRIPTION
When exploring Shuttle compatibility, we noticed that there was no protobuf compiler installed in their build environment and that there is also no way to install one.  
This PR adds a feature gated behind `vendored-protoc` on the `kitsune-search-proto` crate that uses a vendored binary from the `protoc-bin-vendored` crate to build the proto definitions with.

This isn't intended as a permanent addition, but as an optional feature it doesn't hurt to have it.

Related to #78 