### PR TITLE
Bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune"
-version = "0.0.1-pre.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "ammonia",
  "argon2",
@@ -3291,7 +3291,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-cli"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "clap",
  "diesel",
@@ -3309,7 +3309,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-db"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "derive_builder",
  "diesel",
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-http-client"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "derive_builder",
  "futures-core",
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-http-signatures"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "base64 0.21.2",
  "derive_builder",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-messaging"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "ahash 0.8.3",
  "async-trait",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-search"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "autometrics",
  "dotenvy",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-search-proto"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-storage"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune-type"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -4489,7 +4489,7 @@ checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "post-process"
-version = "0.1.0"
+version = "0.0.1-pre.1"
 dependencies = [
  "futures-util",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ members = [
     "kitsune-type",
     "post-process",
 ]
+
+[workspace.package]
+version = "0.0.1-pre.1"

--- a/kitsune-cli/Cargo.toml
+++ b/kitsune-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-cli"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 build = "build.rs"
 
@@ -10,7 +10,7 @@ diesel = "2.1.0"
 diesel-async = "0.3.0"
 dotenvy = "0.15.7"
 envy = "0.4.2"
-kitsune-db = { version = "0.1.0", path = "../kitsune-db" }
+kitsune-db = { path = "../kitsune-db" }
 serde = { version = "1.0.163", features = ["derive"] }
 time = "0.3.21"
 tokio = { version = "1.28.2", features = ["full"] }

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-db"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 build = "build.rs"
 
@@ -12,7 +12,7 @@ diesel_full_text_search = { version = "2.1.0", default-features = false }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "323d6a1af2b819abed72db15a4546cdc38d8e286", features = [
     "postgres",
 ] }
-kitsune-type = { version = "0.1.0", path = "../kitsune-type" }
+kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 serde = { version = "1.0.163", features = ["derive"] }

--- a/kitsune-http-client/Cargo.toml
+++ b/kitsune-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-http-client"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune-http-signatures/Cargo.toml
+++ b/kitsune-http-signatures/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-http-signatures"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune-messaging/Cargo.toml
+++ b/kitsune-messaging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-messaging"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-search"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune-search/proto/Cargo.toml
+++ b/kitsune-search/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-search-proto"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune-storage/Cargo.toml
+++ b/kitsune-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-storage"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune-type/Cargo.toml
+++ b/kitsune-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-type"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "kitsune"
-version = "0.0.1-pre.0"
+version.workspace = true
 edition = "2021"
 repository = "https://github.com/kitsune-soc/kitsune"
-homepage = "https://kitsune-soc.github.io"
+homepage = "https://joinkitsune.org"
 build = "build.rs"
 
 [dependencies]

--- a/post-process/Cargo.toml
+++ b/post-process/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "post-process"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Bump version of all packages to `v0.0.1-pre.1`. The version is also now stored centralised in the workspace manifest for easier bumps in the future.

Just bumping the version, not sure if I'm cutting a release today.