### PR TITLE
Query pipelining

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,8 +1590,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_full_text_search"
-version = "2.0.0"
-source = "git+https://github.com/aumetra/diesel_full_text_search?rev=875494d575950b6e047f456d820dc2f25c058611#875494d575950b6e047f456d820dc2f25c058611"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3975708a44577929dd7d921e5a4c1f95eef7c6a22d3e236d7d92fa108b535fdd"
 dependencies = [
  "diesel",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,3 @@ members = [
     "kitsune-type",
     "post-process",
 ]
-
-[patch.crates-io]
-diesel_full_text_search = { git = "https://github.com/aumetra/diesel_full_text_search", rev = "875494d575950b6e047f456d820dc2f25c058611" }

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 derive_builder = "0.12.0"
 diesel = { version = "2.1.0", features = ["serde_json", "time", "uuid"] }
 diesel-async = { version = "0.3.0", features = ["deadpool", "postgres"] }
-diesel_full_text_search = "2.0.0"
+diesel_full_text_search = { version = "2.1.0", default-features = false }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "323d6a1af2b819abed72db15a4546cdc38d8e286", features = [
     "postgres",
 ] }

--- a/kitsune-db/src/model/job.rs
+++ b/kitsune-db/src/model/job.rs
@@ -27,7 +27,7 @@ pub struct Job {
 
 #[derive(AsChangeset)]
 #[diesel(table_name = jobs)]
-pub struct UpdateJob {
+pub struct UpdateFailedJob {
     pub fail_count: i32,
     pub state: JobState,
     pub run_at: OffsetDateTime,

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -45,7 +45,7 @@ deadpool-redis = "0.12.0"
 derive_builder = "0.12.0"
 diesel = "2.1.0"
 diesel-async = "0.3.0"
-diesel_full_text_search = "2.0.0"
+diesel_full_text_search = { version = "2.1.0", default-features = false }
 enum_dispatch = "0.3.11"
 futures-util = "0.3.28"
 globset = { version = "0.4.10", features = ["simd-accel"] }

--- a/kitsune/src/http/page.rs
+++ b/kitsune/src/http/page.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{Error, Result},
     state::Zustand,
-    util::assert_future_send,
+    try_join,
 };
 use askama::Template;
 use diesel::{BelongingToDsl, QueryDsl, SelectableHelper};
@@ -39,21 +39,17 @@ impl PostComponent {
     pub async fn prepare(state: &Zustand, post: Post) -> Result<Self> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let author_fut = assert_future_send(
-            accounts::table
-                .find(post.account_id)
-                .select(Account::as_select())
-                .get_result::<Account>(&mut db_conn),
-        );
+        let author_fut = accounts::table
+            .find(post.account_id)
+            .select(Account::as_select())
+            .get_result::<Account>(&mut db_conn);
 
-        let attachments_stream_fut = assert_future_send(
-            PostMediaAttachment::belonging_to(&post)
-                .inner_join(media_attachments::table)
-                .select(DbMediaAttachment::as_select())
-                .load_stream::<DbMediaAttachment>(&mut db_conn),
-        );
+        let attachments_stream_fut = PostMediaAttachment::belonging_to(&post)
+            .inner_join(media_attachments::table)
+            .select(DbMediaAttachment::as_select())
+            .load_stream::<DbMediaAttachment>(&mut db_conn);
 
-        let (author, attachments_stream) = tokio::try_join!(author_fut, attachments_stream_fut)?;
+        let (author, attachments_stream) = try_join!(author_fut, attachments_stream_fut)?;
 
         let attachments = attachments_stream
             .map_err(Error::from)

--- a/kitsune/src/http/page.rs
+++ b/kitsune/src/http/page.rs
@@ -1,5 +1,8 @@
-use crate::error::{Error, Result};
-use crate::state::Zustand;
+use crate::{
+    error::{Error, Result},
+    state::Zustand,
+    util::assert_future_send,
+};
 use askama::Template;
 use diesel::{BelongingToDsl, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
@@ -36,17 +39,21 @@ impl PostComponent {
     pub async fn prepare(state: &Zustand, post: Post) -> Result<Self> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let author = accounts::table
-            .find(post.account_id)
-            .select(Account::as_select())
-            .get_result::<Account>(&mut db_conn)
-            .await?;
+        let author_fut = assert_future_send(
+            accounts::table
+                .find(post.account_id)
+                .select(Account::as_select())
+                .get_result::<Account>(&mut db_conn),
+        );
 
-        let attachments_stream = PostMediaAttachment::belonging_to(&post)
-            .inner_join(media_attachments::table)
-            .select(DbMediaAttachment::as_select())
-            .load_stream::<DbMediaAttachment>(&mut db_conn)
-            .await?;
+        let attachments_stream_fut = assert_future_send(
+            PostMediaAttachment::belonging_to(&post)
+                .inner_join(media_attachments::table)
+                .select(DbMediaAttachment::as_select())
+                .load_stream::<DbMediaAttachment>(&mut db_conn),
+        );
+
+        let (author, attachments_stream) = tokio::try_join!(author_fut, attachments_stream_fut)?;
 
         let attachments = attachments_stream
             .map_err(Error::from)

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::Result,
     job::{JobContext, Runnable},
+    util::assert_future_send,
 };
 use async_trait::async_trait;
 use diesel::{
@@ -35,18 +36,23 @@ impl Runnable for DeliverAccept {
             return Ok(());
         };
 
-        let follower_inbox_url = accounts::table
-            .find(follow.follower_id)
-            .select(accounts::inbox_url.assume_not_null())
-            .get_result::<String>(&mut db_conn)
-            .await?;
+        let follower_inbox_url_fut = assert_future_send(
+            accounts::table
+                .find(follow.follower_id)
+                .select(accounts::inbox_url.assume_not_null())
+                .get_result::<String>(&mut db_conn),
+        );
 
-        let (followed_account, followed_user) = accounts::table
-            .find(follow.account_id)
-            .inner_join(users::table.on(accounts::id.eq(users::account_id)))
-            .select((Account::as_select(), User::as_select()))
-            .get_result::<(Account, User)>(&mut db_conn)
-            .await?;
+        let followed_info_fut = assert_future_send(
+            accounts::table
+                .find(follow.account_id)
+                .inner_join(users::table.on(accounts::id.eq(users::account_id)))
+                .select((Account::as_select(), User::as_select()))
+                .get_result::<(Account, User)>(&mut db_conn),
+        );
+
+        let (follower_inbox_url, (followed_account, followed_user)) =
+            tokio::try_join!(follower_inbox_url_fut, followed_info_fut)?;
 
         let followed_account_url = ctx.state.service.url.user_url(followed_account.id);
 

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::Result,
     job::{JobContext, Runnable},
-    util::assert_future_send,
+    try_join,
 };
 use async_trait::async_trait;
 use diesel::{
@@ -36,23 +36,19 @@ impl Runnable for DeliverAccept {
             return Ok(());
         };
 
-        let follower_inbox_url_fut = assert_future_send(
-            accounts::table
-                .find(follow.follower_id)
-                .select(accounts::inbox_url.assume_not_null())
-                .get_result::<String>(&mut db_conn),
-        );
+        let follower_inbox_url_fut = accounts::table
+            .find(follow.follower_id)
+            .select(accounts::inbox_url.assume_not_null())
+            .get_result::<String>(&mut db_conn);
 
-        let followed_info_fut = assert_future_send(
-            accounts::table
-                .find(follow.account_id)
-                .inner_join(users::table.on(accounts::id.eq(users::account_id)))
-                .select((Account::as_select(), User::as_select()))
-                .get_result::<(Account, User)>(&mut db_conn),
-        );
+        let followed_info_fut = accounts::table
+            .find(follow.account_id)
+            .inner_join(users::table.on(accounts::id.eq(users::account_id)))
+            .select((Account::as_select(), User::as_select()))
+            .get_result::<(Account, User)>(&mut db_conn);
 
         let (follower_inbox_url, (followed_account, followed_user)) =
-            tokio::try_join!(follower_inbox_url_fut, followed_info_fut)?;
+            try_join!(follower_inbox_url_fut, followed_info_fut)?;
 
         let followed_account_url = ctx.state.service.url.user_url(followed_account.id);
 

--- a/kitsune/src/job/deliver/favourite.rs
+++ b/kitsune/src/job/deliver/favourite.rs
@@ -2,6 +2,7 @@ use crate::{
     error::Result,
     job::{JobContext, Runnable},
     mapping::IntoActivity,
+    util::assert_future_send,
 };
 use async_trait::async_trait;
 use diesel::{QueryDsl, SelectableHelper};
@@ -28,19 +29,23 @@ impl Runnable for DeliverFavourite {
             .get_result::<Favourite>(&mut db_conn)
             .await?;
 
-        let (account, user) = accounts::table
-            .find(favourite.account_id)
-            .inner_join(users::table)
-            .select((Account::as_select(), User::as_select()))
-            .get_result(&mut db_conn)
-            .await?;
+        let account_user_fut = assert_future_send(
+            accounts::table
+                .find(favourite.account_id)
+                .inner_join(users::table)
+                .select((Account::as_select(), User::as_select()))
+                .get_result(&mut db_conn),
+        );
 
-        let inbox_url = posts::table
-            .find(favourite.post_id)
-            .inner_join(accounts::table)
-            .select(accounts::inbox_url)
-            .get_result::<Option<String>>(&mut db_conn)
-            .await?;
+        let inbox_url_fut = assert_future_send(
+            posts::table
+                .find(favourite.post_id)
+                .inner_join(accounts::table)
+                .select(accounts::inbox_url)
+                .get_result::<Option<String>>(&mut db_conn),
+        );
+
+        let ((account, user), inbox_url) = tokio::try_join!(account_user_fut, inbox_url_fut)?;
 
         if let Some(ref inbox_url) = inbox_url {
             let activity = favourite.into_activity(ctx.state).await?;

--- a/kitsune/src/job/deliver/favourite.rs
+++ b/kitsune/src/job/deliver/favourite.rs
@@ -2,7 +2,7 @@ use crate::{
     error::Result,
     job::{JobContext, Runnable},
     mapping::IntoActivity,
-    util::assert_future_send,
+    try_join,
 };
 use async_trait::async_trait;
 use diesel::{QueryDsl, SelectableHelper};
@@ -29,23 +29,19 @@ impl Runnable for DeliverFavourite {
             .get_result::<Favourite>(&mut db_conn)
             .await?;
 
-        let account_user_fut = assert_future_send(
-            accounts::table
-                .find(favourite.account_id)
-                .inner_join(users::table)
-                .select((Account::as_select(), User::as_select()))
-                .get_result(&mut db_conn),
-        );
+        let account_user_fut = accounts::table
+            .find(favourite.account_id)
+            .inner_join(users::table)
+            .select((Account::as_select(), User::as_select()))
+            .get_result(&mut db_conn);
 
-        let inbox_url_fut = assert_future_send(
-            posts::table
-                .find(favourite.post_id)
-                .inner_join(accounts::table)
-                .select(accounts::inbox_url)
-                .get_result::<Option<String>>(&mut db_conn),
-        );
+        let inbox_url_fut = posts::table
+            .find(favourite.post_id)
+            .inner_join(accounts::table)
+            .select(accounts::inbox_url)
+            .get_result::<Option<String>>(&mut db_conn);
 
-        let ((account, user), inbox_url) = tokio::try_join!(account_user_fut, inbox_url_fut)?;
+        let ((account, user), inbox_url) = try_join!(account_user_fut, inbox_url_fut)?;
 
         if let Some(ref inbox_url) = inbox_url {
             let activity = favourite.into_activity(ctx.state).await?;

--- a/kitsune/src/job/deliver/follow.rs
+++ b/kitsune/src/job/deliver/follow.rs
@@ -2,6 +2,7 @@ use crate::{
     error::Result,
     job::{JobContext, Runnable},
     mapping::IntoActivity,
+    util::assert_future_send,
 };
 use async_trait::async_trait;
 use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
@@ -32,18 +33,23 @@ impl Runnable for DeliverFollow {
             return Ok(());
         };
 
-        let (follower, follower_user) = accounts::table
-            .find(follow.follower_id)
-            .inner_join(users::table)
-            .select((Account::as_select(), User::as_select()))
-            .get_result::<(Account, User)>(&mut db_conn)
-            .await?;
+        let follower_info_fut = assert_future_send(
+            accounts::table
+                .find(follow.follower_id)
+                .inner_join(users::table)
+                .select((Account::as_select(), User::as_select()))
+                .get_result::<(Account, User)>(&mut db_conn),
+        );
 
-        let followed_inbox = accounts::table
-            .find(follow.account_id)
-            .select(accounts::inbox_url)
-            .get_result::<Option<String>>(&mut db_conn)
-            .await?;
+        let followed_inbox_fut = assert_future_send(
+            accounts::table
+                .find(follow.account_id)
+                .select(accounts::inbox_url)
+                .get_result::<Option<String>>(&mut db_conn),
+        );
+
+        let ((follower, follower_user), followed_inbox) =
+            tokio::try_join!(follower_info_fut, followed_inbox_fut)?;
 
         if let Some(followed_inbox) = followed_inbox {
             let follow_activity = follow.into_activity(ctx.state).await?;

--- a/kitsune/src/job/deliver/unfavourite.rs
+++ b/kitsune/src/job/deliver/unfavourite.rs
@@ -2,6 +2,7 @@ use crate::{
     error::Result,
     job::{JobContext, Runnable},
     mapping::IntoActivity,
+    util::assert_future_send,
 };
 use async_trait::async_trait;
 use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
@@ -32,19 +33,23 @@ impl Runnable for DeliverUnfavourite {
             return Ok(());
         };
 
-        let (account, user) = accounts::table
-            .find(favourite.account_id)
-            .inner_join(users::table)
-            .select((Account::as_select(), User::as_select()))
-            .get_result(&mut db_conn)
-            .await?;
+        let account_user_fut = assert_future_send(
+            accounts::table
+                .find(favourite.account_id)
+                .inner_join(users::table)
+                .select((Account::as_select(), User::as_select()))
+                .get_result(&mut db_conn),
+        );
 
-        let inbox_url = posts::table
-            .find(favourite.post_id)
-            .inner_join(accounts::table)
-            .select(accounts::inbox_url)
-            .get_result::<Option<String>>(&mut db_conn)
-            .await?;
+        let inbox_url_fut = assert_future_send(
+            posts::table
+                .find(favourite.post_id)
+                .inner_join(accounts::table)
+                .select(accounts::inbox_url)
+                .get_result::<Option<String>>(&mut db_conn),
+        );
+
+        let ((account, user), inbox_url) = tokio::try_join!(account_user_fut, inbox_url_fut)?;
 
         let favourite_id = favourite.id;
         if let Some(ref inbox_url) = inbox_url {

--- a/kitsune/src/job/deliver/unfollow.rs
+++ b/kitsune/src/job/deliver/unfollow.rs
@@ -2,6 +2,7 @@ use crate::{
     error::Result,
     job::{JobContext, Runnable},
     mapping::IntoActivity,
+    util::assert_future_send,
 };
 use async_trait::async_trait;
 use diesel::{OptionalExtension, QueryDsl, SelectableHelper};
@@ -31,20 +32,28 @@ impl Runnable for DeliverUnfollow {
             return Ok(());
         };
 
-        let (follower, follower_user) = accounts::table
-            .find(follow.follower_id)
-            .inner_join(users::table)
-            .select((Account::as_select(), User::as_select()))
-            .get_result::<(Account, User)>(&mut db_conn)
-            .await?;
+        let follower_info_fut = assert_future_send(
+            accounts::table
+                .find(follow.follower_id)
+                .inner_join(users::table)
+                .select((Account::as_select(), User::as_select()))
+                .get_result::<(Account, User)>(&mut db_conn),
+        );
 
-        let followed_account_inbox_url = accounts::table
-            .find(follow.account_id)
-            .select(accounts::inbox_url)
-            .get_result::<Option<String>>(&mut db_conn)
-            .await?;
+        let followed_account_inbox_url_fut = assert_future_send(
+            accounts::table
+                .find(follow.account_id)
+                .select(accounts::inbox_url)
+                .get_result::<Option<String>>(&mut db_conn),
+        );
 
-        diesel::delete(&follow).execute(&mut db_conn).await?;
+        let delete_fut = diesel::delete(&follow).execute(&mut db_conn);
+
+        let ((follower, follower_user), followed_account_inbox_url, _delete_result) = tokio::try_join!(
+            follower_info_fut,
+            followed_account_inbox_url_fut,
+            delete_fut
+        )?;
 
         if let Some(ref followed_account_inbox_url) = followed_account_inbox_url {
             let follow_activity = follow.into_negate_activity(ctx.state).await?;

--- a/kitsune/src/job/mod.rs
+++ b/kitsune/src/job/mod.rs
@@ -17,7 +17,7 @@ use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl
 use enum_dispatch::enum_dispatch;
 use futures_util::{stream::FuturesUnordered, TryStreamExt};
 use kitsune_db::{
-    model::job::{Job as DbJob, JobState, UpdateJob},
+    model::job::{Job as DbJob, JobState, UpdateFailedJob},
     schema::jobs,
     PgPool,
 };
@@ -93,7 +93,7 @@ async fn execute_one(db_job: DbJob, state: Zustand, deliverer: Deliverer) -> Res
             let backoff_duration = time::Duration::seconds(job.backoff(fail_count as u32) as i64);
 
             diesel::update(&db_job)
-                .set(UpdateJob {
+                .set(UpdateFailedJob {
                     fail_count,
                     state: JobState::Failed,
                     run_at: OffsetDateTime::now_utc() + backoff_duration,

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{ApiError, Error, Result},
     state::Zustand,
-    util::BaseToCc,
+    util::{assert_future_send, BaseToCc},
 };
 use async_trait::async_trait;
 use diesel::{BelongingToDsl, QueryDsl, SelectableHelper};
@@ -71,32 +71,36 @@ impl IntoObject for Post {
         }
 
         let mut db_conn = state.db_conn.get().await?;
-        let account_fut = accounts::table
-            .find(self.account_id)
-            .select(Account::as_select())
-            .get_result(&mut db_conn)
-            .boxed();
+        let account_fut = assert_future_send(
+            accounts::table
+                .find(self.account_id)
+                .select(Account::as_select())
+                .get_result(&mut db_conn),
+        );
 
-        let in_reply_to_fut = OptionFuture::from(self.in_reply_to_id.map(|in_reply_to_id| {
-            posts::table
-                .find(in_reply_to_id)
-                .select(posts::url)
-                .get_result(&mut db_conn)
-        }))
-        .map(Option::transpose)
-        .boxed();
+        let in_reply_to_fut = assert_future_send(
+            OptionFuture::from(self.in_reply_to_id.map(|in_reply_to_id| {
+                posts::table
+                    .find(in_reply_to_id)
+                    .select(posts::url)
+                    .get_result(&mut db_conn)
+            }))
+            .map(Option::transpose),
+        );
 
-        let mentions_fut = Mention::belonging_to(&self)
-            .inner_join(accounts::table)
-            .select((Mention::as_select(), Account::as_select()))
-            .load::<(Mention, Account)>(&mut db_conn)
-            .boxed();
+        let mentions_fut = assert_future_send(
+            Mention::belonging_to(&self)
+                .inner_join(accounts::table)
+                .select((Mention::as_select(), Account::as_select()))
+                .load::<(Mention, Account)>(&mut db_conn),
+        );
 
-        let attachment_stream_fut = PostMediaAttachment::belonging_to(&self)
-            .inner_join(media_attachments::table)
-            .select(DbMediaAttachment::as_select())
-            .load_stream::<DbMediaAttachment>(&mut db_conn)
-            .boxed();
+        let attachment_stream_fut = assert_future_send(
+            PostMediaAttachment::belonging_to(&self)
+                .inner_join(media_attachments::table)
+                .select(DbMediaAttachment::as_select())
+                .load_stream::<DbMediaAttachment>(&mut db_conn),
+        );
 
         let (account, in_reply_to, mentions, attachment_stream) = tokio::try_join!(
             account_fut,
@@ -159,25 +163,27 @@ impl IntoObject for Account {
     async fn into_object(self, state: &Zustand) -> Result<Self::Output> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let icon_fut = OptionFuture::from(self.avatar_id.map(|avatar_id| {
-            media_attachments::table
-                .find(avatar_id)
-                .get_result::<DbMediaAttachment>(&mut db_conn)
-                .map_err(Error::from)
-                .and_then(|media_attachment| media_attachment.into_object(state))
-        }))
-        .map(Option::transpose)
-        .boxed();
+        let icon_fut = assert_future_send(
+            OptionFuture::from(self.avatar_id.map(|avatar_id| {
+                media_attachments::table
+                    .find(avatar_id)
+                    .get_result::<DbMediaAttachment>(&mut db_conn)
+                    .map_err(Error::from)
+                    .and_then(|media_attachment| media_attachment.into_object(state))
+            }))
+            .map(Option::transpose),
+        );
 
-        let image_fut = OptionFuture::from(self.header_id.map(|header_id| {
-            media_attachments::table
-                .find(header_id)
-                .get_result::<DbMediaAttachment>(&mut db_conn)
-                .map_err(Error::from)
-                .and_then(|media_attachment| media_attachment.into_object(state))
-        }))
-        .map(Option::transpose)
-        .boxed();
+        let image_fut = assert_future_send(
+            OptionFuture::from(self.header_id.map(|header_id| {
+                media_attachments::table
+                    .find(header_id)
+                    .get_result::<DbMediaAttachment>(&mut db_conn)
+                    .map_err(Error::from)
+                    .and_then(|media_attachment| media_attachment.into_object(state))
+            }))
+            .map(Option::transpose),
+        );
 
         let (icon, image) = tokio::try_join!(icon_fut, image_fut)?;
 

--- a/kitsune/src/mapping/mastodon/sealed.rs
+++ b/kitsune/src/mapping/mastodon/sealed.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{Error, Result},
     service::{attachment::AttachmentService, url::UrlService},
-    util::assert_future_send,
+    try_join,
 };
 use async_trait::async_trait;
 use diesel::{
@@ -65,29 +65,23 @@ impl IntoMastodon for DbAccount {
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let statuses_count_fut = assert_future_send(
-            posts::table
-                .filter(posts::account_id.eq(self.id))
-                .count()
-                .get_result::<i64>(&mut db_conn),
-        );
+        let statuses_count_fut = posts::table
+            .filter(posts::account_id.eq(self.id))
+            .count()
+            .get_result::<i64>(&mut db_conn);
 
-        let followers_count_fut = assert_future_send(
-            accounts_follows::table
-                .filter(accounts_follows::account_id.eq(self.id))
-                .count()
-                .get_result::<i64>(&mut db_conn),
-        );
+        let followers_count_fut = accounts_follows::table
+            .filter(accounts_follows::account_id.eq(self.id))
+            .count()
+            .get_result::<i64>(&mut db_conn);
 
-        let following_count_fut = assert_future_send(
-            accounts_follows::table
-                .filter(accounts_follows::follower_id.eq(self.id))
-                .count()
-                .get_result::<i64>(&mut db_conn),
-        );
+        let following_count_fut = accounts_follows::table
+            .filter(accounts_follows::follower_id.eq(self.id))
+            .count()
+            .get_result::<i64>(&mut db_conn);
 
         let (statuses_count, followers_count, following_count) =
-            tokio::try_join!(statuses_count_fut, followers_count_fut, following_count_fut)?;
+            try_join!(statuses_count_fut, followers_count_fut, following_count_fut)?;
 
         let mut acct = self.username.clone();
         if !self.local {
@@ -152,36 +146,32 @@ impl IntoMastodon for (&DbAccount, &DbAccount) {
         let mut db_conn = state.db_conn.get().await?;
 
         let (requestor, target) = self;
-        let following_requested_fut = assert_future_send(
-            accounts_follows::table
-                .filter(
-                    accounts_follows::account_id
-                        .eq(target.id)
-                        .and(accounts_follows::follower_id.eq(requestor.id)),
-                )
-                .get_result::<Follow>(&mut db_conn)
-                .map(OptionalExtension::optional)
-                .map_ok(|optional_follow| {
-                    optional_follow.map_or((false, false), |follow| {
-                        (follow.approved_at.is_some(), follow.approved_at.is_none())
-                    })
-                }),
-        );
+        let following_requested_fut = accounts_follows::table
+            .filter(
+                accounts_follows::account_id
+                    .eq(target.id)
+                    .and(accounts_follows::follower_id.eq(requestor.id)),
+            )
+            .get_result::<Follow>(&mut db_conn)
+            .map(OptionalExtension::optional)
+            .map_ok(|optional_follow| {
+                optional_follow.map_or((false, false), |follow| {
+                    (follow.approved_at.is_some(), follow.approved_at.is_none())
+                })
+            });
 
-        let followed_by_fut = assert_future_send(
-            accounts_follows::table
-                .filter(
-                    accounts_follows::account_id
-                        .eq(requestor.id)
-                        .and(accounts_follows::follower_id.eq(target.id)),
-                )
-                .count()
-                .get_result::<i64>(&mut db_conn)
-                .map_ok(|count| count != 0),
-        );
+        let followed_by_fut = accounts_follows::table
+            .filter(
+                accounts_follows::account_id
+                    .eq(requestor.id)
+                    .and(accounts_follows::follower_id.eq(target.id)),
+            )
+            .count()
+            .get_result::<i64>(&mut db_conn)
+            .map_ok(|count| count != 0);
 
         let ((following, requested), followed_by) =
-            tokio::try_join!(following_requested_fut, followed_by_fut)?;
+            try_join!(following_requested_fut, followed_by_fut)?;
 
         Ok(Relationship {
             id: target.id,
@@ -277,25 +267,21 @@ impl IntoMastodon for (&DbAccount, DbPost) {
 
         let (account, post) = self;
 
-        let favourited_fut = assert_future_send(
-            posts_favourites::table
-                .filter(posts_favourites::account_id.eq(account.id))
-                .filter(posts_favourites::post_id.eq(post.id))
-                .count()
-                .get_result::<i64>(&mut db_conn)
-                .map_ok(|count| count != 0),
-        );
+        let favourited_fut = posts_favourites::table
+            .filter(posts_favourites::account_id.eq(account.id))
+            .filter(posts_favourites::post_id.eq(post.id))
+            .count()
+            .get_result::<i64>(&mut db_conn)
+            .map_ok(|count| count != 0);
 
-        let reblogged_fut = assert_future_send(
-            posts::table
-                .filter(posts::account_id.eq(account.id))
-                .filter(posts::reposted_post_id.eq(post.id))
-                .count()
-                .get_result::<i64>(&mut db_conn)
-                .map_ok(|count| count != 0),
-        );
+        let reblogged_fut = posts::table
+            .filter(posts::account_id.eq(account.id))
+            .filter(posts::reposted_post_id.eq(post.id))
+            .count()
+            .get_result::<i64>(&mut db_conn)
+            .map_ok(|count| count != 0);
 
-        let (favourited, reblogged) = tokio::try_join!(favourited_fut, reblogged_fut)?;
+        let (favourited, reblogged) = try_join!(favourited_fut, reblogged_fut)?;
 
         let mut status = post.into_mastodon(state).await?;
         status.favourited = favourited;
@@ -316,51 +302,41 @@ impl IntoMastodon for DbPost {
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let account_fut = assert_future_send(
-            accounts::table
-                .find(self.account_id)
-                .select(DbAccount::as_select())
-                .get_result::<DbAccount>(&mut db_conn)
-                .map_err(Error::from)
-                .and_then(|db_account| db_account.into_mastodon(state)),
-        );
+        let account_fut = accounts::table
+            .find(self.account_id)
+            .select(DbAccount::as_select())
+            .get_result::<DbAccount>(&mut db_conn)
+            .map_err(Error::from)
+            .and_then(|db_account| db_account.into_mastodon(state));
 
-        let reblog_count_fut = assert_future_send(
-            posts::table
-                .filter(posts::reposted_post_id.eq(self.id))
-                .count()
-                .get_result::<i64>(&mut db_conn)
-                .map_err(Error::from),
-        );
+        let reblog_count_fut = posts::table
+            .filter(posts::reposted_post_id.eq(self.id))
+            .count()
+            .get_result::<i64>(&mut db_conn)
+            .map_err(Error::from);
 
-        let favourites_count_fut = assert_future_send(
-            DbFavourite::belonging_to(&self)
-                .count()
-                .get_result::<i64>(&mut db_conn)
-                .map_err(Error::from),
-        );
+        let favourites_count_fut = DbFavourite::belonging_to(&self)
+            .count()
+            .get_result::<i64>(&mut db_conn)
+            .map_err(Error::from);
 
-        let media_attachments_fut = assert_future_send(
-            DbPostMediaAttachment::belonging_to(&self)
-                .inner_join(media_attachments::table)
-                .select(DbMediaAttachment::as_select())
-                .load_stream::<DbMediaAttachment>(&mut db_conn)
-                .map_err(Error::from)
-                .and_then(|attachment_stream| {
-                    attachment_stream
-                        .map_err(Error::from)
-                        .and_then(|attachment| attachment.into_mastodon(state))
-                        .try_collect()
-                }),
-        );
+        let media_attachments_fut = DbPostMediaAttachment::belonging_to(&self)
+            .inner_join(media_attachments::table)
+            .select(DbMediaAttachment::as_select())
+            .load_stream::<DbMediaAttachment>(&mut db_conn)
+            .map_err(Error::from)
+            .and_then(|attachment_stream| {
+                attachment_stream
+                    .map_err(Error::from)
+                    .and_then(|attachment| attachment.into_mastodon(state))
+                    .try_collect()
+            });
 
-        let mentions_stream_fut = assert_future_send(
-            DbMention::belonging_to(&self)
-                .load_stream::<DbMention>(&mut db_conn)
-                .map_err(Error::from),
-        );
+        let mentions_stream_fut = DbMention::belonging_to(&self)
+            .load_stream::<DbMention>(&mut db_conn)
+            .map_err(Error::from);
 
-        let (account, reblog_count, favourites_count, media_attachments, mentions_stream) = tokio::try_join!(
+        let (account, reblog_count, favourites_count, media_attachments, mentions_stream) = try_join!(
             account_fut,
             reblog_count_fut,
             favourites_count_fut,

--- a/kitsune/src/mapping/mastodon/sealed.rs
+++ b/kitsune/src/mapping/mastodon/sealed.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{Error, Result},
     service::{attachment::AttachmentService, url::UrlService},
+    util::assert_future_send,
 };
 use async_trait::async_trait;
 use diesel::{
@@ -64,23 +65,26 @@ impl IntoMastodon for DbAccount {
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let statuses_count_fut = posts::table
-            .filter(posts::account_id.eq(self.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .boxed();
+        let statuses_count_fut = assert_future_send(
+            posts::table
+                .filter(posts::account_id.eq(self.id))
+                .count()
+                .get_result::<i64>(&mut db_conn),
+        );
 
-        let followers_count_fut = accounts_follows::table
-            .filter(accounts_follows::account_id.eq(self.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .boxed();
+        let followers_count_fut = assert_future_send(
+            accounts_follows::table
+                .filter(accounts_follows::account_id.eq(self.id))
+                .count()
+                .get_result::<i64>(&mut db_conn),
+        );
 
-        let following_count_fut = accounts_follows::table
-            .filter(accounts_follows::follower_id.eq(self.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .boxed();
+        let following_count_fut = assert_future_send(
+            accounts_follows::table
+                .filter(accounts_follows::follower_id.eq(self.id))
+                .count()
+                .get_result::<i64>(&mut db_conn),
+        );
 
         let (statuses_count, followers_count, following_count) =
             tokio::try_join!(statuses_count_fut, followers_count_fut, following_count_fut)?;
@@ -148,31 +152,33 @@ impl IntoMastodon for (&DbAccount, &DbAccount) {
         let mut db_conn = state.db_conn.get().await?;
 
         let (requestor, target) = self;
-        let following_requested_fut = accounts_follows::table
-            .filter(
-                accounts_follows::account_id
-                    .eq(target.id)
-                    .and(accounts_follows::follower_id.eq(requestor.id)),
-            )
-            .get_result::<Follow>(&mut db_conn)
-            .map(OptionalExtension::optional)
-            .map_ok(|optional_follow| {
-                optional_follow.map_or((false, false), |follow| {
-                    (follow.approved_at.is_some(), follow.approved_at.is_none())
-                })
-            })
-            .boxed();
+        let following_requested_fut = assert_future_send(
+            accounts_follows::table
+                .filter(
+                    accounts_follows::account_id
+                        .eq(target.id)
+                        .and(accounts_follows::follower_id.eq(requestor.id)),
+                )
+                .get_result::<Follow>(&mut db_conn)
+                .map(OptionalExtension::optional)
+                .map_ok(|optional_follow| {
+                    optional_follow.map_or((false, false), |follow| {
+                        (follow.approved_at.is_some(), follow.approved_at.is_none())
+                    })
+                }),
+        );
 
-        let followed_by_fut = accounts_follows::table
-            .filter(
-                accounts_follows::account_id
-                    .eq(requestor.id)
-                    .and(accounts_follows::follower_id.eq(target.id)),
-            )
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_ok(|count| count != 0)
-            .boxed();
+        let followed_by_fut = assert_future_send(
+            accounts_follows::table
+                .filter(
+                    accounts_follows::account_id
+                        .eq(requestor.id)
+                        .and(accounts_follows::follower_id.eq(target.id)),
+                )
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .map_ok(|count| count != 0),
+        );
 
         let ((following, requested), followed_by) =
             tokio::try_join!(following_requested_fut, followed_by_fut)?;
@@ -271,21 +277,23 @@ impl IntoMastodon for (&DbAccount, DbPost) {
 
         let (account, post) = self;
 
-        let favourited_fut = posts_favourites::table
-            .filter(posts_favourites::account_id.eq(account.id))
-            .filter(posts_favourites::post_id.eq(post.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_ok(|count| count != 0)
-            .boxed();
+        let favourited_fut = assert_future_send(
+            posts_favourites::table
+                .filter(posts_favourites::account_id.eq(account.id))
+                .filter(posts_favourites::post_id.eq(post.id))
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .map_ok(|count| count != 0),
+        );
 
-        let reblogged_fut = posts::table
-            .filter(posts::account_id.eq(account.id))
-            .filter(posts::reposted_post_id.eq(post.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_ok(|count| count != 0)
-            .boxed();
+        let reblogged_fut = assert_future_send(
+            posts::table
+                .filter(posts::account_id.eq(account.id))
+                .filter(posts::reposted_post_id.eq(post.id))
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .map_ok(|count| count != 0),
+        );
 
         let (favourited, reblogged) = tokio::try_join!(favourited_fut, reblogged_fut)?;
 
@@ -308,44 +316,49 @@ impl IntoMastodon for DbPost {
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
         let mut db_conn = state.db_conn.get().await?;
 
-        let account_fut = accounts::table
-            .find(self.account_id)
-            .select(DbAccount::as_select())
-            .get_result::<DbAccount>(&mut db_conn)
-            .map_err(Error::from)
-            .and_then(|db_account| db_account.into_mastodon(state))
-            .boxed();
+        let account_fut = assert_future_send(
+            accounts::table
+                .find(self.account_id)
+                .select(DbAccount::as_select())
+                .get_result::<DbAccount>(&mut db_conn)
+                .map_err(Error::from)
+                .and_then(|db_account| db_account.into_mastodon(state)),
+        );
 
-        let reblog_count_fut = posts::table
-            .filter(posts::reposted_post_id.eq(self.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_err(Error::from)
-            .boxed();
+        let reblog_count_fut = assert_future_send(
+            posts::table
+                .filter(posts::reposted_post_id.eq(self.id))
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .map_err(Error::from),
+        );
 
-        let favourites_count_fut = DbFavourite::belonging_to(&self)
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_err(Error::from)
-            .boxed();
+        let favourites_count_fut = assert_future_send(
+            DbFavourite::belonging_to(&self)
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .map_err(Error::from),
+        );
 
-        let media_attachments_fut = DbPostMediaAttachment::belonging_to(&self)
-            .inner_join(media_attachments::table)
-            .select(DbMediaAttachment::as_select())
-            .load_stream::<DbMediaAttachment>(&mut db_conn)
-            .map_err(Error::from)
-            .and_then(|attachment_stream| {
-                attachment_stream
-                    .map_err(Error::from)
-                    .and_then(|attachment| attachment.into_mastodon(state))
-                    .try_collect()
-            })
-            .boxed();
+        let media_attachments_fut = assert_future_send(
+            DbPostMediaAttachment::belonging_to(&self)
+                .inner_join(media_attachments::table)
+                .select(DbMediaAttachment::as_select())
+                .load_stream::<DbMediaAttachment>(&mut db_conn)
+                .map_err(Error::from)
+                .and_then(|attachment_stream| {
+                    attachment_stream
+                        .map_err(Error::from)
+                        .and_then(|attachment| attachment.into_mastodon(state))
+                        .try_collect()
+                }),
+        );
 
-        let mentions_stream_fut = DbMention::belonging_to(&self)
-            .load_stream::<DbMention>(&mut db_conn)
-            .map_err(Error::from)
-            .boxed();
+        let mentions_stream_fut = assert_future_send(
+            DbMention::belonging_to(&self)
+                .load_stream::<DbMention>(&mut db_conn)
+                .map_err(Error::from),
+        );
 
         let (account, reblog_count, favourites_count, media_attachments, mentions_stream) = tokio::try_join!(
             account_fut,

--- a/kitsune/src/service/account.rs
+++ b/kitsune/src/service/account.rs
@@ -12,6 +12,7 @@ use crate::{
         update::{DeliverUpdate, UpdateEntity},
     },
     sanitize::CleanHtmlExt,
+    util::assert_future_send,
     webfinger::Webfinger,
 };
 use bytes::Bytes;
@@ -20,7 +21,7 @@ use diesel::{
     BoolExpressionMethods, ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper,
 };
 use diesel_async::RunQueryDsl;
-use futures_util::{FutureExt, Stream, TryStreamExt};
+use futures_util::{Stream, TryStreamExt};
 use kitsune_db::{
     model::{
         account::{Account, UpdateAccount},
@@ -133,17 +134,19 @@ impl AccountService {
     pub async fn follow(&self, follow: Follow) -> Result<(Account, Account)> {
         let mut db_conn = self.db_conn.get().await?;
 
-        let account_fut = accounts::table
-            .find(follow.account_id)
-            .select(Account::as_select())
-            .get_result(&mut db_conn)
-            .boxed();
+        let account_fut = assert_future_send(
+            accounts::table
+                .find(follow.account_id)
+                .select(Account::as_select())
+                .get_result(&mut db_conn),
+        );
 
-        let follower_fut = accounts::table
-            .find(follow.follower_id)
-            .select(Account::as_select())
-            .get_result(&mut db_conn)
-            .boxed();
+        let follower_fut = assert_future_send(
+            accounts::table
+                .find(follow.follower_id)
+                .select(Account::as_select())
+                .get_result(&mut db_conn),
+        );
 
         let (account, follower) = tokio::try_join!(account_fut, follower_fut)?;
 
@@ -277,17 +280,19 @@ impl AccountService {
     pub async fn unfollow(&self, unfollow: Unfollow) -> Result<(Account, Account)> {
         let mut db_conn = self.db_conn.get().await?;
 
-        let account_fut = accounts::table
-            .find(unfollow.account_id)
-            .select(Account::as_select())
-            .get_result(&mut db_conn)
-            .boxed();
+        let account_fut = assert_future_send(
+            accounts::table
+                .find(unfollow.account_id)
+                .select(Account::as_select())
+                .get_result(&mut db_conn),
+        );
 
-        let follower_fut = accounts::table
-            .find(unfollow.follower_id)
-            .select(Account::as_select())
-            .get_result(&mut db_conn)
-            .boxed();
+        let follower_fut = assert_future_send(
+            accounts::table
+                .find(unfollow.follower_id)
+                .select(Account::as_select())
+                .get_result(&mut db_conn),
+        );
 
         let (account, follower) = tokio::try_join!(account_fut, follower_fut)?;
 

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -41,9 +41,9 @@ impl BaseToCc for Visibility {
 #[macro_export]
 macro_rules! try_join {
     ($($try_future:expr),+$(,)?) => {{
-        /// Hack around the bogus "higher-ranked lifetime" errors
+        /// Hack around the [bogus "higher-ranked lifetime" errors](https://github.com/rust-lang/rust/issues/102211)
         ///
-        /// Asserts `Send` bounds via its type signature and helps the compiler a little bit with it
+        /// Asserts `Send` bounds via its type signature and helps the compiler a little bit with proving the bound
         #[allow(clippy::inline_always)] // This is literally an empty function, only used for its type signature. 0 runtime implications.
         #[inline(always)]
         fn assert_future_send<O>(

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use crate::state::Zustand;
 use kitsune_db::model::{account::Account, oauth2::access_token::AccessToken, post::Visibility};
 use kitsune_type::ap::PUBLIC_IDENTIFIER;
@@ -34,4 +36,15 @@ impl BaseToCc for Visibility {
             Visibility::MentionOnly => (vec![], vec![]),
         }
     }
+}
+
+/// Hack around the bogus "higher-ranked lifetime" errors
+///
+/// Asserts `Send` bounds via its type signature and helps the compiler a little bit with it
+#[allow(clippy::inline_always)] // This is literally an empty function, only used for its type signature. 0 runtime implications.
+#[inline(always)]
+pub fn assert_future_send<O>(
+    fut: impl Future<Output = O> + Send,
+) -> impl Future<Output = O> + Send {
+    fut
 }

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -1,8 +1,7 @@
-use std::future::Future;
-
 use crate::state::Zustand;
 use kitsune_db::model::{account::Account, oauth2::access_token::AccessToken, post::Visibility};
 use kitsune_type::ap::PUBLIC_IDENTIFIER;
+use std::future::Future;
 use time::OffsetDateTime;
 
 #[must_use]

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -44,7 +44,6 @@ macro_rules! try_join {
         /// Hack around the [bogus "higher-ranked lifetime" errors](https://github.com/rust-lang/rust/issues/102211)
         ///
         /// Asserts `Send` bounds via its type signature and helps the compiler a little bit with proving the bound
-        #[allow(clippy::inline_always)] // This is literally an empty function, only used for its type signature. 0 runtime implications.
         #[inline(always)]
         fn assert_send<O>(
             fut: impl ::core::future::Future<Output = O> + Send,

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -46,14 +46,14 @@ macro_rules! try_join {
         /// Asserts `Send` bounds via its type signature and helps the compiler a little bit with proving the bound
         #[allow(clippy::inline_always)] // This is literally an empty function, only used for its type signature. 0 runtime implications.
         #[inline(always)]
-        fn assert_future_send<O>(
+        fn assert_send<O>(
             fut: impl ::core::future::Future<Output = O> + Send,
         ) -> impl ::core::future::Future<Output = O> + Send {
             fut
         }
 
         ::tokio::try_join!(
-            $( assert_future_send($try_future) ),+
+            $( assert_send($try_future) ),+
         )
     }};
 }


### PR DESCRIPTION
Closes #219 

~~Whether this gets merged is still open since it adds a bunch of boxing to get around the higher-ranked lifetime issue.  
There isn't really any other way to get around it since it's a compiler bug~~.

Update: After reading through the "Bogus higher-ranked lifetime error" issue, I attempted a trick to have a small no-op function with trait bounds to hint the `Send` bound to the compiler. That worked and we have now have a solution with 0 additional boxing.