### PR TITLE
SQLite fixes

### DIFF
--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -215,6 +215,7 @@ impl Fetcher {
                 .boxed()
             })
             .await?;
+
         self.search_service
             .add_to_index(account.clone().into())
             .await?;

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -1,5 +1,3 @@
-use std::ops::Not;
-
 use crate::{
     activitypub::{handle_attachments, handle_mentions},
     error::{Error, Result},
@@ -25,6 +23,7 @@ use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter,
     QuerySelect, TransactionTrait,
 };
+use std::ops::Not;
 use uuid::Uuid;
 
 async fn accept_activity(state: &Zustand, activity: Activity) -> Result<()> {

--- a/kitsune/src/service/instance.rs
+++ b/kitsune/src/service/instance.rs
@@ -39,6 +39,7 @@ impl InstanceService {
         Accounts::find()
             .filter(accounts::Column::Local.eq(false))
             .select_only()
+            .column(accounts::Column::Id)
             .group_by(accounts::Column::Domain)
             .count(&self.db_conn)
             .await


### PR DESCRIPTION
Small fixes for SQLite

1. The select was broken. We called `select_only` but no column to select
2. A transaction in SQLite locks the whole database, then we tried to enqueue the job via a separate database connection. This will obviously fail after the timeout since this would be a double lock. To fix this, I simply moved the job enqueueing outside of the transaction.  
  I think this is fine because the post is in a complete state. It not being federated isn't really a concern of the transaction.

Thanks to `s4if` on Matrix for reporting these issues