### PR TITLE
Remove the unique requirement from the `username` column

### DIFF
--- a/kitsune-db/migration/src/m20220101_000001_create_table.rs
+++ b/kitsune-db/migration/src/m20220101_000001_create_table.rs
@@ -129,12 +129,7 @@ impl MigrationTrait for Migration {
                             .unique_key(),
                     )
                     .col(ColumnDef::new(Users::OidcId).text().unique_key())
-                    .col(
-                        ColumnDef::new(Users::Username)
-                            .text()
-                            .not_null()
-                            .unique_key(),
-                    )
+                    .col(ColumnDef::new(Users::Username).text().not_null())
                     .col(ColumnDef::new(Users::Email).text().not_null().unique_key())
                     .col(ColumnDef::new(Users::Password).text().unique_key())
                     .col(ColumnDef::new(Users::Domain).text().not_null())


### PR DESCRIPTION
This invariant is now covered by the unique index over the username and domain. Done in preparation for #179 