### PR TITLE
Disable HTTP/2

### DIFF
--- a/kitsune-http-client/src/lib.rs
+++ b/kitsune-http-client/src/lib.rs
@@ -321,6 +321,7 @@ impl Default for Client {
 }
 
 /// HTTP response
+#[derive(Debug)]
 pub struct Response {
     inner: HyperResponse<BoxBody<Bytes, BoxError>>,
 }

--- a/kitsune-http-client/src/lib.rs
+++ b/kitsune-http-client/src/lib.rs
@@ -163,7 +163,7 @@ impl ClientBuilder {
             .with_native_roots()
             .https_or_http()
             .enable_http1()
-            .enable_http2()
+            //.enable_http2() TODO: Find out why HTTP/2 causes a "400 Bad Request" with some servers.
             .build();
 
         let client: HyperClient<HttpsConnector<HttpConnector>, Body> =

--- a/kitsune-http-client/tests/basic.rs
+++ b/kitsune-http-client/tests/basic.rs
@@ -5,7 +5,7 @@ use kitsune_http_client::Client;
 async fn basic_request() {
     let client = Client::builder().build();
     let req = Request::builder()
-        .uri("https://rust-lang.org")
+        .uri("https://www.rust-lang.org")
         .body(Body::empty())
         .unwrap();
     let response = client.execute(req).await.unwrap();

--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -56,8 +56,8 @@ pub struct Fetcher {
     #[builder(default =
         Client::builder()
             .default_header(
-                "Accept",
-                HeaderValue::from_static("application/activity+json"),
+                "accept",
+                HeaderValue::from_static("application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""),
             )
             .unwrap()
             .user_agent(USER_AGENT)


### PR DESCRIPTION
With some servers, our HTTP client will get a "400 Bad Request" in response with HTTP/2 enabled.  
Not yet entirely sure why, but to mitigate this for now disabling HTTP/2 should work. 

Issue tracked in #225