### PR TITLE
Fix small ActivityPub incompatibilities

### DIFF
--- a/kitsune-type/src/ap/object.rs
+++ b/kitsune-type/src/ap/object.rs
@@ -50,7 +50,7 @@ pub struct PublicKey {
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Note {
-    pub subject: Option<String>,
+    pub summary: Option<String>,
     pub content: String,
     #[serde(flatten)]
     pub rest: BaseObject,

--- a/kitsune-type/src/webfinger.rs
+++ b/kitsune-type/src/webfinger.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Deserialize, Serialize)]
 pub struct Link {
     pub rel: String,
+    pub r#type: Option<String>,
     pub href: Option<String>,
 }
 

--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -313,7 +313,7 @@ where
             id: Uuid::new_v7(uuid_timestamp),
             account_id: user.id,
             in_reply_to_id,
-            subject: note.subject,
+            subject: note.summary,
             content: note.content,
             is_sensitive: note.rest.sensitive,
             visibility,

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -62,7 +62,7 @@ async fn create_activity(
                     id: Uuid::now_v7(),
                     account_id: author.id,
                     in_reply_to_id,
-                    subject: note.subject,
+                    subject: note.summary,
                     content: note.content,
                     is_sensitive: note.rest.sensitive,
                     visibility,

--- a/kitsune/src/http/handler/well_known/webfinger.rs
+++ b/kitsune/src/http/handler/well_known/webfinger.rs
@@ -44,6 +44,7 @@ async fn get(
         aliases: vec![account.url.clone()],
         links: vec![Link {
             rel: "self".into(),
+            r#type: Some("application/activity+json".into()),
             href: Some(account.url),
         }],
     })

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -94,7 +94,7 @@ impl IntoObject for posts::Model {
         to.append(&mut mentioned);
 
         Ok(Object::Note(Note {
-            subject: self.subject,
+            summary: self.subject,
             content: self.content,
             rest: BaseObject {
                 context: ap_context(),

--- a/kitsune/src/sanitize.rs
+++ b/kitsune/src/sanitize.rs
@@ -18,8 +18,8 @@ impl CleanHtmlExt for Actor {
 
 impl CleanHtmlExt for Note {
     fn clean_html(&mut self) {
-        if let Some(ref mut subject) = self.subject {
-            subject.clean_html();
+        if let Some(ref mut summary) = self.summary {
+            summary.clean_html();
         }
 
         self.content.clean_html();


### PR DESCRIPTION
Fixes:

- Missing `type` field in Webfinger response
- The post subject field is actually called `summary`