### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -183,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -485,8 +485,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "autometrics"
-version = "0.3.3"
-source = "git+https://github.com/autometrics-dev/autometrics-rs.git?rev=49cce6b481e2d6ff2d1d49eedef8c9bc60e13319#49cce6b481e2d6ff2d1d49eedef8c9bc60e13319"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73a1afb092b1338927ad3a05d3c5f15bded11f2553f2cdc74f62fe2de723f625"
 dependencies = [
  "autometrics-macros",
  "metrics",
@@ -494,8 +495,9 @@ dependencies = [
 
 [[package]]
 name = "autometrics-macros"
-version = "0.3.3"
-source = "git+https://github.com/autometrics-dev/autometrics-rs.git?rev=49cce6b481e2d6ff2d1d49eedef8c9bc60e13319#49cce6b481e2d6ff2d1d49eedef8c9bc60e13319"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671556627235f00378badcea4c05a91d395201aa0a126ded473811fef2f31a22"
 dependencies = [
  "percent-encoding",
  "proc-macro2",
@@ -621,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88573bcfbe1dcfd54d4912846df028b42d6255cbf9ce07be216b1bbfd11fc4b9"
+checksum = "ae23b9fe7a07d0919000116c4c5c0578303fbce6fc8d32efca1f7759d4c20faf"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -633,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a63d4f1c04b3abb7603001e4513f19617427bf27ca185b2ac663a1e342d39e"
+checksum = "a6367acbd6849b8c7c659e166955531274ae147bf83ab4312885991f6b6706cb"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -654,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f52352bae50d3337d5d6151b695d31a8c10ebea113eca5bead531f8301b067"
+checksum = "5230d25d244a51339273b8870f0f77874cd4449fb4f8f629b21188ae10cfc0ba"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -678,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168f08f8439c8b317b578a695e514c5cd7b869e73849a2d6b71ced4de6ce193d"
+checksum = "22d2a2bcc16e5c4d949ffd2b851da852b9bbed4bb364ed4ae371b42137ca06d9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -689,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03bcc02d7ed9649d855c8ce4a735e9848d7b8f7568aad0504c158e3baa955df8"
+checksum = "b60e2133beb9fe6ffe0b70deca57aaeff0a35ad24a9c6fab2fd3b4f45b99fdb5"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-types",
@@ -712,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da88b3a860f65505996c29192d800f1aeb9480440f56d63aad33a3c12045017a"
+checksum = "3a4d94f556c86a0dd916a5d7c39747157ea8cb909ca469703e20fee33e448b67"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -728,18 +730,18 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b0c1e87d75cac889dca2a7f5ba280da2cde8122448e7fec1d614194dfa00c70"
+checksum = "5ce3d6e6ebb00b2cce379f079ad5ec508f9bcc3a9510d9b9c1840ed1d6f8af39"
 dependencies = [
  "aws-smithy-types",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0afc731fd1417d791f9145a1e0c30e23ae0beaab9b4814017708ead2fc20f1"
+checksum = "58db46fc1f4f26be01ebdb821751b4e2482cd43aa2b64a0348fb89762defaffa"
 dependencies = [
  "base64-simd",
  "itoa",
@@ -750,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-xml"
-version = "0.55.1"
+version = "0.55.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5398c1c25dfc6f8c282b1552a66aa807c9d6e15e1b3a84b94aa44e7859bec3"
+checksum = "fb557fe4995bd9ec87fb244bbb254666a971dc902a783e9da8b7711610e9664c"
 dependencies = [
  "xmlparser",
 ]
@@ -775,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.16"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113713495a32dd0ab52baf5c10044725aa3aec00b31beda84218e469029b72a3"
+checksum = "b70caf9f1b0c045f7da350636435b775a9733adf2df56e8aa2a29210fbc335d4"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -1108,12 +1110,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "eef2b3ded6a26dfaec672a742c93c8cf6b689220324da509ec5caa20de55dc83"
 dependencies = [
  "bitflags",
- "clap_derive 3.2.18",
+ "clap_derive 3.2.24",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -1146,9 +1148,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "d756c5824fc5c0c1ee8e36000f576968dbcb2081def956c83fad6f40acd46f96"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -1592,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b14af2045fa69ed2b7a48934bebb842d0f33e73e96e78766ecb14bb5347a11"
+checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
 dependencies = [
  "const-oid 0.9.2",
  "zeroize",
@@ -2316,11 +2318,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2941,9 +2943,9 @@ checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a558e3d911bc3c7bfc8c78bc580b404d6e51c1cefbf656e176a94b49b0df40"
+checksum = "f4ac0e912c8ef1b735e92369695618dc5b1819f5a7bf3f167301a3ba1cea515e"
 dependencies = [
  "cc",
  "libc",
@@ -3273,9 +3275,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d88dad3f985ec267a3fcb7a1726f5cb1a7e8cad8b646e70a84f967210df23da"
+checksum = "4e2894987a3459f3ffb755608bd82188f8ed00d0ae077f1edea29c068d639d98"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3554,9 +3556,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.86"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -3761,9 +3763,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3793,9 +3795,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be99c4c1d2fc2769b1d00239431d711d08f6efedcecb8b6e30707160aee99c15"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3803,9 +3805,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56094789873daa36164de2e822b3888c6ae4b4f9da555a1103587658c805b1e"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3816,9 +3818,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6733073c7cff3d8459fda0e42f13a047870242aed8b509fe98000928975f359e"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
 dependencies = [
  "once_cell",
  "pest",
@@ -3933,7 +3935,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.4",
+ "der 0.7.5",
  "spki 0.7.1",
 ]
 
@@ -4504,9 +4506,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.14"
+version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
+checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
 dependencies = [
  "bitflags",
  "errno",
@@ -4631,9 +4633,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d875e2fcd965320e50066028ac0b4877ff07edbb734a6ddfeff48a87dbab38"
+checksum = "fade86e8d41fd1a4721f84cb834f4ca2783f973cc30e6212b7fafc134f169214"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4657,12 +4659,12 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-cli"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ead9f7dac975f10447f17d08edbb2046daa087b5e0b50bbf8211f303459078c"
+checksum = "efbf34a2caf70c2e3be9bb1e674e9540f6dfd7c8f40f6f05daf3b9740e476005"
 dependencies = [
  "chrono",
- "clap 3.2.23",
+ "clap 3.2.24",
  "dotenvy",
  "regex",
  "sea-schema",
@@ -4673,9 +4675,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b593e9c0cdbb18cafd4da7b92e67a9c2d9892934f3a2d8bbac73d5ba4a98a1"
+checksum = "28936f26d62234ff0be16f80115dbdeb3237fe9c25cf18fbcd1e3b3592360f20"
 dependencies = [
  "bae",
  "heck 0.3.3",
@@ -4686,12 +4688,12 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-migration"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7a6123c1035b0530deb713820688f0234431ab6c1893b14dce493ade76af"
+checksum = "278d3adfd0832b6ffc17d3cfbc574d3695a5c1b38814e0bc8ac238d33f3d87cf"
 dependencies = [
  "async-trait",
- "clap 3.2.23",
+ "clap 3.2.24",
  "dotenvy",
  "futures",
  "sea-orm",
@@ -5107,7 +5109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
- "der 0.7.4",
+ "der 0.7.5",
 ]
 
 [[package]]
@@ -5531,9 +5533,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5545,7 +5547,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5560,9 +5562,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5592,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5616,9 +5618,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5762,11 +5764,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
 dependencies = [
- "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -5775,13 +5776,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1681920287,
-        "narHash": "sha256-+/d6XQQfhhXVfqfLROJoqj3TuG38CAeoT6jO1g9r1k0=",
+        "lastModified": 1682453498,
+        "narHash": "sha256-WoWiAd7KZt5Eh6n+qojcivaVpnXKqBsVgpixpV2L9CE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "645bc49f34fa8eff95479f0345ff57e55b53437e",
+        "rev": "c8018361fa1d1650ee8d4b96294783cf564e8a7f",
         "type": "github"
       },
       "original": {
@@ -81,11 +81,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1682043560,
-        "narHash": "sha256-ZsF4Yee9pQbvLtwSVGgYux+az4yFSLXrxPyGHm3ptJM=",
+        "lastModified": 1682475596,
+        "narHash": "sha256-hQS8kPq5mSIhLZTRlCt1LHMBJtrOkWiXtvtizaU1e1Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "48037a6f8faeee138ede96bf607bc95c9dab9aec",
+        "rev": "4d1bb70dd1231d0cd1d76deffe7bf0b6127185ea",
         "type": "github"
       },
       "original": {

--- a/kitsune-cli/Cargo.toml
+++ b/kitsune-cli/Cargo.toml
@@ -8,12 +8,12 @@ clap = { version = "4.2.4", features = ["derive"] }
 dotenvy = "0.15.7"
 envy = "0.4.2"
 kitsune-db = { version = "0.1.0", path = "../kitsune-db" }
-sea-orm = { version = "0.11.2", default-features = false, features = [
+sea-orm = { version = "0.11.3", default-features = false, features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
 ] }
 serde = { version = "1.0.160", features = ["derive"] }
 time = "0.3.20"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.28.0", features = ["full"] }
 tracing-subscriber = "0.3.17"
 uuid = { version = "1.3.1", features = ["v7"] }

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 derive_builder = "0.12.0"
 kitsune-type = { path = "../kitsune-type" }
 migration = { path = "migration" }
-sea-orm = { version = "0.11.2", default-features = false, features = [
+sea-orm = { version = "0.11.3", default-features = false, features = [
     "with-json",
     "with-time",
     "with-uuid",

--- a/kitsune-db/migration/Cargo.toml
+++ b/kitsune-db/migration/Cargo.toml
@@ -9,10 +9,10 @@ name = "migration"
 path = "src/lib.rs"
 
 [dependencies]
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.28.0", features = ["full"] }
 
 [dependencies.sea-orm-migration]
-version = "0.11.2"
+version = "0.11.3"
 features = [
   # Enable at least one `ASYNC_RUNTIME` and `DATABASE_DRIVER` feature if you want to run migration via CLI.
   # View the list of supported features at https://www.sea-ql.org/SeaORM/docs/install-and-config/database-and-async-runtime.

--- a/kitsune-http-client/Cargo.toml
+++ b/kitsune-http-client/Cargo.toml
@@ -29,4 +29,4 @@ tower-http = { version = "0.4.0", features = [
 ] }
 
 [dev-dependencies]
-tokio = { version = "1.27.0", features = ["macros", "rt"] }
+tokio = { version = "1.28.0", features = ["macros", "rt"] }

--- a/kitsune-http-signatures/Cargo.toml
+++ b/kitsune-http-signatures/Cargo.toml
@@ -11,9 +11,9 @@ rayon = "1.7.0"
 ring = { version = "0.16.20", features = ["std"] }
 time = { version = "0.3.20", features = ["formatting", "parsing"] }
 thiserror = "1.0.40"
-tokio = { version = "1.27.0", features = ["sync"] }
+tokio = { version = "1.28.0", features = ["sync"] }
 
 [dev-dependencies]
 pem = "2.0.1"
 pkcs8 = { version = "0.10.2", features = ["alloc"] }
-tokio = { version = "1.27.0", features = ["macros", "rt"] }
+tokio = { version = "1.28.0", features = ["macros", "rt"] }

--- a/kitsune-messaging/Cargo.toml
+++ b/kitsune-messaging/Cargo.toml
@@ -15,6 +15,6 @@ redis = { version = "0.23.0", features = [
 ] }
 serde = "1.0.160"
 serde_json = "1.0.96"
-tokio = { version = "1.27.0", features = ["macros", "rt", "sync"] }
-tokio-stream = { version = "0.1.12", features = ["sync"] }
-tracing = "0.1.37"
+tokio = { version = "1.28.0", features = ["macros", "rt", "sync"] }
+tokio-stream = { version = "0.1.14", features = ["sync"] }
+tracing = "0.1.38"

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-autometrics = { git = "https://github.com/autometrics-dev/autometrics-rs.git", rev = "49cce6b481e2d6ff2d1d49eedef8c9bc60e13319", default-features = false, features = [
+autometrics = { version = "0.4.0", default-features = false, features = [
     "metrics",
 ] }
 dotenvy = "0.15.7"
@@ -16,16 +16,16 @@ metrics = "0.21.0"
 metrics-exporter-prometheus = "0.12.0"
 metrics-tracing-context = "0.14.0"
 metrics-util = "0.15.0"
-mimalloc = "0.1.36"
+mimalloc = "0.1.37"
 prost = "0.11.9"
 serde = { version = "1.0.160", features = ["derive"] }
 tantivy = "0.19.2"
 time = "0.3.20"
-tokio = { version = "1.27.0", features = ["full"] }
+tokio = { version = "1.28.0", features = ["full"] }
 tonic = "0.9.2"
 tonic-health = "0.9.2"
 tower-http = { version = "0.4.0", features = ["add-extension", "trace"] }
-tracing = "0.1.37"
+tracing = "0.1.38"
 tracing-subscriber = "0.3.17"
 
 [features]

--- a/kitsune-storage/Cargo.toml
+++ b/kitsune-storage/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1.68"
 aws-sdk-s3 = "0.26.0"
-aws-smithy-http = "0.55.1"
+aws-smithy-http = "0.55.2"
 bytes = "1.4.0"
 enum_dispatch = "0.3.11"
 futures-util = "0.3.28"
@@ -14,12 +14,12 @@ http = "0.2.9"
 http-body = "0.4.5"
 pin-project-lite = "0.2.9"
 sync_wrapper = "0.1.2"
-tokio = { version = "1.27.0", features = ["fs", "io-util"] }
-tokio-util = { version = "0.7.7", features = ["io"] }
+tokio = { version = "1.28.0", features = ["fs", "io-util"] }
+tokio-util = { version = "0.7.8", features = ["io"] }
 
 [dev-dependencies]
 aws-credential-types = { version = "0.55.1", features = [
     "hardcoded-credentials",
 ] }
 tempfile = "3.5.0"
-tokio = { version = "1.27.0", features = ["macros", "rt"] }
+tokio = { version = "1.28.0", features = ["macros", "rt"] }

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -25,14 +25,14 @@ async-graphql-axum = "5.0.7"
 async-recursion = "1.0.4"
 async-stream = "0.3.5"
 async-trait = "0.1.68"
-autometrics = { git = "https://github.com/autometrics-dev/autometrics-rs.git", rev = "49cce6b481e2d6ff2d1d49eedef8c9bc60e13319", default-features = false, features = [
+autometrics = { version = "0.4.0", default-features = false, features = [
     "metrics",
 ] }
 aws-credential-types = { version = "0.55.1", features = [
     "hardcoded-credentials",
 ] }
 aws-sdk-s3 = "0.26.0"
-axum = { version = "0.6.16", features = ["headers", "macros", "multipart"] }
+axum = { version = "0.6.17", features = ["headers", "macros", "multipart"] }
 axum-extra = { version = "0.7.4", features = ["query"] }
 axum-prometheus = { git = "https://github.com/Ptrskay3/axum-prometheus.git", rev = "b62b65dd3a0c932233bcc6aa755d0f37c2a645da" }
 base64 = "0.21.0"
@@ -63,7 +63,7 @@ metrics = "0.21.0"
 metrics-exporter-prometheus = "0.12.0"
 metrics-tracing-context = "0.14.0"
 metrics-util = "0.15.0"
-mimalloc = "0.1.36"
+mimalloc = "0.1.37"
 mime = "0.3.17"
 mime_guess = "2.0.4"
 once_cell = "1.17.1"
@@ -78,7 +78,7 @@ rand = "0.8.5"
 rayon = "1.7.0"
 redis = "0.23.0"
 rsa = "0.8.2"
-sea-orm = { version = "0.11.2", default-features = false, features = [
+sea-orm = { version = "0.11.3", default-features = false, features = [
     "runtime-tokio-rustls",
     "sqlx-postgres",
     "sqlx-sqlite",
@@ -94,11 +94,11 @@ strum = { version = "0.24.1", features = ["derive"] }
 tempfile = "3.5.0"
 thiserror = "1.0.40"
 time = "0.3.20"
-tokio = { version = "1.27.0", features = ["full"] }
-tokio-util = { version = "0.7.7", features = ["compat"] }
+tokio = { version = "1.28.0", features = ["full"] }
+tokio-util = { version = "0.7.8", features = ["compat"] }
 tonic = "0.9.2"
 tower-http = { version = "0.4.0", features = ["cors", "fs", "trace"] }
-tracing = "0.1.37"
+tracing = "0.1.38"
 tracing-subscriber = "0.3.17"
 typed-builder = "0.14.0"
 url = "2.3.1"

--- a/post-process/Cargo.toml
+++ b/post-process/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 [dependencies]
 futures-util = "0.3.28"
-pest = "2.5.7"
-pest_derive = "2.5.7"
+pest = "2.6.0"
+pest_derive = "2.6.0"
 
 [dev-dependencies]
 insta = { version = "1.29.0", features = ["glob"] }
 pretty_assertions = "1.3.0"
-tokio = { version = "1.27.0", features = ["macros", "rt"] }
+tokio = { version = "1.28.0", features = ["macros", "rt"] }


### PR DESCRIPTION
Most noteworthy, removes the dependency on the Git version of `autometrics` since the version bump of `metrics` has been published as `v0.4`