### PR TITLE
Make search results chronologically ordered

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -497,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+checksum = "2bd379e511536bad07447f899300aa526e9bae8e6f66dc5e5ca45d7587b7c1ec"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -528,7 +530,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -566,7 +568,7 @@ dependencies = [
  "serde_html_form",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -603,7 +605,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
 ]
 
 [[package]]
@@ -665,9 +667,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit_field"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -851,6 +853,9 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "census"
@@ -2172,11 +2177,12 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "iri-string"
-version = "0.4.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f0f7638c1e223529f1bfdc48c8b133b9e0b434094d1d28473161ee48b235f78"
+checksum = "21859b667d66a4c1dacd9df0863b3efb65785474255face87f5bca39dd8407c0"
 dependencies = [
- "nom",
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -2205,6 +2211,15 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "jobserver"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -2285,7 +2300,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic",
- "tower-http",
+ "tower-http 0.4.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -2336,7 +2351,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.4.0",
 ]
 
 [[package]]
@@ -2390,10 +2405,11 @@ dependencies = [
  "serde",
  "tantivy",
  "tempdir",
+ "time 0.3.20",
  "tokio",
  "tonic",
  "tonic-health",
- "tower-http",
+ "tower-http 0.4.0",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3418,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3933d3ac2717077b3d5f42b40f59edfb1fb6a8c14e1c7de0f38075c4bac8e314"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3428,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24be1d23b4552a012093e1b93697b73d644ae9590e3253d878d0e77d411b614"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
  "heck 0.4.1",
@@ -3450,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9935362e8369bc3acd874caeeae814295c504c2bdbcde5c024089cf8b4dc12"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -3463,9 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de56acd5cc9642cac2a9518d4c8c53818905398fe42d33235859e0d542a7695"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
  "prost",
 ]
@@ -4010,7 +4026,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
- "time 0.3.19",
+ "time 0.3.20",
  "tracing",
  "url",
  "uuid",
@@ -4073,7 +4089,7 @@ dependencies = [
  "rust_decimal",
  "sea-query-derive",
  "serde_json",
- "time 0.3.19",
+ "time 0.3.20",
  "uuid",
 ]
 
@@ -4089,7 +4105,7 @@ dependencies = [
  "sea-query",
  "serde_json",
  "sqlx",
- "time 0.3.19",
+ "time 0.3.20",
  "uuid",
 ]
 
@@ -4449,7 +4465,7 @@ dependencies = [
  "sqlx-rt",
  "stringprep",
  "thiserror",
- "time 0.3.19",
+ "time 0.3.20",
  "tokio-stream",
  "url",
  "uuid",
@@ -4611,7 +4627,7 @@ dependencies = [
  "tantivy-query-grammar",
  "tempfile",
  "thiserror",
- "time 0.3.19",
+ "time 0.3.20",
  "uuid",
  "winapi",
 ]
@@ -4666,16 +4682,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -4767,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53250a3b3fed8ff8fd988587d8925d26a83ac3845d9e03b220b37f34c2b8d6c2"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
  "serde",
@@ -4785,9 +4800,9 @@ checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
 
 [[package]]
 name = "time-macros"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a460aeb8de6dcb0f381e1ee05f1cd56fcf5a5f6eb8187ff3d8f0b11078d38b7c"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
 dependencies = [
  "time-core",
 ]
@@ -5008,6 +5023,25 @@ name = "tower-http"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -5590,6 +5624,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.7+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5611,5 +5675,5 @@ dependencies = [
  "lazy_static",
  "quick-error",
  "regex",
- "time 0.3.19",
+ "time 0.3.20",
 ]

--- a/kitsune-http-client/Cargo.toml
+++ b/kitsune-http-client/Cargo.toml
@@ -18,7 +18,7 @@ kitsune-http-signatures = { path = "../kitsune-http-signatures" }
 serde = "1.0.152"
 serde_json = "1.0.93"
 tower = "0.4.13"
-tower-http = { version = "0.3.5", features = [
+tower-http = { version = "0.4.0", features = [
     "decompression-full",
     "follow-redirect",
     "map-response-body",

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -15,13 +15,14 @@ metrics-exporter-prometheus = "0.11.0"
 metrics-tracing-context = "0.13.0"
 metrics-util = "0.14.0"
 mimalloc = "0.1.34"
-prost = "0.11.7"
+prost = "0.11.8"
 serde = { version = "1.0.152", features = ["derive"] }
 tantivy = "0.19.2"
+time = "0.3.20"
 tokio = { version = "1.25.0", features = ["full"] }
 tonic = "0.8.3"
 tonic-health = "0.8.0"
-tower-http = { version = "0.3.5", features = ["add-extension", "trace"] }
+tower-http = { version = "0.4.0", features = ["add-extension", "trace"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 

--- a/kitsune-search/proto/Cargo.toml
+++ b/kitsune-search/proto/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-prost = "0.11.7"
+prost = "0.11.8"
 serde = { version = "1.0.152", features = ["derive"] }
 tonic = { version = "0.8.3", default-features = false, features = [
     "codegen",

--- a/kitsune-search/src/grpc/service/index.rs
+++ b/kitsune-search/src/grpc/service/index.rs
@@ -8,8 +8,8 @@ use kitsune_search_proto::{
         RemoveIndexRequest, RemoveIndexResponse, ResetRequest, ResetResponse,
     },
 };
-use std::time::SystemTime;
-use tantivy::{Document, IndexWriter, Term};
+use tantivy::{DateTime, Document, IndexWriter, Term};
+use time::OffsetDateTime;
 use tokio::sync::RwLock;
 use tonic::{async_trait, Request, Response, Status, Streaming};
 
@@ -23,13 +23,6 @@ pub struct IndexService {
 
     /// Writer of the post index
     pub post: RwLock<IndexWriter>,
-}
-
-fn get_now_unix_timestamp() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs()
 }
 
 impl IndexService {
@@ -48,7 +41,10 @@ impl IndexService {
                     document.add_text(account_schema.description, description);
                 }
 
-                document.add_u64(account_schema.indexed_at, get_now_unix_timestamp());
+                document.add_date(
+                    account_schema.indexed_at,
+                    DateTime::from_utc(OffsetDateTime::now_utc()),
+                );
 
                 increment_counter!("added_documents", "index" => GrpcSearchIndex::Account.as_str_name());
 
@@ -64,7 +60,10 @@ impl IndexService {
                     document.add_text(post_schema.subject, subject);
                 }
 
-                document.add_u64(post_schema.indexed_at, get_now_unix_timestamp());
+                document.add_date(
+                    post_schema.indexed_at,
+                    DateTime::from_utc(OffsetDateTime::now_utc()),
+                );
 
                 increment_counter!("added_documents", "index" => GrpcSearchIndex::Post.as_str_name());
 

--- a/kitsune-search/src/grpc/service/search.rs
+++ b/kitsune-search/src/grpc/service/search.rs
@@ -8,7 +8,7 @@ use kitsune_search_proto::{
     search::{search_server::Search, SearchRequest, SearchResponse, SearchResult},
 };
 use std::ops::Bound;
-use tantivy::{collector::TopDocs, IndexReader};
+use tantivy::{collector::TopDocs, DateTime, IndexReader};
 use tonic::{async_trait, Request, Response, Status};
 
 /// Search service
@@ -62,7 +62,7 @@ impl Search for SearchService {
 
         let top_docs_collector = TopDocs::with_limit(req.get_ref().max_results as usize)
             .and_offset(req.get_ref().offset as usize)
-            .order_by_fast_field::<u64>(indexed_at_field);
+            .order_by_fast_field::<DateTime>(indexed_at_field);
         let results = searcher
             .search(&query, &top_docs_collector)
             .map_err(|e| Status::internal(e.to_string()))?;

--- a/kitsune-search/src/search/schema.rs
+++ b/kitsune-search/src/search/schema.rs
@@ -56,6 +56,9 @@ pub struct AccountSchema {
     /// Description (or bio, etc.) field (might be empty)
     pub description: Field,
 
+    /// Unix timestamp of when the account was indexed
+    pub indexed_at: Field,
+
     /// The underlying tantivy schema with the above defined fields
     pub tantivy_schema: Schema,
 }
@@ -67,6 +70,7 @@ impl Default for AccountSchema {
         let display_name = builder.add_text_field("display_name", FAST | TEXT);
         let username = builder.add_text_field("username", FAST | STRING);
         let description = builder.add_text_field("description", FAST | TEXT);
+        let indexed_at = builder.add_u64_field("indexed_at", FAST);
         let tantivy_schema = builder.build();
 
         Self {
@@ -74,6 +78,7 @@ impl Default for AccountSchema {
             display_name,
             username,
             description,
+            indexed_at,
             tantivy_schema,
         }
     }
@@ -125,6 +130,9 @@ pub struct PostSchema {
     /// Content field
     pub content: Field,
 
+    /// Unix timestamp of when the post was indexed
+    pub indexed_at: Field,
+
     /// The underlying tantivy schema with the above defined fields
     pub tantivy_schema: Schema,
 }
@@ -135,12 +143,14 @@ impl Default for PostSchema {
         let id = builder.add_bytes_field("id", FAST | INDEXED | STORED);
         let subject = builder.add_text_field("subject", FAST | TEXT);
         let content = builder.add_text_field("content", FAST | TEXT);
+        let indexed_at = builder.add_u64_field("indexed_at", FAST);
         let tantivy_schema = builder.build();
 
         Self {
             id,
             subject,
             content,
+            indexed_at,
             tantivy_schema,
         }
     }

--- a/kitsune-search/src/search/schema.rs
+++ b/kitsune-search/src/search/schema.rs
@@ -70,7 +70,7 @@ impl Default for AccountSchema {
         let display_name = builder.add_text_field("display_name", FAST | TEXT);
         let username = builder.add_text_field("username", FAST | STRING);
         let description = builder.add_text_field("description", FAST | TEXT);
-        let indexed_at = builder.add_u64_field("indexed_at", FAST);
+        let indexed_at = builder.add_date_field("indexed_at", FAST);
         let tantivy_schema = builder.build();
 
         Self {
@@ -143,7 +143,7 @@ impl Default for PostSchema {
         let id = builder.add_bytes_field("id", FAST | INDEXED | STORED);
         let subject = builder.add_text_field("subject", FAST | TEXT);
         let content = builder.add_text_field("content", FAST | TEXT);
-        let indexed_at = builder.add_u64_field("indexed_at", FAST);
+        let indexed_at = builder.add_date_field("indexed_at", FAST);
         let tantivy_schema = builder.build();
 
         Self {

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -23,7 +23,7 @@ async-trait = "0.1.64"
 autometrics = { version = "0.2.4", default-features = false, features = [
     "metrics",
 ] }
-axum = { version = "0.6.7", features = ["headers", "macros"] }
+axum = { version = "0.6.8", features = ["headers", "macros"] }
 axum-extra = { version = "0.5.0", features = ["query"] }
 axum-prometheus = "0.3.1"
 base64 = "0.21.0"
@@ -73,7 +73,7 @@ thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.7", features = ["compat"] }
 tonic = "0.8.3"
-tower-http = { version = "0.3.5", features = ["cors", "fs", "trace"] }
+tower-http = { version = "0.4.0", features = ["cors", "fs", "trace"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = "2.3.1"

--- a/kitsune/src/service/search.rs
+++ b/kitsune/src/service/search.rs
@@ -51,7 +51,6 @@ impl From<SearchIndex> for GrpcSearchIndex {
 #[derive(Clone, Copy)]
 pub struct SearchResult {
     pub id: Uuid,
-    pub score: f32,
 }
 
 impl From<GrpcSearchResult> for SearchResult {
@@ -63,10 +62,7 @@ impl From<GrpcSearchResult> for SearchResult {
                 .expect("Received non-UUID from search service"),
         );
 
-        Self {
-            id,
-            score: value.score,
-        }
+        Self { id }
     }
 }
 

--- a/proto/search/search.proto
+++ b/proto/search/search.proto
@@ -10,9 +10,6 @@ import "common.proto";
 message SearchResult {
     // Unique identifier of the entry
     bytes id = 1;
-
-    // Score of the result
-    float score = 2;
 }
 
 // Request to query the search index 


### PR DESCRIPTION
Currently the results are ordered by their Levenshtein distance, i.e. the closer the search query matches the text, the higher it ranks.  
I'm not sure how Mastodon handles it, whether they do chronological handling, too. 

We should closely imitate Mastodon in terms of search result ordering, otherwise we might break expectations some clients have.

It would be great if someone on an instance with full-text search could chime in an tell me how Mastodon orders the results (my instance doesn't have full-text search for posts enabled)