### PR TITLE
Ignore duplicate mentions

### DIFF
--- a/kitsune/src/activitypub/mod.rs
+++ b/kitsune/src/activitypub/mod.rs
@@ -50,6 +50,7 @@ async fn handle_mentions(
                 })
                 .collect::<Vec<NewMention<'_>>>(),
         )
+        .on_conflict_do_nothing()
         .execute(db_conn)
         .await?;
 


### PR DESCRIPTION
Currently the insertion into the database fails if a post has two duplicate mentions.  
This can happen when someone posts something like:

```
I really like @kitsune. Check out @kitsune 
```

Some implementations then send an object with the same mention object. This PR just ignores duplicate issues via a `ON CONFLICT NO NOTHING` clause