### PR TITLE
ActivityPub type rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,23 @@ We successfully federated with Mastodon on the following functionality:
 - Actors
 - Posts
     - Create
+        - Incoming and outgoing
     - Delete
+        - Incoming and outgoing
     - Replies
+        - Incoming and outgoing
     - Content Warnings
+        - Outgoing
     - Media attachments
+        - Outgoing
 - Likes
     - Added
     - Removed
+- Follows
+    - Added
+        - Incoming
+    - Removed
+        - Incoming
 
 (last updated: 09.04.2023)
 

--- a/kitsune-type/src/ap/collection.rs
+++ b/kitsune-type/src/ap/collection.rs
@@ -9,7 +9,7 @@ pub enum CollectionType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Collection {
-    #[serde(rename = "@context")]
+    #[serde(default, rename = "@context")]
     pub context: Value,
     pub id: String,
     pub r#type: CollectionType,
@@ -26,7 +26,7 @@ pub enum PageType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionPage {
-    #[serde(rename = "@context")]
+    #[serde(default, rename = "@context")]
     pub context: Value,
     pub id: String,
     pub r#type: PageType,

--- a/kitsune-type/src/ap/collection.rs
+++ b/kitsune-type/src/ap/collection.rs
@@ -1,13 +1,12 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum CollectionType {
-    #[default]
     OrderedCollection,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Collection {
     #[serde(rename = "@context")]
@@ -19,13 +18,12 @@ pub struct Collection {
     pub last: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum PageType {
-    #[default]
     OrderedCollectionPage,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CollectionPage {
     #[serde(rename = "@context")]

--- a/kitsune-type/src/ap/helper.rs
+++ b/kitsune-type/src/ap/helper.rs
@@ -1,4 +1,4 @@
-use super::{Activity, BaseObject, Object, PUBLIC_IDENTIFIER};
+use super::{Activity, Object, PUBLIC_IDENTIFIER};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -37,31 +37,21 @@ pub trait CcTo {
 
 impl CcTo for Activity {
     fn cc(&self) -> &[String] {
-        self.rest.cc()
+        &self.cc
     }
 
     fn to(&self) -> &[String] {
-        self.rest.to()
-    }
-}
-
-impl CcTo for BaseObject {
-    fn cc(&self) -> &[String] {
-        self.cc.as_slice()
-    }
-
-    fn to(&self) -> &[String] {
-        self.to.as_slice()
+        &self.to
     }
 }
 
 impl CcTo for Object {
     fn cc(&self) -> &[String] {
-        &self.rest.cc
+        &self.cc
     }
 
     fn to(&self) -> &[String] {
-        &self.rest.to
+        &self.to
     }
 }
 
@@ -76,16 +66,6 @@ pub trait Privacy {
 
 impl Privacy for Activity {
     fn is_public(&self) -> bool {
-        self.rest.is_public()
-    }
-
-    fn is_unlisted(&self) -> bool {
-        self.rest.is_unlisted()
-    }
-}
-
-impl Privacy for BaseObject {
-    fn is_public(&self) -> bool {
         self.to.iter().any(|url| url == PUBLIC_IDENTIFIER)
     }
 
@@ -96,10 +76,10 @@ impl Privacy for BaseObject {
 
 impl Privacy for Object {
     fn is_public(&self) -> bool {
-        self.rest.is_public()
+        self.to.iter().any(|url| url == PUBLIC_IDENTIFIER)
     }
 
     fn is_unlisted(&self) -> bool {
-        self.rest.is_unlisted()
+        !self.is_public() && self.cc.iter().any(|url| url == PUBLIC_IDENTIFIER)
     }
 }

--- a/kitsune-type/src/ap/helper.rs
+++ b/kitsune-type/src/ap/helper.rs
@@ -1,4 +1,4 @@
-use super::{Activity, Object, PUBLIC_IDENTIFIER};
+use super::{Object, PUBLIC_IDENTIFIER};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -35,16 +35,6 @@ pub trait CcTo {
     fn to(&self) -> &[String];
 }
 
-impl CcTo for Activity {
-    fn cc(&self) -> &[String] {
-        &self.cc
-    }
-
-    fn to(&self) -> &[String] {
-        &self.to
-    }
-}
-
 impl CcTo for Object {
     fn cc(&self) -> &[String] {
         &self.cc
@@ -61,16 +51,6 @@ pub trait Privacy {
 
     fn is_private(&self) -> bool {
         !self.is_public() && !self.is_unlisted()
-    }
-}
-
-impl Privacy for Activity {
-    fn is_public(&self) -> bool {
-        self.to.iter().any(|url| url == PUBLIC_IDENTIFIER)
-    }
-
-    fn is_unlisted(&self) -> bool {
-        !self.is_public() && self.cc.iter().any(|url| url == PUBLIC_IDENTIFIER)
     }
 }
 

--- a/kitsune-type/src/ap/mod.rs
+++ b/kitsune-type/src/ap/mod.rs
@@ -93,7 +93,7 @@ impl ObjectField {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Activity {
-    #[serde(rename = "@context")]
+    #[serde(default, rename = "@context")]
     pub context: Value,
     pub id: String,
     pub r#type: ActivityType,

--- a/kitsune-type/src/ap/mod.rs
+++ b/kitsune-type/src/ap/mod.rs
@@ -53,6 +53,10 @@ pub enum ObjectField {
     Actor(Actor),
     Object(Object),
     Url(String),
+    // We really just need the ID from a tombstone object.
+    // These are used by, for example, Mastodon in the object field of `Delete` activities.
+    // So we just hack this in as the last possible case.
+    Tombstone { id: String },
 }
 
 impl ObjectField {
@@ -62,6 +66,7 @@ impl ObjectField {
             Self::Actor(ref actor) => &actor.id,
             Self::Object(ref object) => &object.id,
             Self::Url(ref url) => url,
+            Self::Tombstone { ref id } => id,
         }
     }
 
@@ -117,6 +122,7 @@ impl Activity {
             ObjectField::Actor(ref actor) => actor.id.as_str(),
             ObjectField::Object(ref object) => object.id.as_str(),
             ObjectField::Url(ref url) => url,
+            ObjectField::Tombstone { ref id } => id,
         }
     }
 }

--- a/kitsune-type/src/ap/mod.rs
+++ b/kitsune-type/src/ap/mod.rs
@@ -132,7 +132,7 @@ pub enum ObjectType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Object {
-    #[serde(rename = "@context")]
+    #[serde(default, rename = "@context")]
     pub context: Value,
     pub id: String,
     pub r#type: ObjectType,

--- a/kitsune-type/src/ap/mod.rs
+++ b/kitsune-type/src/ap/mod.rs
@@ -47,6 +47,7 @@ pub enum ActivityType {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
 pub enum ObjectField {
     Activity(Box<Activity>),
     Actor(Actor),
@@ -100,10 +101,6 @@ pub struct Activity {
     pub object: ObjectField,
     #[serde(default)]
     pub published: DateTime<Utc>,
-    #[serde(default)]
-    pub to: Vec<String>,
-    #[serde(default)]
-    pub cc: Vec<String>,
 }
 
 impl Activity {
@@ -133,6 +130,7 @@ pub enum ObjectType {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Object {
     #[serde(rename = "@context")]
     pub context: Value,

--- a/kitsune-type/src/ap/object.rs
+++ b/kitsune-type/src/ap/object.rs
@@ -1,16 +1,16 @@
-use super::BaseObject;
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum MediaAttachmentType {
     Audio,
-    #[default]
     Document,
     Image,
     Video,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaAttachment {
     pub r#type: MediaAttachmentType,
@@ -20,24 +20,24 @@ pub struct MediaAttachment {
     pub url: String,
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum ActorType {
     Group,
-    #[default]
     Person,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Actor {
+    #[serde(rename = "@context")]
+    pub context: Value,
+    pub id: String,
     pub r#type: ActorType,
     pub name: Option<String>,
     pub preferred_username: String,
     pub subject: Option<String>,
     pub icon: Option<MediaAttachment>,
     pub image: Option<MediaAttachment>,
-    #[serde(flatten)]
-    pub rest: BaseObject,
     #[serde(default)]
     pub manually_approves_followers: bool,
     pub public_key: PublicKey,
@@ -45,9 +45,10 @@ pub struct Actor {
     pub outbox: String,
     pub followers: String,
     pub following: String,
+    pub published: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKey {
     pub id: String,

--- a/kitsune-type/src/ap/object.rs
+++ b/kitsune-type/src/ap/object.rs
@@ -29,7 +29,7 @@ pub enum ActorType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Actor {
-    #[serde(rename = "@context")]
+    #[serde(default, rename = "@context")]
     pub context: Value,
     pub id: String,
     pub r#type: ActorType,

--- a/kitsune/src/activitypub/deliverer.rs
+++ b/kitsune/src/activitypub/deliverer.rs
@@ -12,7 +12,6 @@ use kitsune_http_client::Client;
 use kitsune_http_signatures::{ring::signature::RsaKeyPair, PrivateKey};
 use kitsune_type::ap::Activity;
 use rsa::pkcs8::SecretDocument;
-use serde::Serialize;
 use sha2::{Digest, Sha256};
 use typed_builder::TypedBuilder;
 use url::Url;
@@ -33,18 +32,15 @@ impl Deliverer {
     /// # Panics
     ///
     /// - Panics in case the inbox URL isn't actually a valid URL
-    #[instrument(skip_all, fields(%inbox_url, activity_url = %activity.rest.id))]
+    #[instrument(skip_all, fields(%inbox_url, activity_url = %activity.id))]
     #[autometrics(track_concurrency)]
-    pub async fn deliver<T>(
+    pub async fn deliver(
         &self,
         inbox_url: &str,
         account: &accounts::Model,
         user: &users::Model,
-        activity: &Activity<T>,
-    ) -> Result<()>
-    where
-        T: Serialize,
-    {
+        activity: &Activity,
+    ) -> Result<()> {
         if !self
             .federation_filter
             .is_url_allowed(&Url::parse(inbox_url)?)?

--- a/kitsune/src/http/extractor/signed_activity.rs
+++ b/kitsune/src/http/extractor/signed_activity.rs
@@ -41,11 +41,8 @@ impl FromRequest<Zustand, Body> for SignedActivity {
                 return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
             }
         };
-        let ap_id = activity
-            .rest
-            .attributed_to()
-            .ok_or_else(|| StatusCode::BAD_REQUEST.into_response())?;
 
+        let ap_id = activity.actor();
         let remote_user = state.fetcher.fetch_actor(ap_id.into()).await?;
         if !verify_signature(&parts, &remote_user).await? {
             // Refetch the user and try again

--- a/kitsune/src/http/extractor/signed_activity.rs
+++ b/kitsune/src/http/extractor/signed_activity.rs
@@ -6,7 +6,7 @@ use crate::{
 use async_trait::async_trait;
 use axum::{
     body::Body,
-    extract::FromRequest,
+    extract::{FromRequest, OriginalUri},
     response::{IntoResponse, Response},
     RequestExt,
 };
@@ -26,13 +26,21 @@ impl FromRequest<Zustand, Body> for SignedActivity {
     type Rejection = Response;
 
     async fn from_request(
-        req: http::Request<Body>,
+        mut req: http::Request<Body>,
         state: &Zustand,
     ) -> Result<Self, Self::Rejection> {
-        let (parts, body) = req
+        // Axum will cut out the "/users" part of the router (due to the nesting)
+        // That's why we get the original URI here (which includes the full path)
+        let OriginalUri(original_uri) = req
+            .extract_parts()
+            .await
+            .map_err(IntoResponse::into_response)?;
+
+        let (mut parts, body) = req
             .with_limited_body()
             .expect("[Bug] Payload size of inbox not limited")
             .into_parts();
+        parts.uri = original_uri;
 
         let activity: Activity = match hyper::body::to_bytes(body).await {
             Ok(bytes) => serde_json::from_slice(&bytes).map_err(Error::from)?,

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -45,7 +45,6 @@ async fn create_activity(
     author: accounts::Model,
     activity: Activity,
 ) -> Result<()> {
-    let visibility = Visibility::from_activitypub(&author, &activity);
     if let Some(object) = activity.object.into_object() {
         let in_reply_to_id = OptionFuture::from(
             object
@@ -61,6 +60,7 @@ async fn create_activity(
             .db_conn
             .transaction(|tx| {
                 async move {
+                    let visibility = Visibility::from_activitypub(&author, &object);
                     let new_post = Posts::insert(
                         posts::Model {
                             id: Uuid::now_v7(),

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -49,7 +49,6 @@ async fn create_activity(
     if let Some(object) = activity.object.into_object() {
         let in_reply_to_id = OptionFuture::from(
             object
-                .rest
                 .in_reply_to
                 .as_ref()
                 .map(|post_url| state.fetcher.fetch_object(post_url)),
@@ -70,11 +69,11 @@ async fn create_activity(
                             reposted_post_id: None,
                             subject: object.summary,
                             content: object.content,
-                            is_sensitive: object.rest.sensitive,
+                            is_sensitive: object.sensitive,
                             visibility,
                             is_local: false,
-                            url: object.rest.id,
-                            created_at: object.rest.published.into(),
+                            url: object.id,
+                            created_at: object.published.into(),
                             updated_at: Utc::now().into(),
                         }
                         .into_active_model(),
@@ -151,8 +150,8 @@ async fn follow_activity(
             account_id: followed_user.id,
             follower_id: author.id,
             approved_at: None,
-            url: activity.rest.id,
-            created_at: activity.rest.published.into(),
+            url: activity.id,
+            created_at: activity.published.into(),
             updated_at: Utc::now().into(),
         }
         .into_active_model(),
@@ -183,7 +182,7 @@ async fn like_activity(state: &Zustand, author: accounts::Model, activity: Activ
             id: Uuid::now_v7(),
             account_id: author.id,
             post_id: post.id,
-            url: activity.rest.id,
+            url: activity.id,
             created_at: Utc::now().into(),
         }
         .into_active_model(),

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -17,7 +17,7 @@ use kitsune_type::ap::{
     ap_context,
     helper::StringOrObject,
     object::{Actor, ActorType, MediaAttachment, MediaAttachmentType, PublicKey},
-    BaseObject, Object, ObjectType, Tag, TagType,
+    Object, ObjectType, Tag, TagType,
 };
 use mime::Mime;
 use sea_orm::{prelude::*, QuerySelect};
@@ -120,22 +120,19 @@ impl IntoObject for posts::Model {
         }
 
         Ok(Object {
+            context: ap_context(),
+            id: self.url,
             r#type: ObjectType::Note,
+            attributed_to: StringOrObject::String(account.url),
+            in_reply_to,
+            sensitive: self.is_sensitive,
             summary: self.subject,
             content: self.content,
             attachment,
             tag,
-            url: Some(self.url.clone()),
-            rest: BaseObject {
-                context: ap_context(),
-                id: self.url,
-                attributed_to: Some(StringOrObject::String(account.url)),
-                in_reply_to,
-                sensitive: self.is_sensitive,
-                published: self.created_at.into(),
-                to,
-                cc,
-            },
+            published: self.created_at.into(),
+            to,
+            cc,
         })
     }
 }
@@ -170,6 +167,8 @@ impl IntoObject for accounts::Model {
         let following_url = format!("{}/following", self.url);
 
         Ok(Actor {
+            context: ap_context(),
+            id: self.url.clone(),
             r#type: ActorType::Person,
             name: self.display_name,
             subject: self.note,
@@ -181,16 +180,12 @@ impl IntoObject for accounts::Model {
             outbox: outbox_url,
             followers: self.followers_url,
             following: following_url,
-            rest: BaseObject {
-                id: self.url.clone(),
-                published: self.created_at.into(),
-                ..Default::default()
-            },
             public_key: PublicKey {
                 id: public_key_id,
                 owner: self.url,
                 public_key_pem: self.public_key,
             },
+            published: self.created_at.into(),
         })
     }
 }

--- a/kitsune/src/service/federation_filter.rs
+++ b/kitsune/src/service/federation_filter.rs
@@ -10,19 +10,19 @@ pub trait Entity {
 
 impl Entity for Activity {
     fn id(&self) -> &str {
-        &self.rest.id
+        &self.id
     }
 }
 
 impl Entity for Actor {
     fn id(&self) -> &str {
-        &self.rest.id
+        &self.id
     }
 }
 
 impl Entity for Object {
     fn id(&self) -> &str {
-        &self.rest.id
+        &self.id
     }
 }
 


### PR DESCRIPTION
The current layout of the ActivityPub types felt a bit off. This PR changes how they are represented as structs.  
While the new structure does introduce some repeated field names, I think it's still easier to reason about than the previous one.