### PR TITLE
Populate `reblogged` and `favourited` properties in Mastodon status entities

### DIFF
--- a/kitsune-type/src/mastodon/status.rs
+++ b/kitsune-type/src/mastodon/status.rs
@@ -48,4 +48,6 @@ pub struct Status {
     pub media_attachments: Vec<MediaAttachment>,
     pub mentions: Vec<Mention>,
     pub reblog: Option<Box<Status>>,
+    pub favourited: bool,
+    pub reblogged: bool,
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/statuses/favourite.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/statuses/favourite.rs
@@ -32,5 +32,5 @@ pub async fn post(
 ) -> Result<Response> {
     let post = post.favourite(id, user_data.account.id).await?;
 
-    Ok(Json(mastodon_mapper.map(post).await?).into_response())
+    Ok(Json(mastodon_mapper.map((&user_data.account, post)).await?).into_response())
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/statuses/unfavourite.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/statuses/unfavourite.rs
@@ -32,5 +32,5 @@ pub async fn post(
 ) -> Result<Response> {
     let post = post.unfavourite(id, user_data.account.id).await?;
 
-    Ok(Json(mastodon_mapper.map(post).await?).into_response())
+    Ok(Json(mastodon_mapper.map((&user_data.account, post)).await?).into_response())
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/timelines/home.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/timelines/home.rs
@@ -57,7 +57,7 @@ pub async fn get(
         .get_home(get_home)
         .await?
         .take(limit)
-        .and_then(|post| mastodon_mapper.map(post))
+        .and_then(|post| mastodon_mapper.map((&user_data.account, post)))
         .try_collect()
         .await?;
 


### PR DESCRIPTION
Closes #166 