### PR TITLE
Replace a bunch of `derive_builder` usage with `typed-builder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2605,6 +2605,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "typed-builder",
  "url",
  "utoipa",
  "utoipa-swagger-ui",
@@ -5679,6 +5680,17 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "typed-builder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cba322cb9b7bc6ca048de49e83918223f35e7a86311267013afff257004870"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "typenum"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -95,6 +95,7 @@ tonic = "0.9.0"
 tower-http = { version = "0.4.0", features = ["cors", "fs", "trace"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
+typed-builder = "0.14.0"
 url = "2.3.1"
 utoipa = { version = "3.2.1", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "3.1.2", features = ["axum"] }

--- a/kitsune/src/http/extractor/signed_activity.rs
+++ b/kitsune/src/http/extractor/signed_activity.rs
@@ -51,11 +51,7 @@ impl FromRequest<Zustand, Body> for SignedActivity {
             // Refetch the user and try again
             // Maybe they rekeyed
 
-            let opts = FetchOptions::builder()
-                .refetch(true)
-                .url(ap_id)
-                .build()
-                .unwrap();
+            let opts = FetchOptions::builder().refetch(true).url(ap_id).build();
             let remote_user = state.fetcher.fetch_actor(opts).await?;
 
             if !verify_signature(&parts, &remote_user).await? {

--- a/kitsune/src/http/graphql/mutation/auth.rs
+++ b/kitsune/src/http/graphql/mutation/auth.rs
@@ -40,8 +40,7 @@ impl AuthMutation {
         let create_app = CreateApp::builder()
             .name(name)
             .redirect_uris(redirect_uri)
-            .build()
-            .unwrap();
+            .build();
         let application = ctx.state().service.oauth2.create_app(create_app).await?;
 
         Ok(application.into())
@@ -60,8 +59,7 @@ impl AuthMutation {
             .username(username)
             .email(email)
             .password(password)
-            .build()
-            .unwrap();
+            .build();
         let new_user = state.service.user.register(register).await?;
 
         Ok(new_user.into())

--- a/kitsune/src/http/handler/mastodon/api/v1/accounts/statuses.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/accounts/statuses.rs
@@ -50,18 +50,12 @@ pub async fn get(
 ) -> Result<Json<Vec<Status>>> {
     let fetching_account_id = auth_data.map(|user_data| user_data.0.account.id);
 
-    let mut get_posts = GetPosts::builder().account_id(account_id).clone();
-    if let Some(fetching_account_id) = fetching_account_id {
-        get_posts.fetching_account_id(fetching_account_id);
-    }
-    if let Some(max_id) = query.max_id {
-        get_posts.max_id(max_id);
-    }
-    if let Some(min_id) = query.min_id {
-        get_posts.min_id(min_id);
-    }
-
-    let get_posts = get_posts.build().unwrap();
+    let get_posts = GetPosts::builder()
+        .account_id(account_id)
+        .fetching_account_id(fetching_account_id)
+        .max_id(query.max_id)
+        .min_id(query.min_id)
+        .build();
     let limit = min(query.limit, MAX_LIMIT);
 
     let statuses: Vec<Status> = account

--- a/kitsune/src/http/handler/mastodon/api/v1/apps.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/apps.rs
@@ -30,8 +30,7 @@ async fn post(
     let create_app = CreateApp::builder()
         .name(form.client_name)
         .redirect_uris(form.redirect_uris)
-        .build()
-        .unwrap();
+        .build();
     let application = oauth2.create_app(create_app).await?;
 
     Ok(Json(App {

--- a/kitsune/src/http/handler/mastodon/api/v1/media.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/media.rs
@@ -131,8 +131,7 @@ pub async fn put(
         .account_id(user_data.account.id)
         .attachment_id(attachment_id)
         .description(form.description)
-        .build()
-        .unwrap();
+        .build();
 
     attachment_service
         .update(update)

--- a/kitsune/src/http/handler/mastodon/api/v1/timelines/home.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/timelines/home.rs
@@ -46,19 +46,12 @@ pub async fn get(
     Query(query): Query<GetQuery>,
     AuthExtractor(user_data): MastodonAuthExtractor,
 ) -> Result<Json<Vec<Status>>> {
-    let mut get_home = GetHome::builder()
+    let get_home = GetHome::builder()
         .fetching_account_id(user_data.account.id)
-        .clone();
-
-    if let Some(max_id) = query.max_id {
-        get_home.max_id(max_id);
-    }
-    if let Some(min_id) = query.min_id {
-        get_home.min_id(min_id);
-    }
-
+        .max_id(query.max_id)
+        .min_id(query.min_id)
+        .build();
     let limit = min(query.limit, MAX_LIMIT);
-    let get_home = get_home.build().unwrap();
 
     let statuses: Vec<Status> = timeline
         .get_home(get_home)

--- a/kitsune/src/http/handler/mastodon/api/v1/timelines/public.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/timelines/public.rs
@@ -45,20 +45,13 @@ pub async fn get(
     State(timeline): State<TimelineService>,
     Query(query): Query<GetQuery>,
 ) -> Result<Json<Vec<Status>>> {
-    let mut get_public = GetPublic::builder()
+    let get_public = GetPublic::builder()
         .only_local(query.local)
         .only_remote(query.remote)
-        .clone();
-
-    if let Some(max_id) = query.max_id {
-        get_public.max_id(max_id);
-    }
-    if let Some(min_id) = query.min_id {
-        get_public.min_id(min_id);
-    }
-
+        .max_id(query.max_id)
+        .min_id(query.min_id)
+        .build();
     let limit = min(query.limit, MAX_LIMIT);
-    let get_public = get_public.build().unwrap();
 
     let statuses: Vec<Status> = timeline
         .get_public(get_public)

--- a/kitsune/src/http/handler/oauth/authorize.rs
+++ b/kitsune/src/http/handler/oauth/authorize.rs
@@ -113,8 +113,7 @@ pub async fn post(
         .application(application)
         .state(query.state)
         .user_id(user.id)
-        .build()
-        .unwrap();
+        .build();
 
     oauth2_service
         .create_authorisation_code_response(authorisation_code)

--- a/kitsune/src/http/handler/oidc/callback.rs
+++ b/kitsune/src/http/handler/oidc/callback.rs
@@ -46,8 +46,7 @@ pub async fn get(
             .email(user_info.email)
             .username(user_info.username)
             .oidc_id(user_info.subject)
-            .build()
-            .unwrap();
+            .build();
 
         user_service.register(register).await?
     };
@@ -64,8 +63,8 @@ pub async fn get(
         .application(application)
         .state(user_info.oauth2.state)
         .user_id(user.id)
-        .build()
-        .unwrap();
+        .build();
+
     oauth_service
         .create_authorisation_code_response(authorisation_code)
         .await

--- a/kitsune/src/http/handler/users/mod.rs
+++ b/kitsune/src/http/handler/users/mod.rs
@@ -46,14 +46,11 @@ async fn get_html(
         .await?
         .ok_or(ApiError::NotFound)?;
 
-    let mut get_posts = GetPosts::builder().account_id(account.id).clone();
-    if let Some(max_id) = query.max_id {
-        get_posts.max_id(max_id);
-    }
-    if let Some(min_id) = query.min_id {
-        get_posts.min_id(min_id);
-    }
-    let get_posts = get_posts.build().unwrap();
+    let get_posts = GetPosts::builder()
+        .account_id(account.id)
+        .max_id(query.max_id)
+        .min_id(query.min_id)
+        .build();
 
     let posts = account_service
         .get_posts(get_posts)

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -54,14 +54,11 @@ pub async fn get(
     let base_url = format!("{}{}", url_service.base_url(), original_uri.path());
 
     if query.page {
-        let mut get_posts = GetPosts::builder().account_id(account.id).clone();
-        if let Some(max_id) = query.max_id {
-            get_posts.max_id(max_id);
-        }
-        if let Some(min_id) = query.min_id {
-            get_posts.min_id(min_id);
-        }
-        let get_posts = get_posts.build().unwrap();
+        let get_posts = GetPosts::builder()
+            .account_id(account.id)
+            .max_id(query.max_id)
+            .min_id(query.min_id)
+            .build();
 
         let posts: Vec<posts::Model> = state
             .service

--- a/kitsune/src/main.rs
+++ b/kitsune/src/main.rs
@@ -223,52 +223,43 @@ async fn initialise_state(config: &Configuration, conn: DatabaseConnection) -> Z
         .post_cache(prepare_cache(config, "ACTIVITYPUB-POST"))
         .search_service(search_service.clone())
         .user_cache(prepare_cache(config, "ACTIVITYPUB-USER"))
-        .build()
-        .unwrap();
+        .build();
 
     let webfinger = Webfinger::new(prepare_cache(config, "WEBFINGER"));
 
     let url_service = UrlService::builder()
         .scheme(config.url.scheme.as_str())
         .domain(config.url.domain.as_str())
-        .build()
-        .unwrap();
+        .build();
 
-    let account_service = AccountService::builder()
-        .db_conn(conn.clone())
-        .build()
-        .unwrap();
+    let account_service = AccountService::builder().db_conn(conn.clone()).build();
 
     let attachment_service = AttachmentService::builder()
         .db_conn(conn.clone())
         .media_proxy_enabled(config.server.media_proxy_enabled)
         .storage_backend(prepare_storage(config))
         .url_service(url_service.clone())
-        .build()
-        .unwrap();
+        .build();
 
     let instance_service = InstanceService::builder()
         .db_conn(conn.clone())
         .name(config.instance.name.as_str())
         .description(config.instance.description.as_str())
         .character_limit(config.instance.character_limit)
-        .build()
-        .unwrap();
+        .build();
 
     let oidc_service = OptionFuture::from(config.server.oidc.as_ref().map(|oidc_config| async {
         OidcService::builder()
             .client(prepare_oidc_client(oidc_config, &url_service).await)
             .login_state(prepare_cache(config, "OIDC-LOGIN-STATE"))
             .build()
-            .unwrap()
     }))
     .await;
 
     let oauth2_service = Oauth2Service::builder()
         .db_conn(conn.clone())
         .url_service(url_service.clone())
-        .build()
-        .unwrap();
+        .build();
 
     let post_resolver = PostResolver::new(conn.clone(), fetcher.clone(), webfinger.clone());
     let post_service = PostService::builder()
@@ -278,20 +269,15 @@ async fn initialise_state(config: &Configuration, conn: DatabaseConnection) -> Z
         .search_service(search_service.clone())
         .status_event_emitter(status_event_emitter.clone())
         .url_service(url_service.clone())
-        .build()
-        .unwrap();
+        .build();
 
-    let timeline_service = TimelineService::builder()
-        .db_conn(conn.clone())
-        .build()
-        .unwrap();
+    let timeline_service = TimelineService::builder().db_conn(conn.clone()).build();
 
     let user_service = UserService::builder()
         .db_conn(conn.clone())
         .registrations_open(config.instance.registrations_open)
         .url_service(url_service.clone())
-        .build()
-        .unwrap();
+        .build();
 
     #[cfg(feature = "mastodon-api")]
     let mastodon_mapper = kitsune::mapping::MastodonMapper::builder()

--- a/kitsune/src/mapping/mastodon/mod.rs
+++ b/kitsune/src/mapping/mastodon/mod.rs
@@ -10,6 +10,7 @@ use futures_util::StreamExt;
 use sea_orm::DatabaseConnection;
 use serde_json::Value;
 use std::{sync::Arc, time::Duration};
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 mod sealed;
@@ -21,19 +22,13 @@ pub trait MapperMarker: IntoMastodon {}
 
 impl<T> MapperMarker for T where T: IntoMastodon {}
 
-#[derive(Builder)]
-#[builder(pattern = "owned")]
+#[derive(TypedBuilder)]
 struct CacheInvalidationActor {
     cache: ArcCache<Uuid, Value>,
     event_consumer: PostEventConsumer,
 }
 
 impl CacheInvalidationActor {
-    #[must_use]
-    pub fn builder() -> CacheInvalidationActorBuilder {
-        CacheInvalidationActorBuilder::default()
-    }
-
     async fn run(mut self) {
         loop {
             while let Some(event) = self.event_consumer.next().await {
@@ -81,7 +76,6 @@ pub struct MastodonMapper {
                                 .ok_or(MastodonMapperBuilderError::UninitializedField(\"cache_invalidator\"))?
                         )
                         .build()
-                        .unwrap()
                         .spawn();",
         ),
         setter(name = "cache_invalidator", strip_option)

--- a/kitsune/src/mapping/mod.rs
+++ b/kitsune/src/mapping/mod.rs
@@ -7,4 +7,4 @@ pub use self::activitypub::IntoActivity;
 pub use self::activitypub::IntoObject;
 
 #[cfg(feature = "mastodon-api")]
-pub use self::mastodon::{MastodonMapper, MastodonMapperBuilder, MastodonMapperBuilderError};
+pub use self::mastodon::MastodonMapper;

--- a/kitsune/src/resolve/post.rs
+++ b/kitsune/src/resolve/post.rs
@@ -137,8 +137,8 @@ mod test {
             .search_service(Arc::new(NoopSearchService))
             .post_cache(Arc::new(NoopCache))
             .user_cache(Arc::new(NoopCache))
-            .build()
-            .unwrap();
+            .build();
+
         let mention_resolver = PostResolver::new(
             db_conn.clone(),
             fetcher,

--- a/kitsune/src/service/account.rs
+++ b/kitsune/src/service/account.rs
@@ -1,5 +1,4 @@
 use crate::error::{Error, Result};
-use derive_builder::Builder;
 use futures_util::{Stream, TryStreamExt};
 use kitsune_db::{
     entity::{
@@ -9,48 +8,37 @@ use kitsune_db::{
     r#trait::{PermissionCheck, PostPermissionCheckExt},
 };
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder};
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct GetPosts {
     /// ID of the account whose posts are getting fetched
     account_id: Uuid,
 
     /// ID of the account that is requesting the posts
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     fetching_account_id: Option<Uuid>,
 
     /// Smallest ID
     ///
     /// Used for pagination
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     min_id: Option<Uuid>,
 
     /// Largest ID
     ///
     /// Used for pagination
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     max_id: Option<Uuid>,
 }
 
-impl GetPosts {
-    #[must_use]
-    pub fn builder() -> GetPostsBuilder {
-        GetPostsBuilder::default()
-    }
-}
-
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct AccountService {
     db_conn: DatabaseConnection,
 }
 
 impl AccountService {
-    #[must_use]
-    pub fn builder() -> AccountServiceBuilder {
-        AccountServiceBuilder::default()
-    }
-
     /// Get a local account by its username
     pub async fn get_local_by_username(&self, username: &str) -> Result<Option<accounts::Model>> {
         Accounts::find()

--- a/kitsune/src/service/attachment.rs
+++ b/kitsune/src/service/attachment.rs
@@ -12,23 +12,17 @@ use sea_orm::{
     QueryFilter,
 };
 use std::sync::Arc;
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 const ALLOWED_FILETYPES: &[mime::Name<'_>] = &[mime::IMAGE, mime::VIDEO, mime::AUDIO];
 
-#[derive(Builder)]
+#[derive(TypedBuilder)]
 pub struct Update {
     account_id: Uuid,
     attachment_id: Uuid,
     #[builder(setter(strip_option))]
     description: Option<String>,
-}
-
-impl Update {
-    #[must_use]
-    pub fn builder() -> UpdateBuilder {
-        UpdateBuilder::default()
-    }
 }
 
 #[derive(Builder)]
@@ -50,19 +44,19 @@ impl<S> Upload<S> {
     }
 }
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct AttachmentService {
-    #[builder(default = "
+    #[builder(default =
         Client::builder()
             .content_length_limit(None)
             .user_agent(concat!(
-                env!(\"CARGO_PKG_NAME\"),
-                \"/\",
-                env!(\"CARGO_PKG_VERSION\")
+                env!("CARGO_PKG_NAME"),
+                "/",
+                env!("CARGO_PKG_VERSION")
             ))
             .unwrap()
             .build()
-    ")]
+    )]
     client: Client,
     db_conn: DatabaseConnection,
     media_proxy_enabled: bool,
@@ -71,11 +65,6 @@ pub struct AttachmentService {
 }
 
 impl AttachmentService {
-    #[must_use]
-    pub fn builder() -> AttachmentServiceBuilder {
-        AttachmentServiceBuilder::default()
-    }
-
     pub async fn get_by_id(&self, id: Uuid) -> Result<media_attachments::Model> {
         MediaAttachments::find_by_id(id)
             .one(&self.db_conn)

--- a/kitsune/src/service/instance.rs
+++ b/kitsune/src/service/instance.rs
@@ -1,5 +1,4 @@
 use crate::error::{Error, Result};
-use derive_builder::Builder;
 use kitsune_db::entity::{
     accounts, posts,
     prelude::{Accounts, Posts, Users},
@@ -8,8 +7,9 @@ use sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter, QuerySelect,
 };
 use std::sync::Arc;
+use typed_builder::TypedBuilder;
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct InstanceService {
     db_conn: DatabaseConnection,
     #[builder(setter(into))]
@@ -20,11 +20,6 @@ pub struct InstanceService {
 }
 
 impl InstanceService {
-    #[must_use]
-    pub fn builder() -> InstanceServiceBuilder {
-        InstanceServiceBuilder::default()
-    }
-
     #[must_use]
     pub fn character_limit(&self) -> usize {
         self.character_limit

--- a/kitsune/src/service/oauth2.rs
+++ b/kitsune/src/service/oauth2.rs
@@ -7,12 +7,12 @@ use askama::Template;
 use askama_axum::IntoResponse;
 use axum::response::Response;
 use chrono::{Duration, Utc};
-use derive_builder::Builder;
 use http::StatusCode;
 use kitsune_db::entity::{oauth2_applications, oauth2_authorization_codes};
 use once_cell::sync::Lazy;
 use sea_orm::{ActiveModelTrait, DatabaseConnection, IntoActiveModel};
 use std::str::FromStr;
+use typed_builder::TypedBuilder;
 use url::Url;
 use uuid::Uuid;
 
@@ -21,31 +21,17 @@ pub static TOKEN_VALID_DURATION: Lazy<Duration> = Lazy::new(|| Duration::hours(1
 /// If the Redirect URI is equal to this string, show the token instead of redirecting the user
 const SHOW_TOKEN_URI: &str = "urn:ietf:wg:oauth:2.0:oob";
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct AuthorisationCode {
     application: oauth2_applications::Model,
     state: Option<String>,
     user_id: Uuid,
 }
 
-impl AuthorisationCode {
-    #[must_use]
-    pub fn builder() -> AuthorisationCodeBuilder {
-        AuthorisationCodeBuilder::default()
-    }
-}
-
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct CreateApp {
     name: String,
     redirect_uris: String,
-}
-
-impl CreateApp {
-    #[must_use]
-    pub fn builder() -> CreateAppBuilder {
-        CreateAppBuilder::default()
-    }
 }
 
 #[derive(Template)]
@@ -56,18 +42,13 @@ struct ShowTokenPage {
     token: String,
 }
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct Oauth2Service {
     db_conn: DatabaseConnection,
     url_service: UrlService,
 }
 
 impl Oauth2Service {
-    #[must_use]
-    pub fn builder() -> Oauth2ServiceBuilder {
-        Oauth2ServiceBuilder::default()
-    }
-
     pub async fn create_app(&self, create_app: CreateApp) -> Result<oauth2_applications::Model> {
         oauth2_applications::Model {
             id: Uuid::now_v7(),

--- a/kitsune/src/service/oidc.rs
+++ b/kitsune/src/service/oidc.rs
@@ -2,7 +2,6 @@ use crate::{
     cache::ArcCache,
     error::{OidcError, Result},
 };
-use derive_builder::Builder;
 use http::Request;
 use hyper::Body;
 use kitsune_http_client::{Client, Error};
@@ -12,6 +11,7 @@ use openidconnect::{
     OAuth2TokenResponse, PkceCodeChallenge, PkceCodeVerifier, Scope, TokenResponse,
 };
 use serde::{Deserialize, Serialize};
+use typed_builder::TypedBuilder;
 use url::Url;
 use uuid::Uuid;
 
@@ -66,18 +66,13 @@ impl Clone for LoginState {
     }
 }
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct OidcService {
     client: CoreClient,
     login_state: ArcCache<String, LoginState>,
 }
 
 impl OidcService {
-    #[must_use]
-    pub fn builder() -> OidcServiceBuilder {
-        OidcServiceBuilder::default()
-    }
-
     pub async fn authorisation_url(
         &self,
         oauth2_application_id: Uuid,

--- a/kitsune/src/service/post.rs
+++ b/kitsune/src/service/post.rs
@@ -34,6 +34,7 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait,
     IntoActiveModel, ModelTrait, PaginatorTrait, QueryFilter, TransactionTrait,
 };
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 #[derive(Clone, Builder)]
@@ -112,8 +113,7 @@ impl DeletePost {
     }
 }
 
-#[derive(Builder, Clone)]
-#[builder(pattern = "owned")]
+#[derive(Clone, TypedBuilder)]
 pub struct PostService {
     db_conn: DatabaseConnection,
     instance_service: InstanceService,
@@ -124,11 +124,6 @@ pub struct PostService {
 }
 
 impl PostService {
-    #[must_use]
-    pub fn builder() -> PostServiceBuilder {
-        PostServiceBuilder::default()
-    }
-
     async fn process_media_attachments<C>(
         conn: &C,
         post_id: Uuid,

--- a/kitsune/src/service/timeline.rs
+++ b/kitsune/src/service/timeline.rs
@@ -1,5 +1,4 @@
 use crate::error::{Error, Result};
-use derive_builder::Builder;
 use futures_util::{Stream, TryStreamExt};
 use kitsune_db::{
     custom::Visibility,
@@ -14,32 +13,26 @@ use sea_orm::{
     ColumnTrait, DatabaseConnection, EntityTrait, JoinType, QueryFilter, QueryOrder, QuerySelect,
     QueryTrait, RelationTrait,
 };
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct GetHome {
     fetching_account_id: Uuid,
 
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     max_id: Option<Uuid>,
 
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     min_id: Option<Uuid>,
 }
 
-impl GetHome {
-    #[must_use]
-    pub fn builder() -> GetHomeBuilder {
-        GetHomeBuilder::default()
-    }
-}
-
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct GetPublic {
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     max_id: Option<Uuid>,
 
-    #[builder(default, setter(strip_option))]
+    #[builder(default)]
     min_id: Option<Uuid>,
 
     #[builder(default)]
@@ -49,24 +42,12 @@ pub struct GetPublic {
     only_remote: bool,
 }
 
-impl GetPublic {
-    #[must_use]
-    pub fn builder() -> GetPublicBuilder {
-        GetPublicBuilder::default()
-    }
-}
-
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct TimelineService {
     db_conn: DatabaseConnection,
 }
 
 impl TimelineService {
-    #[must_use]
-    pub fn builder() -> TimelineServiceBuilder {
-        TimelineServiceBuilder::default()
-    }
-
     /// Get a stream of posts that resemble the users home timeline
     pub async fn get_home(
         &self,

--- a/kitsune/src/service/url.rs
+++ b/kitsune/src/service/url.rs
@@ -1,12 +1,12 @@
-use derive_builder::Builder;
 use std::sync::Arc;
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
 /// Small "service" to centralise the creation of URLs
 ///
 /// For some light deduplication purposes and to centralise the whole formatting story.
 /// Allows for easier adjustments of URLs.
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct UrlService {
     #[builder(setter(into))]
     scheme: Arc<str>,
@@ -15,11 +15,6 @@ pub struct UrlService {
 }
 
 impl UrlService {
-    #[must_use]
-    pub fn builder() -> UrlServiceBuilder {
-        UrlServiceBuilder::default()
-    }
-
     #[must_use]
     pub fn base_url(&self) -> String {
         format!("{}://{}", self.scheme, self.domain)

--- a/kitsune/src/service/user.rs
+++ b/kitsune/src/service/user.rs
@@ -2,7 +2,6 @@ use super::url::UrlService;
 use crate::error::{ApiError, Error, Result};
 use argon2::{password_hash::SaltString, Argon2, PasswordHasher};
 use chrono::Utc;
-use derive_builder::Builder;
 use futures_util::{future::OptionFuture, FutureExt};
 use kitsune_db::entity::{
     accounts,
@@ -17,9 +16,10 @@ use sea_orm::{
     ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, IntoActiveModel, QueryFilter,
     TransactionTrait,
 };
+use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct Register {
     /// Username of the new user
     username: String,
@@ -36,14 +36,7 @@ pub struct Register {
     password: Option<String>,
 }
 
-impl Register {
-    #[must_use]
-    pub fn builder() -> RegisterBuilder {
-        RegisterBuilder::default()
-    }
-}
-
-#[derive(Builder, Clone)]
+#[derive(Clone, TypedBuilder)]
 pub struct UserService {
     db_conn: DatabaseConnection,
     registrations_open: bool,
@@ -51,11 +44,6 @@ pub struct UserService {
 }
 
 impl UserService {
-    #[must_use]
-    pub fn builder() -> UserServiceBuilder {
-        UserServiceBuilder::default()
-    }
-
     pub async fn register(&self, register: Register) -> Result<users::Model> {
         if !self.registrations_open {
             return Err(ApiError::RegistrationsClosed.into());


### PR DESCRIPTION
The usage of the builder pattern for passing options between services is nice but the runtime validation of whether all the parameters are present is a potential source of mistakes.

`typed-builder` utilises the typestate pattern to produce compile-time validated builders. This will make future refactors of services and their parameters easier 