### PR TITLE
Simplify the usage of generics

### DIFF
--- a/kitsune/src/cache.rs
+++ b/kitsune/src/cache.rs
@@ -7,6 +7,8 @@ use std::{fmt::Display, marker::PhantomData, ops::Deref, sync::Arc, time::Durati
 
 type CacheResult<T, E = CacheError> = Result<T, E>;
 
+pub type ArcCache<K, V> = Arc<dyn Cache<K, V>>;
+
 #[async_trait]
 pub trait Cache<K, V>: Send + Sync
 where

--- a/kitsune/src/http/handler/mastodon/api/v2/search.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/search.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::Result,
     http::extractor::MastodonAuthExtractor,
-    service::search::{ArcSearchService, SearchIndex, SearchService},
+    service::search::{ArcSearchService, SearchIndex},
     state::Zustand,
 };
 use axum::{

--- a/kitsune/src/mapping/mastodon/mod.rs
+++ b/kitsune/src/mapping/mastodon/mod.rs
@@ -1,6 +1,6 @@
 use self::sealed::{IntoMastodon, MapperState};
 use crate::{
-    cache::{Cache, RedisCache},
+    cache::{ArcCache, RedisCache},
     error::Result,
     event::{post::EventType, PostEventConsumer},
     service::attachment::AttachmentService,
@@ -24,7 +24,7 @@ impl<T> MapperMarker for T where T: IntoMastodon {}
 #[derive(Builder)]
 #[builder(pattern = "owned")]
 struct CacheInvalidationActor {
-    cache: Arc<dyn Cache<Uuid, Value> + Send + Sync>,
+    cache: ArcCache<Uuid, Value>,
     event_consumer: PostEventConsumer,
 }
 
@@ -90,7 +90,7 @@ pub struct MastodonMapper {
     attachment_service: AttachmentService,
     db_conn: DatabaseConnection,
     default_avatar_url: String,
-    mastodon_cache: Arc<dyn Cache<Uuid, Value> + Send + Sync>,
+    mastodon_cache: ArcCache<Uuid, Value>,
 }
 
 impl MastodonMapper {

--- a/kitsune/src/service/search.rs
+++ b/kitsune/src/service/search.rs
@@ -14,7 +14,7 @@ use std::{future, ops::Deref, sync::Arc};
 use tonic::transport::{Channel, Endpoint};
 use uuid::Uuid;
 
-pub type ArcSearchService = Arc<dyn SearchService + Send + Sync>;
+pub type ArcSearchService = Arc<dyn SearchService>;
 
 pub enum SearchItem {
     Account(accounts::Model),


### PR DESCRIPTION
Some of the types inside Kitsune were highly parameterised using generic types. This was originally done for testability.

Recently the testability shifted from using generics to using dynamic dispatch since using generic parameters with Axum's `State` extractor is pretty difficult.  
The generic parameters defaulted to their Arc'd counterparts as a quick fix.  

This PR removes the generic parameters since they aren't really needed anymore to provide testability 