### PR TITLE
Enable CPU features

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,6 @@
 [build]
 rustdocflags = ["--document-private-items"]
-rustflags = ["--cfg", "uuid_unstable"]
+rustflags = ["--cfg", "uuid_unstable", "-C", "target-feature=+aes"]
 
 [registries.crates-io]
 protocol = "sparse"

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
           sqlite
           zlib
         ];
-        cargoConfig = builtins.fromTOML (builtins.readFile ./.cargo/config.toml);
+        cargoConfig = builtins.fromTOML (builtins.readFile ./.cargo/config.toml);  # TODO: Set the target CPU conditionally
         cargoToml = builtins.fromTOML (builtins.readFile ./kitsune/Cargo.toml);
         basePackage = {
           inherit (cargoToml.package) version;


### PR DESCRIPTION
This PR enables the `aes` CPU feature. We still need to find a way to conditionally set the `target_cpu` flag in the Nix build step, to enable CPU specific optimisations 