### PR TITLE
Fix follows on unlocked accounts

### DIFF
--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -1,0 +1,61 @@
+use crate::{
+    error::Result,
+    job::{JobContext, Runnable},
+};
+use async_trait::async_trait;
+use chrono::Utc;
+use kitsune_db::entity::prelude::{Accounts, AccountsFollowers, Users};
+use kitsune_type::ap::{ap_context, helper::StringOrObject, Activity, ActivityType, ObjectField};
+use sea_orm::EntityTrait;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Deserialize, Serialize)]
+pub struct DeliverAccept {
+    pub follow_id: Uuid,
+}
+
+#[async_trait]
+impl Runnable for DeliverAccept {
+    #[instrument(skip_all, fields(follow_id = %self.follow_id))]
+    async fn run(&self, ctx: JobContext<'_>) -> Result<()> {
+        let Some(follow) = AccountsFollowers::find_by_id(self.follow_id)
+            .one(&ctx.state.db_conn)
+            .await?
+        else {
+            return Ok(());
+        };
+        let follower = Accounts::find_by_id(follow.follower_id)
+            .one(&ctx.state.db_conn)
+            .await?
+            .expect("[Bug] Missing follower");
+        let Some((followed_account, Some(followed_user))) = Accounts::find_by_id(follow.account_id)
+            .find_also_related(Users)
+            .one(&ctx.state.db_conn)
+            .await?
+        else {
+            error!("missing followed user");
+            return Ok(());
+        };
+
+        let accept_activity = Activity {
+            context: ap_context(),
+            id: format!("{}#accept", follow.url),
+            r#type: ActivityType::Accept,
+            actor: StringOrObject::String(followed_account.url.clone()),
+            object: ObjectField::Url(follow.url),
+            published: Utc::now(),
+        };
+
+        ctx.deliverer
+            .deliver(
+                &follower.inbox_url,
+                &followed_account,
+                &followed_user,
+                &accept_activity,
+            )
+            .await?;
+
+        Ok(())
+    }
+}

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -38,6 +38,11 @@ impl Runnable for DeliverAccept {
             return Ok(());
         };
 
+        // Constructing this here is against our idea of the `IntoActivity` and `IntoObject` traits
+        // But I'm not sure how I could encode these into the form of these two traits
+        // So we make an exception for this
+        //
+        // If someone has a better idea, please open an issue
         let accept_activity = Activity {
             context: ap_context(),
             id: format!("{}#accept", follow.url),

--- a/kitsune/src/job/deliver/mod.rs
+++ b/kitsune/src/job/deliver/mod.rs
@@ -1,3 +1,4 @@
+pub mod accept;
 pub mod create;
 pub mod delete;
 pub mod favourite;

--- a/kitsune/src/job/mod.rs
+++ b/kitsune/src/job/mod.rs
@@ -1,9 +1,9 @@
 use self::{
     catch_panic::CatchPanic,
     deliver::{
-        create::DeliverCreate, delete::DeliverDelete, favourite::DeliverFavourite,
-        follow::DeliverFollow, unfavourite::DeliverUnfavourite, unfollow::DeliverUnfollow,
-        update::DeliverUpdate,
+        accept::DeliverAccept, create::DeliverCreate, delete::DeliverDelete,
+        favourite::DeliverFavourite, follow::DeliverFollow, unfavourite::DeliverUnfavourite,
+        unfollow::DeliverUnfollow, update::DeliverUpdate,
     },
 };
 use crate::{
@@ -37,6 +37,7 @@ const PAUSE_BETWEEN_QUERIES: Duration = Duration::from_secs(5);
 #[enum_dispatch(Runnable)]
 #[derive(Deserialize, Serialize)]
 pub enum Job {
+    DeliverAccept,
     DeliverCreate,
     DeliverDelete,
     DeliverFavourite,


### PR DESCRIPTION
ActivityPub requires the delivery of an `Accept` activity as a reply to a `Follow`. These weren't sent out yet.  
This PR adds a job to deliver accept activities and enqueues such a job inside the inbox when user is unlocked.

