### PR TITLE
Small database-level optimisations

### DIFF
--- a/kitsune-db/migrations/2023-05-19-192931_initial_tables/down.sql
+++ b/kitsune-db/migrations/2023-05-19-192931_initial_tables/down.sql
@@ -1,3 +1,6 @@
+DROP INDEX "idx-jobs-updated_at" ON jobs (updated_at);
+DROP INDEX "idx-jobs-run_at" ON jobs (run_at);
+DROP INDEX "idx-jobs-state" ON jobs (state);
 DROP INDEX "idx-posts-visibility";
 DROP INDEX "idx-posts-reposted_post_id";
 DROP INDEX "idx-posts-in_reply_to_id";

--- a/kitsune-db/migrations/2023-05-19-192931_initial_tables/up.sql
+++ b/kitsune-db/migrations/2023-05-19-192931_initial_tables/up.sql
@@ -137,6 +137,10 @@ CREATE TABLE jobs (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+CREATE INDEX "idx-jobs-state" ON jobs (state);
+CREATE INDEX "idx-jobs-run_at" ON jobs (run_at);
+CREATE INDEX "idx-jobs-updated_at" ON jobs (updated_at);
+
 SELECT diesel_manage_updated_at('accounts');
 SELECT diesel_manage_updated_at('accounts_follows');
 SELECT diesel_manage_updated_at('posts');

--- a/kitsune/src/http/graphql/types/account.rs
+++ b/kitsune/src/http/graphql/types/account.rs
@@ -65,7 +65,7 @@ impl Account {
 
     pub async fn posts(&self, ctx: &Context<'_>) -> Result<Vec<super::Post>> {
         let account_service = &ctx.state().service.account;
-        let get_posts = GetPosts::builder().account_id(self.id).build();
+        let get_posts = GetPosts::builder().account_id(self.id).limit(40).build();
         let posts = account_service
             .get_posts(get_posts)
             .await?

--- a/kitsune/src/http/handler/mastodon/api/v1/accounts/statuses.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/accounts/statuses.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{Path, Query, State},
     Json,
 };
-use futures_util::{FutureExt, StreamExt, TryStreamExt};
+use futures_util::{FutureExt, TryStreamExt};
 use kitsune_type::mastodon::Status;
 use serde::Deserialize;
 use std::cmp::min;
@@ -56,13 +56,12 @@ pub async fn get(
         .fetching_account_id(fetching_account_id)
         .max_id(query.max_id)
         .min_id(query.min_id)
+        .limit(min(query.limit, MAX_LIMIT))
         .build();
-    let limit = min(query.limit, MAX_LIMIT);
 
     let statuses: Vec<Status> = account
         .get_posts(get_posts)
         .await?
-        .take(limit)
         .and_then(|post| {
             if let Some(AuthExtractor(ref user_data)) = user_data {
                 mastodon_mapper

--- a/kitsune/src/http/handler/mastodon/api/v1/timelines/home.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/timelines/home.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{Query, State},
     Json,
 };
-use futures_util::{StreamExt, TryStreamExt};
+use futures_util::TryStreamExt;
 use kitsune_type::mastodon::Status;
 use serde::Deserialize;
 use std::cmp::min;
@@ -50,13 +50,12 @@ pub async fn get(
         .fetching_account_id(user_data.account.id)
         .max_id(query.max_id)
         .min_id(query.min_id)
+        .limit(min(query.limit, MAX_LIMIT))
         .build();
-    let limit = min(query.limit, MAX_LIMIT);
 
     let statuses: Vec<Status> = timeline
         .get_home(get_home)
         .await?
-        .take(limit)
         .and_then(|post| mastodon_mapper.map((&user_data.account, post)))
         .try_collect()
         .await?;

--- a/kitsune/src/http/handler/mastodon/api/v1/timelines/public.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/timelines/public.rs
@@ -8,7 +8,7 @@ use axum::{
     extract::{Query, State},
     Json,
 };
-use futures_util::{FutureExt, StreamExt, TryStreamExt};
+use futures_util::{FutureExt, TryStreamExt};
 use kitsune_type::mastodon::Status;
 use serde::Deserialize;
 use std::cmp::min;
@@ -52,13 +52,12 @@ pub async fn get(
         .only_remote(query.remote)
         .max_id(query.max_id)
         .min_id(query.min_id)
+        .limit(min(query.limit, MAX_LIMIT))
         .build();
-    let limit = min(query.limit, MAX_LIMIT);
 
     let statuses: Vec<Status> = timeline
         .get_public(get_public)
         .await?
-        .take(limit)
         .and_then(|post| {
             if let Some(AuthExtractor(ref user_data)) = user_data {
                 mastodon_mapper

--- a/kitsune/src/http/handler/users/mod.rs
+++ b/kitsune/src/http/handler/users/mod.rs
@@ -51,6 +51,7 @@ async fn get_html(
         .account_id(account.id)
         .max_id(query.max_id)
         .min_id(query.min_id)
+        .limit(40)
         .build();
 
     let posts = account_service

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -57,6 +57,7 @@ pub async fn get(
             .account_id(account.id)
             .max_id(query.max_id)
             .min_id(query.min_id)
+            .limit(ACTIVITIES_PER_PAGE)
             .build();
 
         let posts: Vec<Post> = state
@@ -64,7 +65,6 @@ pub async fn get(
             .account
             .get_posts(get_posts)
             .await?
-            .take(ACTIVITIES_PER_PAGE)
             .try_collect()
             .await?;
 

--- a/kitsune/src/job/mod.rs
+++ b/kitsune/src/job/mod.rs
@@ -132,7 +132,7 @@ async fn get_jobs(db_conn: &PgPool, num_jobs: usize) -> Result<Vec<DbJob>> {
                         )),
                     )
                     .limit(num_jobs as i64)
-                    .order(jobs::created_at.asc())
+                    .order(jobs::id.asc())
                     .for_update()
                     .load(tx)
                     .await?;

--- a/kitsune/src/service/account.rs
+++ b/kitsune/src/service/account.rs
@@ -66,6 +66,9 @@ pub struct GetPosts {
     #[builder(default)]
     fetching_account_id: Option<Uuid>,
 
+    /// Limit of returned posts
+    limit: usize,
+
     /// Smallest ID
     ///
     /// Used for pagination
@@ -246,7 +249,8 @@ impl AccountService {
             .filter(posts::account_id.eq(get_posts.account_id))
             .add_post_permission_check(permission_check)
             .select(Post::as_select())
-            .order(posts::created_at.desc())
+            .order(posts::id.desc())
+            .limit(get_posts.limit as i64)
             .into_boxed();
 
         if let Some(min_id) = get_posts.min_id {

--- a/kitsune/src/service/timeline.rs
+++ b/kitsune/src/service/timeline.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 #[derive(Clone, TypedBuilder)]
 pub struct GetHome {
     fetching_account_id: Uuid,
+    limit: usize,
 
     #[builder(default)]
     max_id: Option<Uuid>,
@@ -24,6 +25,8 @@ pub struct GetHome {
 
 #[derive(Clone, TypedBuilder)]
 pub struct GetPublic {
+    limit: usize,
+
     #[builder(default)]
     max_id: Option<Uuid>,
 
@@ -79,7 +82,8 @@ impl TimelineService {
                             .select(posts_mentions::post_id),
                     )),
             )
-            .order(posts::created_at.desc())
+            .order(posts::id.desc())
+            .limit(get_home.limit as i64)
             .select(Post::as_select())
             .into_boxed();
 
@@ -111,7 +115,8 @@ impl TimelineService {
 
         let mut query = posts::table
             .add_post_permission_check(permission_check)
-            .order(posts::created_at.desc())
+            .order(posts::id.desc())
+            .limit(get_public.limit as i64)
             .select(Post::as_select())
             .into_boxed();
 


### PR DESCRIPTION
- Additional indices on the job table
- Limit via the SQL query instead of `.take` on streams
- Order by the k-sortable IDs instead of by the timestamp