### PR TITLE
Add basic Meilisearch support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33741baa462d86e43fdec5e8ffca7c6ac82847ad06cbfb382c1bdbf527de9e6b"
 dependencies = [
  "abnf-core",
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -28,7 +28,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c44e09c43ae1c368fb91a03a566472d0087c26cf7e1b9e8e289c14ede681dd7d"
 dependencies = [
- "nom",
+ "nom 7.1.3",
 ]
 
 [[package]]
@@ -229,7 +229,7 @@ dependencies = [
  "basic-toml",
  "mime",
  "mime_guess",
- "nom",
+ "nom 7.1.3",
  "proc-macro2",
  "quote",
  "serde",
@@ -1060,6 +1060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "castaway"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520fbf3c07483f94e3e3ca9d0cfd913d7718ef2483d2cfd91c0d9e91474ab913"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,6 +1375,37 @@ checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "curl"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
+dependencies = [
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.61+curl-8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
+dependencies = [
+ "cc",
+ "libc",
+ "libnghttp2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi",
 ]
 
 [[package]]
@@ -1670,6 +1716,9 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elsa"
@@ -1879,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1894,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1904,15 +1953,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1932,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-lite"
@@ -1953,32 +2002,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.11",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2329,16 +2378,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.54"
+version = "0.1.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c17cc76786e99f8d2f055c11159e7f0091c42474dcc3189fbab96072e873e6d"
+checksum = "716f12fbcfac6ffab0a5e9ec51d0a0ff70503742bb2dc7b99396394c9dc323f0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows 0.46.0",
+ "windows 0.47.0",
 ]
 
 [[package]]
@@ -2445,6 +2494,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "isahc"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
+dependencies = [
+ "async-channel",
+ "castaway",
+ "crossbeam-utils",
+ "curl",
+ "curl-sys",
+ "encoding_rs",
+ "event-listener",
+ "futures-lite",
+ "http",
+ "log",
+ "mime",
+ "once_cell",
+ "polling",
+ "slab",
+ "sluice",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "waker-fn",
+]
+
+[[package]]
+name = "iso8601-duration"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b51dd97fa24074214b9eb14da518957573f4dec3189112610ae1ccec9ac464"
+dependencies = [
+ "nom 5.1.2",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2560,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
+dependencies = [
+ "base64 0.21.0",
+ "ring",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2515,6 +2612,7 @@ dependencies = [
  "kitsune-search-proto",
  "kitsune-storage",
  "kitsune-type",
+ "meilisearch-sdk",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-tracing-context",
@@ -2719,6 +2817,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2741,12 +2852,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "libnghttp2-sys"
+version = "0.1.7+1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ed28aba195b38d5ff02b9170cbff627e336a20925e43b4945390401c5dc93f"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898745e570c7d0453cc1fbc4a701eb6c662ed54e8fec8b7d14be137ebeeb9d14"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -2893,6 +3026,45 @@ checksum = "56220900f1a0923789ecd6bf25fbae8af3b2f1ff3e9e297fc9b6b8674dd4d852"
 dependencies = [
  "instant",
  "log",
+]
+
+[[package]]
+name = "meilisearch-index-setting-macro"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fedd7e2fabfbcc91679f3d76f6d648ea7fc9ea87c841b10d26c2a258f408da"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "meilisearch-sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6be928c91e1b23689725586b56f3284f394d93185accfa2771caec3e10015d"
+dependencies = [
+ "async-trait",
+ "either",
+ "futures",
+ "futures-io",
+ "isahc",
+ "iso8601-duration",
+ "js-sys",
+ "jsonwebtoken",
+ "log",
+ "meilisearch-index-setting-macro",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time 0.3.20",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yaup",
 ]
 
 [[package]]
@@ -3128,6 +3300,17 @@ dependencies = [
 
 [[package]]
 name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
@@ -3281,6 +3464,19 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -3629,6 +3825,22 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "polling"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
+dependencies = [
+ "autocfg",
+ "bitflags",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -4688,6 +4900,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sluice"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
+dependencies = [
+ "async-channel",
+ "futures-core",
+ "futures-io",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4745,7 +4968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
 dependencies = [
  "itertools",
- "nom",
+ "nom 7.1.3",
  "unicode_categories",
 ]
 
@@ -5724,6 +5947,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5839,16 +6074,16 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
 name = "windows"
-version = "0.46.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdacb41e6a96a052c6cb63a144f24900236121c6f63f4f8219fef5977ecb0c25"
+checksum = "2649ff315bee4c98757f15dac226efe3d81927adbb6e882084bb1ee3e0c330a7"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.47.0",
 ]
 
 [[package]]
@@ -5857,13 +6092,13 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5872,7 +6107,7 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -5881,13 +6116,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f8996d3f43b4b2d44327cd71b7b0efd1284ab60e6e9d0e8b630e18555d87d3e"
+dependencies = [
+ "windows_aarch64_gnullvm 0.47.0",
+ "windows_aarch64_msvc 0.47.0",
+ "windows_i686_gnu 0.47.0",
+ "windows_i686_msvc 0.47.0",
+ "windows_x86_64_gnu 0.47.0",
+ "windows_x86_64_gnullvm 0.47.0",
+ "windows_x86_64_msvc 0.47.0",
 ]
 
 [[package]]
@@ -5897,10 +6147,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831d567d53d4f3cb1db332b68e6e2b6260228eb4d99a777d8b2e8ed794027c90"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a42d54a417c60ce4f0e31661eed628f0fa5aca73448c093ec4d45fab4c51cdf"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5909,10 +6171,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1925beafdbb22201a53a483db861a5644123157c1c3cee83323a2ed565d71e3"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8ef8f2f1711b223947d9b69b596cf5a4e452c930fb58b6fc3fdae7d0ec6b31"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5921,16 +6195,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7acaa0c2cf0d2ef99b61c308a0c3dbae430a51b7345dedec470bd8f53f5a3642"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a0628f71be1d11e17ca4a0e9e15b3a5180f6fbf1c2d55e3ba3f850378052c1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6e62c256dc6d40b8c8707df17df8d774e60e39db723675241e7c15e910bce7"
 
 [[package]]
 name = "winnow"
@@ -5961,6 +6253,16 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yaup"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59e7d27bed43f7c37c25df5192ea9d435a8092a902e02203359ac9ce3e429d9"
+dependencies = [
+ "serde",
+ "url",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2636,6 +2636,7 @@ dependencies = [
  "serde_dhall",
  "serde_json",
  "sha2",
+ "strum",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5122,6 +5123,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "subtle"

--- a/config.example.dhall
+++ b/config.example.dhall
@@ -30,7 +30,7 @@ in    { cache =
             , prometheus_port = 9000
             }
           : types.Server
-      , search = makeSearchConfig "https://localhost:8081"
+      , search = types.Search.Meilisearch { instance_url = "http://localhost:7700", api_key = "xTJC-083-CMzIA0ga6gEXTpJKKafPe55JuxpMYzBkjc" }
       , storage = types.Storage.Fs { upload_dir = "./uploads" } : types.Storage
       , url = { scheme = "http", domain = "localhost:5000" } : types.Url
       }

--- a/config.example.dhall
+++ b/config.example.dhall
@@ -30,7 +30,7 @@ in    { cache =
             , prometheus_port = 9000
             }
           : types.Server
-      , search = types.Search.Meilisearch { instance_url = "http://localhost:7700", api_key = "xTJC-083-CMzIA0ga6gEXTpJKKafPe55JuxpMYzBkjc" }
+      , search = makeSearchConfig "https://localhost:8081"
       , storage = types.Storage.Fs { upload_dir = "./uploads" } : types.Storage
       , url = { scheme = "http", domain = "localhost:5000" } : types.Url
       }

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
                         rust-bin.stable.latest.default
                         sqlite
                         yarn
+                        zlib
                     ];
                 };
             }

--- a/flake.nix
+++ b/flake.nix
@@ -18,7 +18,7 @@
                         cargo-insta
                         dhall
                         nodejs
-                        openssl_1_1
+                        openssl
                         #postgresql_15
                         protobuf
                         redis

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
                         cargo-insta
                         dhall
                         nodejs
+                        openssl_1_1
                         #postgresql_15
                         protobuf
                         redis

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -54,6 +54,7 @@ kitsune-messaging = { path = "../kitsune-messaging" }
 kitsune-search-proto = { path = "../kitsune-search/proto" }
 kitsune-storage = { path = "../kitsune-storage" }
 kitsune-type = { path = "../kitsune-type" }
+meilisearch-sdk = "0.22.1"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
 metrics-tracing-context = "0.13.0"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -86,6 +86,7 @@ serde = { version = "1.0.159", features = ["derive"] }
 serde_dhall = { version = "0.12.1", default-features = false }
 serde_json = "1.0.95"
 sha2 = "0.10.6"
+strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 tokio = { version = "1.27.0", features = ["full"] }

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -54,7 +54,7 @@ kitsune-messaging = { path = "../kitsune-messaging" }
 kitsune-search-proto = { path = "../kitsune-search/proto" }
 kitsune-storage = { path = "../kitsune-storage" }
 kitsune-type = { path = "../kitsune-type" }
-meilisearch-sdk = "0.22.1"
+meilisearch-sdk = { version = "0.22.1", optional = true }
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
 metrics-tracing-context = "0.13.0"
@@ -107,3 +107,4 @@ pretty_assertions = "1.3.0"
 [features]
 default = ["mastodon-api"]
 mastodon-api = []
+meilisearch = ["dep:meilisearch-sdk"]

--- a/kitsune/config/types.dhall
+++ b/kitsune/config/types.dhall
@@ -8,6 +8,8 @@ let Instance = ./types/instance.dhall
 
 let Kitsune = ./types/search/kitsune.dhall
 
+let Meilisearch = ./types/search/meilisearch.dhall
+
 let Messaging = ./types/messaging.dhall
 
 let Oidc = ./types/oidc.dhall
@@ -43,6 +45,7 @@ in  { Cache
     , FsStorage
     , Instance
     , Kitsune
+    , Meilisearch
     , Messaging
     , Oidc
     , RedisCache

--- a/kitsune/config/types/search.dhall
+++ b/kitsune/config/types/search.dhall
@@ -1,1 +1,5 @@
-let Kitsune = ./search/kitsune.dhall in < Kitsune : Kitsune | Sql | None >
+let Kitsune = ./search/kitsune.dhall
+
+let Meilisearch = ./search/meilisearch.dhall
+
+in  < Kitsune : Kitsune | Meilisearch : Meilisearch | Sql | None >

--- a/kitsune/config/types/search/meilisearch.dhall
+++ b/kitsune/config/types/search/meilisearch.dhall
@@ -1,0 +1,1 @@
+{ instance_url : Text, api_key : Text }

--- a/kitsune/src/config.rs
+++ b/kitsune/src/config.rs
@@ -54,8 +54,15 @@ pub struct KitsuneSearchConfiguration {
 }
 
 #[derive(Clone, Deserialize, Serialize, StaticType)]
+pub struct MeiliSearchConfiguration {
+    pub instance_url: String,
+    pub api_key: String,
+}
+
+#[derive(Clone, Deserialize, Serialize, StaticType)]
 pub enum SearchConfiguration {
     Kitsune(KitsuneSearchConfiguration),
+    Meilisearch(MeiliSearchConfiguration),
     Sql,
     None,
 }

--- a/kitsune/src/error.rs
+++ b/kitsune/src/error.rs
@@ -102,6 +102,7 @@ pub enum SearchError {
     #[error(transparent)]
     Database(#[from] sea_orm::DbErr),
 
+    #[cfg(feature = "meilisearch")]
     #[error(transparent)]
     Meilisearch(#[from] meilisearch_sdk::errors::Error),
 

--- a/kitsune/src/error.rs
+++ b/kitsune/src/error.rs
@@ -98,6 +98,21 @@ pub enum OidcError {
 }
 
 #[derive(Debug, Error)]
+pub enum SearchError {
+    #[error(transparent)]
+    Database(#[from] sea_orm::DbErr),
+
+    #[error(transparent)]
+    Meilisearch(#[from] meilisearch_sdk::errors::Error),
+
+    #[error(transparent)]
+    TonicStatus(#[from] tonic::Status),
+
+    #[error(transparent)]
+    TonicTransport(#[from] tonic::transport::Error),
+}
+
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum Error {
     #[error(transparent)]
@@ -170,6 +185,9 @@ pub enum Error {
     PostProcessing(post_process::BoxError),
 
     #[error(transparent)]
+    Search(#[from] SearchError),
+
+    #[error(transparent)]
     SerdeJson(#[from] serde_json::Error),
 
     #[error(transparent)]
@@ -177,12 +195,6 @@ pub enum Error {
 
     #[error(transparent)]
     Storage(kitsune_storage::BoxError),
-
-    #[error(transparent)]
-    TonicStatus(#[from] tonic::Status),
-
-    #[error(transparent)]
-    TonicTransport(#[from] tonic::transport::Error),
 
     #[error(transparent)]
     UrlParse(#[from] url::ParseError),

--- a/kitsune/src/main.rs
+++ b/kitsune/src/main.rs
@@ -190,10 +190,11 @@ async fn prepare_search(
                 .await
                 .expect("Failed to connect to the search servers"),
         ),
-        SearchConfiguration::Meilisearch(config) => Arc::new(MeiliSearchService::new(
-            &config.instance_url,
-            &config.api_key,
-        )),
+        SearchConfiguration::Meilisearch(config) => Arc::new(
+            MeiliSearchService::new(&config.instance_url, &config.api_key)
+                .await
+                .expect("Failed to connect to Meilisearch"),
+        ),
         SearchConfiguration::Sql => Arc::new(SqlSearchService::new(db_conn.clone())),
         SearchConfiguration::None => Arc::new(NoopSearchService),
     }

--- a/kitsune/src/main.rs
+++ b/kitsune/src/main.rs
@@ -21,7 +21,10 @@ use kitsune::{
         oauth2::Oauth2Service,
         oidc::{async_client, OidcService},
         post::PostService,
-        search::{ArcSearchService, GrpcSearchService, NoopSearchService, SqlSearchService},
+        search::{
+            ArcSearchService, GrpcSearchService, MeiliSearchService, NoopSearchService,
+            SqlSearchService,
+        },
         timeline::TimelineService,
         url::UrlService,
         user::UserService,
@@ -183,10 +186,14 @@ async fn prepare_search(
 ) -> ArcSearchService {
     match search_config {
         SearchConfiguration::Kitsune(config) => Arc::new(
-            GrpcSearchService::new(&config.index_server, &config.search_servers)
+            GrpcSearchService::connect(&config.index_server, &config.search_servers)
                 .await
                 .expect("Failed to connect to the search servers"),
         ),
+        SearchConfiguration::Meilisearch(config) => Arc::new(MeiliSearchService::new(
+            &config.instance_url,
+            &config.api_key,
+        )),
         SearchConfiguration::Sql => Arc::new(SqlSearchService::new(db_conn.clone())),
         SearchConfiguration::None => Arc::new(NoopSearchService),
     }

--- a/kitsune/src/main.rs
+++ b/kitsune/src/main.rs
@@ -193,7 +193,7 @@ async fn prepare_search(
         SearchConfiguration::Meilisearch(_config) => {
             #[cfg(feature = "meilisearch")]
             // To avoid an "unused variable" warning in case the feature is deactivated
-            #[allow(clippy::used-underscore-binding)]
+            #[allow(clippy::used_underscore_binding)]
             return Arc::new(
                 MeiliSearchService::new(&_config.instance_url, &_config.api_key)
                     .await

--- a/kitsune/src/main.rs
+++ b/kitsune/src/main.rs
@@ -192,6 +192,8 @@ async fn prepare_search(
         ),
         SearchConfiguration::Meilisearch(_config) => {
             #[cfg(feature = "meilisearch")]
+            // To avoid an "unused variable" warning in case the feature is deactivated
+            #[allow(clippy::used-underscore-binding)]
             return Arc::new(
                 MeiliSearchService::new(&_config.instance_url, &_config.api_key)
                     .await

--- a/kitsune/src/service/search/grpc.rs
+++ b/kitsune/src/service/search/grpc.rs
@@ -1,5 +1,4 @@
-use super::{SearchIndex, SearchItem, SearchResult, SearchService};
-use crate::error::Result;
+use super::{Result, SearchIndex, SearchItem, SearchResult, SearchService};
 use async_trait::async_trait;
 use futures_util::stream;
 use kitsune_search_proto::{
@@ -24,7 +23,7 @@ pub struct GrpcSearchService {
 }
 
 impl GrpcSearchService {
-    pub async fn new(index_endpoint: &str, search_endpoints: &[String]) -> Result<Self> {
+    pub async fn connect(index_endpoint: &str, search_endpoints: &[String]) -> Result<Self> {
         let index_channel = Endpoint::from_shared(index_endpoint.to_string())?
             .connect()
             .await?;

--- a/kitsune/src/service/search/meilisearch.rs
+++ b/kitsune/src/service/search/meilisearch.rs
@@ -1,0 +1,96 @@
+use super::{Result, SearchIndex, SearchItem, SearchResult, SearchService};
+use async_trait::async_trait;
+use meilisearch_sdk::{indexes::Index, Client};
+use uuid::Uuid;
+
+pub struct MeiliSearchService {
+    client: Client,
+}
+
+impl MeiliSearchService {
+    #[must_use]
+    pub fn new(host: &str, api_key: &str) -> Self {
+        Self {
+            client: Client::new(host, api_key),
+        }
+    }
+
+    fn get_index(&self, index: SearchIndex) -> Index {
+        match index {
+            SearchIndex::Account => self.client.index("accounts"),
+            SearchIndex::Post => self.client.index("posts"),
+        }
+    }
+}
+
+#[async_trait]
+impl SearchService for MeiliSearchService {
+    async fn add_to_index(&self, item: SearchItem) -> Result<()> {
+        self.get_index(item.index())
+            .add_documents(&[item], Some("id"))
+            .await?
+            .wait_for_completion(&self.client, None, None)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn remove_from_index(&self, item: SearchItem) -> Result<()> {
+        match item {
+            SearchItem::Account(account) => {
+                self.get_index(SearchIndex::Account)
+                    .delete_document(account.id)
+                    .await?
+            }
+            SearchItem::Post(post) => {
+                self.get_index(SearchIndex::Post)
+                    .delete_document(post.id)
+                    .await?
+            }
+        }
+        .wait_for_completion(&self.client, None, None)
+        .await?;
+
+        Ok(())
+    }
+
+    async fn reset_index(&self, index: SearchIndex) -> Result<()> {
+        self.get_index(index)
+            .delete_all_documents()
+            .await?
+            .wait_for_completion(&self.client, None, None)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        index: SearchIndex,
+        query: String,
+        max_results: u64,
+        offset: u64,
+        min_id: Option<Uuid>,
+        max_id: Option<Uuid>,
+    ) -> Result<Vec<SearchResult>> {
+        let filter = format!(
+            "id > {} AND id < {}",
+            min_id.unwrap_or_else(Uuid::nil),
+            max_id.unwrap_or_else(Uuid::max)
+        );
+
+        #[allow(clippy::cast_possible_truncation)]
+        let results = self
+            .get_index(index)
+            .search()
+            .with_query(&query)
+            .with_filter(&filter)
+            .with_sort(&["id:desc"])
+            .with_offset(offset as usize)
+            .with_limit(max_results as usize)
+            .execute::<SearchResult>()
+            .await?;
+
+        Ok(results.hits.into_iter().map(|item| item.result).collect())
+    }
+}

--- a/kitsune/src/service/search/mod.rs
+++ b/kitsune/src/service/search/mod.rs
@@ -21,15 +21,19 @@ pub struct Account {
     pub display_name: Option<String>,
     pub username: String,
     pub note: Option<String>,
+    /// Timestamp of the creation expressed in seconds since the Unix epoch
+    pub created_at: u64,
 }
 
 impl From<accounts::Model> for Account {
     fn from(value: accounts::Model) -> Self {
+        let (created_at_secs, _) = value.id.get_timestamp().unwrap().to_unix();
         Self {
             id: value.id,
             display_name: value.display_name,
             username: value.username,
             note: value.note,
+            created_at: created_at_secs,
         }
     }
 }
@@ -39,14 +43,18 @@ pub struct Post {
     pub id: Uuid,
     pub subject: Option<String>,
     pub content: String,
+    /// Timestamp of the creation expressed in seconds since the Unix epoch
+    pub created_at: u64,
 }
 
 impl From<posts::Model> for Post {
     fn from(value: posts::Model) -> Self {
+        let (created_at_secs, _) = value.id.get_timestamp().unwrap().to_unix();
         Self {
             id: value.id,
             subject: value.subject,
             content: value.content,
+            created_at: created_at_secs,
         }
     }
 }

--- a/kitsune/src/service/search/mod.rs
+++ b/kitsune/src/service/search/mod.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use kitsune_db::entity::{accounts, posts};
 use serde::{Deserialize, Serialize};
 use std::{ops::Deref, sync::Arc};
+use strum::EnumIter;
 use uuid::Uuid;
 
 mod grpc;
@@ -88,7 +89,7 @@ impl From<posts::Model> for SearchItem {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, EnumIter)]
 pub enum SearchIndex {
     Account,
     Post,

--- a/kitsune/src/service/search/mod.rs
+++ b/kitsune/src/service/search/mod.rs
@@ -7,10 +7,13 @@ use strum::EnumIter;
 use uuid::Uuid;
 
 mod grpc;
+#[cfg(feature = "meilisearch")]
 mod meilisearch;
 mod sql;
 
-pub use self::{grpc::GrpcSearchService, meilisearch::MeiliSearchService, sql::SqlSearchService};
+#[cfg(feature = "meilisearch")]
+pub use self::meilisearch::MeiliSearchService;
+pub use self::{grpc::GrpcSearchService, sql::SqlSearchService};
 
 pub type ArcSearchService = Arc<dyn SearchService>;
 

--- a/kitsune/src/service/search/sql.rs
+++ b/kitsune/src/service/search/sql.rs
@@ -1,5 +1,4 @@
-use super::{SearchIndex, SearchItem, SearchResult, SearchService};
-use crate::error::Result;
+use super::{Result, SearchIndex, SearchItem, SearchResult, SearchService};
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
 use kitsune_db::{


### PR DESCRIPTION
Closes #136 

The support is gated behind the `meilisearch` feature flag. This is because the SDK uses `ishac` as their HTTP client which somewhere in the dependency tree pulls in a crate that requires installed OpenSSL development libraries.  
Due to this required native dependency this feature is explicitly *opt-in*