### PR TITLE
Fix URL parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "kitsune-type",
     "post-process",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.0.1-pre.1"

--- a/post-process/grammar/post.pest
+++ b/post-process/grammar/post.pest
@@ -69,7 +69,12 @@ link_content = {
 }
 
 link_postfix = _{
-    &(EOI | NEWLINE | WHITE_SPACE)
+    &(
+        EOI |
+        NEWLINE |
+        WHITE_SPACE |
+        "<" // Hack around the link parser not including HTML tags into links
+    )
 }
 
 link_schema = {

--- a/post-process/tests/input/mixed/mixed_content_2
+++ b/post-process/tests/input/mixed/mixed_content_2
@@ -1,0 +1,1 @@
+<p>hello world! check out my github: https://github.com/aumetra</p>

--- a/post-process/tests/snapshots/mixed__mixed_content@mixed_content_1.snap
+++ b/post-process/tests/snapshots/mixed__mixed_content@mixed_content_1.snap
@@ -1,0 +1,118 @@
+---
+source: post-process/tests/mixed.rs
+expression: "PostParser::parse(Rule::post, &post).unwrap()"
+input_file: post-process/tests/input/mixed/mixed_content_1
+---
+[
+    Pair {
+        rule: text,
+        span: Span {
+            str: "hey,",
+            start: 0,
+            end: 4,
+        },
+        inner: [],
+    },
+    Pair {
+        rule: mention,
+        span: Span {
+            str: " @真島",
+            start: 4,
+            end: 12,
+        },
+        inner: [
+            Pair {
+                rule: component_prefix,
+                span: Span {
+                    str: " ",
+                    start: 4,
+                    end: 5,
+                },
+                inner: [],
+            },
+            Pair {
+                rule: mention_username,
+                span: Span {
+                    str: "真島",
+                    start: 6,
+                    end: 12,
+                },
+                inner: [],
+            },
+        ],
+    },
+    Pair {
+        rule: text,
+        span: Span {
+            str: " looking good..",
+            start: 12,
+            end: 27,
+        },
+        inner: [],
+    },
+    Pair {
+        rule: hashtag,
+        span: Span {
+            str: " #龍が如く7",
+            start: 27,
+            end: 42,
+        },
+        inner: [
+            Pair {
+                rule: component_prefix,
+                span: Span {
+                    str: " ",
+                    start: 27,
+                    end: 28,
+                },
+                inner: [],
+            },
+            Pair {
+                rule: hashtag_content,
+                span: Span {
+                    str: "龍が如く7",
+                    start: 29,
+                    end: 42,
+                },
+                inner: [],
+            },
+        ],
+    },
+    Pair {
+        rule: text,
+        span: Span {
+            str: " ",
+            start: 42,
+            end: 43,
+        },
+        inner: [],
+    },
+    Pair {
+        rule: link,
+        span: Span {
+            str: "https://upload.wikimedia.org/wikipedia/en/3/3b/GoroMajimafive.jpg",
+            start: 43,
+            end: 108,
+        },
+        inner: [
+            Pair {
+                rule: link_schema,
+                span: Span {
+                    str: "https",
+                    start: 43,
+                    end: 48,
+                },
+                inner: [],
+            },
+            Pair {
+                rule: link_content,
+                span: Span {
+                    str: "upload.wikimedia.org/wikipedia/en/3/3b/GoroMajimafive.jpg",
+                    start: 51,
+                    end: 108,
+                },
+                inner: [],
+            },
+        ],
+    },
+]

--- a/post-process/tests/snapshots/mixed__mixed_content@mixed_content_2.snap
+++ b/post-process/tests/snapshots/mixed__mixed_content@mixed_content_2.snap
@@ -1,0 +1,53 @@
+---
+source: post-process/tests/mixed.rs
+expression: "PostParser::parse(Rule::post, &post).unwrap()"
+input_file: post-process/tests/input/mixed/mixed_content_2
+---
+[
+    Pair {
+        rule: text,
+        span: Span {
+            str: "<p>hello world! check out my github: ",
+            start: 0,
+            end: 37,
+        },
+        inner: [],
+    },
+    Pair {
+        rule: link,
+        span: Span {
+            str: "https://github.com/aumetra",
+            start: 37,
+            end: 63,
+        },
+        inner: [
+            Pair {
+                rule: link_schema,
+                span: Span {
+                    str: "https",
+                    start: 37,
+                    end: 42,
+                },
+                inner: [],
+            },
+            Pair {
+                rule: link_content,
+                span: Span {
+                    str: "github.com/aumetra",
+                    start: 45,
+                    end: 63,
+                },
+                inner: [],
+            },
+        ],
+    },
+    Pair {
+        rule: text,
+        span: Span {
+            str: "</p>",
+            start: 63,
+            end: 67,
+        },
+        inner: [],
+    },
+]


### PR DESCRIPTION
The URL parser had a bug where it considered HTML following a link (i.e. "https://example.com<\/p>") as part of the link.  
This PR fixes this my marking `<` as a link delimiter.