### PR TITLE
Small optimisations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-C debuginfo=0 --cfg uuid_unstable"
+  RUSTFLAGS: "-C debuginfo=0 -C target-cpu=native --cfg uuid_unstable"
 
 jobs:
   clippy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,9 +3354,9 @@ dependencies = [
 [[package]]
 name = "iso8601-timestamp"
 version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368d05885f276773b79b4578869a60ab91e880415d17fb2a8d193aea74188a29"
+source = "git+https://github.com/aumetra/iso8601-timestamp.git?rev=664bf4be14ba26c2a3ed46887f1bbaa434cf41a8#664bf4be14ba26c2a3ed46887f1bbaa434cf41a8"
 dependencies = [
+ "diesel",
  "generic-array",
  "serde",
  "time",
@@ -3546,13 +3546,13 @@ dependencies = [
  "diesel-async",
  "diesel_full_text_search",
  "diesel_migrations_async",
+ "iso8601-timestamp",
  "kitsune-type",
  "num-derive",
  "num-traits 0.2.15",
  "serde",
  "serde_json",
  "thiserror",
- "time",
  "tracing-log",
  "uuid",
 ]
@@ -3565,6 +3565,7 @@ dependencies = [
  "diesel-async",
  "embed-sdk",
  "http",
+ "iso8601-timestamp",
  "kitsune-db",
  "kitsune-http-client",
  "once_cell",
@@ -3572,7 +3573,6 @@ dependencies = [
  "serde_json",
  "smol_str",
  "thiserror",
- "time",
  "typed-builder",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3632,6 +3632,7 @@ name = "kitsune-search"
 version = "0.0.1-pre.1"
 dependencies = [
  "async-trait",
+ "bytes",
  "diesel",
  "diesel-async",
  "diesel_full_text_search",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,6 +3446,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "iso8601-timestamp",
  "kitsune-cache",
  "kitsune-db",
  "kitsune-embed",
@@ -3712,11 +3713,11 @@ dependencies = [
 name = "kitsune-type"
 version = "0.0.1-pre.1"
 dependencies = [
+ "iso8601-timestamp",
  "pretty_assertions",
  "serde",
  "serde_json",
  "smol_str",
- "time",
  "utoipa",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8868f09ff8cea88b079da74ae569d9b8c62a23c68c746240b704ee6f7525c89c"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "ascii_utils"
@@ -1003,7 +1003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
- "arrayvec 0.7.3",
+ "arrayvec 0.7.4",
  "constant_time_eq 0.2.6",
 ]
 
@@ -1339,9 +1339,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
 dependencies = [
  "libc",
 ]
@@ -2123,6 +2123,15 @@ checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits 0.2.15",
 ]
 
 [[package]]
@@ -2923,6 +2932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f985624e90f861184145c13b736873a0f83cdb998a292dbb0653598ab03aecbf"
+dependencies = [
+ "hashbrown 0.13.2",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,6 +3481,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "simd-json",
  "smol_str",
  "strum",
  "tempfile",
@@ -3492,7 +3512,7 @@ dependencies = [
  "enum_dispatch",
  "redis",
  "serde",
- "serde_json",
+ "simd-json",
  "thiserror",
  "tokio",
  "tracing",
@@ -3559,6 +3579,7 @@ dependencies = [
 name = "kitsune-http-client"
 version = "0.0.1-pre.1"
 dependencies = [
+ "bytes",
  "derive_builder",
  "futures-core",
  "headers",
@@ -3568,7 +3589,7 @@ dependencies = [
  "kitsune-http-signatures",
  "pin-project-lite",
  "serde",
- "serde_json",
+ "simd-json",
  "tokio",
  "tower",
  "tower-http",
@@ -3723,6 +3744,70 @@ name = "levenshtein_automata"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -4579,9 +4664,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+checksum = "16833386b02953ca926d19f64af613b9bf742c48dcd5e09b32fbfc9740bf84e2"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4611,9 +4696,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+checksum = "7763190f9406839f99e5197afee8c9e759969f7dbfa40ad3b8dbee8757b745b5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4621,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+checksum = "249061b22e99973da1f5f5f1410284419e283bb60b79255bf5f42a94b66a2e00"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4634,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.6.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+checksum = "457c310cfc9cf3f22bc58901cc7f0d3410ac5d6298e432a4f9a6138565cb6df6"
 dependencies = [
  "once_cell",
  "pest",
@@ -5932,9 +6017,9 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5997,6 +6082,26 @@ dependencies = [
  "digest",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-json"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d0815e7ff0f1f05e09d4b029f86d8a330f0ab15b35b28736f3758325f59e14"
+dependencies = [
+ "halfbrown",
+ "lexical-core",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
 name = "similar"
@@ -6182,9 +6287,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 dependencies = [
  "phf 0.10.1",
  "strum_macros",
@@ -6192,15 +6297,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.24.3"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+checksum = "fe9f3bd7d2e45dcc5e265fbb88d6513e4747d8ef9444cf01a533119bce28a157"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 1.0.109",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -7039,6 +7144,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "value-trait"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a5b6c8ceb01263b969cac48d4a6705134d490ded13d889e52c0cfc80c6945e"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7086,11 +7203,10 @@ dependencies = [
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -7392,9 +7508,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7685beb53fc20efc2605f32f5d51e9ba18b8ef237961d1760169d2290d3bee"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3428,7 +3438,7 @@ dependencies = [
  "axum-extra",
  "axum-flash",
  "axum-prometheus",
- "base64 0.21.2",
+ "base64-simd",
  "bytes",
  "chrono",
  "const-oid 0.10.0-pre",
@@ -3443,7 +3453,7 @@ dependencies = [
  "futures-util",
  "globset",
  "headers",
- "hex",
+ "hex-simd",
  "http",
  "hyper",
  "iso8601-timestamp",
@@ -3598,7 +3608,7 @@ dependencies = [
 name = "kitsune-http-signatures"
 version = "0.0.1-pre.1"
 dependencies = [
- "base64 0.21.2",
+ "base64-simd",
  "derive_builder",
  "http",
  "pem",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "kitsune-search",
  "kitsune-storage",
  "kitsune-type",
+ "kitsune-uuid",
  "metrics",
  "metrics-exporter-prometheus",
  "metrics-tracing-context",
@@ -3496,7 +3497,6 @@ dependencies = [
  "url",
  "utoipa",
  "utoipa-swagger-ui",
- "uuid",
  "vergen",
  "zxcvbn",
 ]
@@ -3528,11 +3528,11 @@ dependencies = [
  "dotenvy",
  "envy",
  "kitsune-db",
+ "kitsune-uuid",
  "serde",
  "time",
  "tokio",
  "tracing-subscriber",
- "uuid",
  "vergen",
 ]
 
@@ -3547,13 +3547,13 @@ dependencies = [
  "diesel_migrations_async",
  "iso8601-timestamp",
  "kitsune-type",
+ "kitsune-uuid",
  "num-derive",
  "num-traits 0.2.15",
  "serde",
  "simd-json",
  "thiserror",
  "tracing-log",
- "uuid",
 ]
 
 [[package]]
@@ -3639,13 +3639,13 @@ dependencies = [
  "futures-util",
  "kitsune-db",
  "kitsune-search-proto",
+ "kitsune-uuid",
  "meilisearch-sdk",
  "serde",
  "strum",
  "thiserror",
  "tonic",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -3713,20 +3713,22 @@ name = "kitsune-type"
 version = "0.0.1-pre.1"
 dependencies = [
  "iso8601-timestamp",
+ "kitsune-uuid",
  "pretty_assertions",
  "serde",
  "simd-json",
  "smol_str",
  "utoipa",
- "uuid",
 ]
 
 [[package]]
 name = "kitsune-uuid"
 version = "0.0.1-pre.1"
 dependencies = [
+ "async-graphql",
  "diesel",
  "serde",
+ "thiserror",
  "uuid",
  "uuid-simd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,7 +3479,6 @@ dependencies = [
  "rsa 0.9.2",
  "serde",
  "serde_dhall",
- "serde_json",
  "serial_test",
  "sha2",
  "simd-json",
@@ -3570,7 +3569,6 @@ dependencies = [
  "kitsune-http-client",
  "once_cell",
  "scraper",
- "serde_json",
  "smol_str",
  "thiserror",
  "typed-builder",
@@ -3622,7 +3620,7 @@ dependencies = [
  "pin-project-lite",
  "redis",
  "serde",
- "serde_json",
+ "simd-json",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3717,7 +3715,7 @@ dependencies = [
  "iso8601-timestamp",
  "pretty_assertions",
  "serde",
- "serde_json",
+ "simd-json",
  "smol_str",
  "utoipa",
  "uuid",
@@ -6882,9 +6880,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "8803eee176538f94ae9a14b55b2804eb7e1441f8210b1c31290b3bccdccff73b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3352,8 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "iso8601-timestamp"
-version = "0.2.10"
-source = "git+https://github.com/aumetra/iso8601-timestamp.git?rev=664bf4be14ba26c2a3ed46887f1bbaa434cf41a8#664bf4be14ba26c2a3ed46887f1bbaa434cf41a8"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd7663ae5b511b3d13c7d374dbe73b03da3da8e66b83950390173bc7c7325cc"
 dependencies = [
  "diesel",
  "generic-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3722,6 +3722,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune-uuid"
+version = "0.0.1-pre.1"
+dependencies = [
+ "diesel",
+ "serde",
+ "uuid",
+ "uuid-simd",
+]
+
+[[package]]
 name = "kstring"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7135,6 +7145,17 @@ dependencies = [
  "getrandom 0.2.10",
  "rand 0.8.5",
  "serde",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,7 +1730,6 @@ dependencies = [
  "byteorder",
  "diesel_derives",
  "itoa",
- "serde_json",
  "time",
  "uuid",
 ]
@@ -3551,7 +3550,7 @@ dependencies = [
  "num-derive",
  "num-traits 0.2.15",
  "serde",
- "serde_json",
+ "simd-json",
  "thiserror",
  "tracing-log",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 opt-level = 3
 
 [profile.release]
+codegen-units = 1
 lto = true
 strip = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,6 @@ resolver = "2"
 version = "0.0.1-pre.1"
 
 [patch.crates-io] # Patch to get client credential support for async
+iso8601-timestamp = { git = "https://github.com/aumetra/iso8601-timestamp.git", rev = "664bf4be14ba26c2a3ed46887f1bbaa434cf41a8" }
 oxide-auth = { git = "https://github.com/aumetra/oxide-auth.git", branch = "aumetra/add-error-impl" }
 oxide-auth-async = { git = "https://github.com/aumetra/oxide-auth.git", branch = "aumetra/add-error-impl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,5 @@ resolver = "2"
 version = "0.0.1-pre.1"
 
 [patch.crates-io] # Patch to get client credential support for async
-iso8601-timestamp = { git = "https://github.com/aumetra/iso8601-timestamp.git", rev = "664bf4be14ba26c2a3ed46887f1bbaa434cf41a8" }
 oxide-auth = { git = "https://github.com/aumetra/oxide-auth.git", branch = "aumetra/add-error-impl" }
 oxide-auth-async = { git = "https://github.com/aumetra/oxide-auth.git", branch = "aumetra/add-error-impl" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "kitsune-search-server/proto",
     "kitsune-storage",
     "kitsune-type",
+    "kitsune-uuid",
     "post-process",
 ]
 resolver = "2"

--- a/kitsune-cache/Cargo.toml
+++ b/kitsune-cache/Cargo.toml
@@ -11,7 +11,7 @@ derive_builder = "0.12.0"
 enum_dispatch = "0.3.11"
 redis = "0.23.0"
 serde = "1.0.164"
-serde_json = "1.0.96"
+simd-json = "0.10.3"
 thiserror = "1.0.40"
 tracing = "0.1.37"
 

--- a/kitsune-cache/src/error.rs
+++ b/kitsune-cache/src/error.rs
@@ -11,5 +11,5 @@ pub enum Error {
     Redis(#[from] RedisError),
 
     #[error(transparent)]
-    SerdeJson(#[from] serde_json::Error),
+    SimdJson(#[from] simd_json::Error),
 }

--- a/kitsune-cache/src/redis.rs
+++ b/kitsune-cache/src/redis.rs
@@ -76,7 +76,8 @@ where
 
         debug!(%key, "Fetching cache entry");
         if let Some(serialised) = conn.get::<_, Option<String>>(&key).await? {
-            let deserialised = serde_json::from_str(&serialised)?;
+            let mut serialised_bytes = serialised.into_bytes();
+            let deserialised = simd_json::from_slice(&mut serialised_bytes)?;
             Ok(Some(deserialised))
         } else {
             Ok(None)
@@ -87,7 +88,7 @@ where
     async fn set(&self, key: &K, value: &V) -> CacheResult<()> {
         let mut conn = self.redis_conn.get().await?;
         let key = self.compute_key(key);
-        let serialised = serde_json::to_string(value)?;
+        let serialised = simd_json::to_string(value)?;
 
         debug!(%key, ttl = ?self.ttl, "Setting cache entry");
         #[allow(clippy::cast_possible_truncation)]

--- a/kitsune-cli/Cargo.toml
+++ b/kitsune-cli/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.164", features = ["derive"] }
 time = "0.3.22"
 tokio = { version = "1.28.2", features = ["full"] }
 tracing-subscriber = "0.3.17"
-uuid = { version = "1.3.4", features = ["v7"] }
+uuid = { package = "kitsune-uuid", path = "../kitsune-uuid" }
 
 [build-dependencies]
 vergen = { version = "8.2.1", features = ["build", "git", "gitoxide"] }

--- a/kitsune-cli/src/main.rs
+++ b/kitsune-cli/src/main.rs
@@ -1,3 +1,7 @@
+#![forbid(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::module_name_repetitions, forbidden_lint_groups)]
+
 use self::{config::Configuration, role::RoleSubcommand};
 use clap::{Parser, Subcommand};
 use diesel::{ExpressionMethods, QueryDsl};
@@ -39,7 +43,7 @@ async fn clear_completed_jobs(db_conn: &mut AsyncPgConnection) -> Result<()> {
         .execute(db_conn)
         .await?;
 
-    println!("Deleted {} succeeded jobs from the database", delete_result);
+    println!("Deleted {delete_result} succeeded jobs from the database");
 
     Ok(())
 }

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -12,7 +12,7 @@ diesel_full_text_search = { version = "2.1.0", default-features = false }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "296db45f2b2120a496f7231537685fe5974c0829", features = [
     "postgres",
 ] }
-iso8601-timestamp = { version = "0.2.10", features = ["diesel-pg"] }
+iso8601-timestamp = { version = "0.2.11", features = ["diesel-pg"] }
 kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -6,18 +6,18 @@ build = "build.rs"
 
 [dependencies]
 derive_builder = "0.12.0"
-diesel = { version = "2.1.0", features = ["serde_json", "time", "uuid"] }
+diesel = { version = "2.1.0", features = ["serde_json", "uuid"] }
 diesel-async = { version = "0.3.1", features = ["deadpool", "postgres"] }
 diesel_full_text_search = { version = "2.1.0", default-features = false }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "296db45f2b2120a496f7231537685fe5974c0829", features = [
     "postgres",
 ] }
+iso8601-timestamp = { version = "0.2.10", features = ["diesel-pg"] }
 kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
 thiserror = "1.0.40"
-time = "0.3.22"
 tracing-log = "0.1.3"
 uuid = "1.3.4"

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -16,7 +16,7 @@ kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
+serde_json = "1.0.97"
 thiserror = "1.0.40"
 time = "0.3.22"
 tracing-log = "0.1.3"

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -6,7 +6,7 @@ build = "build.rs"
 
 [dependencies]
 derive_builder = "0.12.0"
-diesel = { version = "2.1.0", features = ["serde_json", "uuid"] }
+diesel = { version = "2.1.0", features = ["uuid"] }
 diesel-async = { version = "0.3.1", features = ["deadpool", "postgres"] }
 diesel_full_text_search = { version = "2.1.0", default-features = false }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "296db45f2b2120a496f7231537685fe5974c0829", features = [
@@ -17,7 +17,7 @@ kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.3.3"
 num-traits = "0.2.15"
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.97"
+simd-json = "0.10.3"
 thiserror = "1.0.40"
 tracing-log = "0.1.3"
 uuid = "1.3.4"

--- a/kitsune-db/Cargo.toml
+++ b/kitsune-db/Cargo.toml
@@ -20,4 +20,4 @@ serde = { version = "1.0.164", features = ["derive"] }
 simd-json = "0.10.3"
 thiserror = "1.0.40"
 tracing-log = "0.1.3"
-uuid = "1.3.4"
+uuid = { package = "kitsune-uuid", path = "../kitsune-uuid" }

--- a/kitsune-db/src/json.rs
+++ b/kitsune-db/src/json.rs
@@ -25,7 +25,7 @@ impl fmt::Display for JsonError {
 
 impl Error for JsonError {}
 
-#[derive(FromSqlRow, AsExpression, Serialize, Deserialize, Debug, Clone)]
+#[derive(AsExpression, Clone, Debug, Deserialize, FromSqlRow, Serialize)]
 #[diesel(sql_type = Jsonb)]
 #[serde(transparent)]
 pub struct Json<T>(pub T);
@@ -53,8 +53,7 @@ where
         if bytes[0] != 1 {
             return Err(JsonError("Unsupported JSONB encoding version").into());
         }
-
-        Ok(Self(serde_json::from_slice(&bytes[1..])?))
+        Ok(serde_json::from_slice(&bytes[1..])?)
     }
 }
 

--- a/kitsune-db/src/json.rs
+++ b/kitsune-db/src/json.rs
@@ -53,7 +53,7 @@ where
         if bytes[0] != 1 {
             return Err(JsonError("Unsupported JSONB encoding version").into());
         }
-        Ok(serde_json::from_slice(&bytes[1..])?)
+        Ok(simd_json::from_reader(&bytes[1..])?)
     }
 }
 
@@ -63,7 +63,7 @@ where
 {
     fn to_sql<'b>(&'b self, out: &mut serialize::Output<'b, '_, Pg>) -> serialize::Result {
         out.write_all(&[1])?;
-        serde_json::to_writer(out, self)
+        simd_json::to_writer(out, self)
             .map(|_| IsNull::No)
             .map_err(Into::into)
     }

--- a/kitsune-db/src/lib.rs
+++ b/kitsune-db/src/lib.rs
@@ -1,3 +1,12 @@
+#![forbid(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions,
+    forbidden_lint_groups
+)]
+
 use diesel_async::{
     pooled_connection::{deadpool::Pool, AsyncDieselConnectionManager},
     AsyncPgConnection,
@@ -13,6 +22,7 @@ pub mod function;
 pub mod json;
 pub mod model;
 pub mod post_permission_check;
+#[allow(clippy::wildcard_imports)]
 pub mod schema;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();

--- a/kitsune-db/src/model/account.rs
+++ b/kitsune-db/src/model/account.rs
@@ -7,11 +7,11 @@ use diesel::{
     sql_types::Integer,
     AsChangeset, AsExpression, FromSqlRow, Identifiable, Insertable, Queryable, Selectable,
 };
+use iso8601_timestamp::Timestamp;
 use kitsune_type::ap::actor::ActorType as ApActorType;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Identifiable, Serialize, Selectable, Queryable)]
@@ -35,8 +35,8 @@ pub struct Account {
     pub shared_inbox_url: Option<String>,
     pub public_key_id: String,
     pub public_key: String,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(AsChangeset)]
@@ -86,7 +86,7 @@ pub struct NewAccount<'a> {
     pub shared_inbox_url: Option<&'a str>,
     pub public_key_id: &'a str,
     pub public_key: &'a str,
-    pub created_at: Option<OffsetDateTime>,
+    pub created_at: Option<Timestamp>,
 }
 
 #[derive(

--- a/kitsune-db/src/model/favourite.rs
+++ b/kitsune-db/src/model/favourite.rs
@@ -1,8 +1,8 @@
 use super::{account::Account, post::Post};
 use crate::schema::posts_favourites;
 use diesel::{Associations, Identifiable, Insertable, Queryable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Associations, Clone, Deserialize, Identifiable, Serialize, Queryable)]
@@ -16,7 +16,7 @@ pub struct Favourite {
     pub account_id: Uuid,
     pub post_id: Uuid,
     pub url: String,
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]
@@ -26,5 +26,5 @@ pub struct NewFavourite {
     pub account_id: Uuid,
     pub post_id: Uuid,
     pub url: String,
-    pub created_at: Option<OffsetDateTime>,
+    pub created_at: Option<Timestamp>,
 }

--- a/kitsune-db/src/model/follower.rs
+++ b/kitsune-db/src/model/follower.rs
@@ -1,7 +1,7 @@
 use crate::schema::accounts_follows;
 use diesel::{Identifiable, Insertable, Queryable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Serialize, Identifiable, Queryable)]
@@ -10,10 +10,10 @@ pub struct Follow {
     pub id: Uuid,
     pub account_id: Uuid,
     pub follower_id: Uuid,
-    pub approved_at: Option<OffsetDateTime>,
+    pub approved_at: Option<Timestamp>,
     pub url: String,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]
@@ -22,7 +22,7 @@ pub struct NewFollow<'a> {
     pub id: Uuid,
     pub account_id: Uuid,
     pub follower_id: Uuid,
-    pub approved_at: Option<OffsetDateTime>,
+    pub approved_at: Option<Timestamp>,
     pub url: &'a str,
-    pub created_at: Option<OffsetDateTime>,
+    pub created_at: Option<Timestamp>,
 }

--- a/kitsune-db/src/model/job.rs
+++ b/kitsune-db/src/model/job.rs
@@ -7,10 +7,10 @@ use diesel::{
     sql_types::Integer,
     AsChangeset, AsExpression, FromSqlRow, Identifiable, Insertable, Queryable, Selectable,
 };
+use iso8601_timestamp::Timestamp;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Serialize, Identifiable, Queryable, Selectable)]
@@ -19,10 +19,10 @@ pub struct Job<T> {
     pub id: Uuid,
     pub state: JobState,
     pub context: Json<T>,
-    pub run_at: OffsetDateTime,
+    pub run_at: Timestamp,
     pub fail_count: i32,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(AsChangeset)]
@@ -30,7 +30,7 @@ pub struct Job<T> {
 pub struct UpdateFailedJob {
     pub fail_count: i32,
     pub state: JobState,
-    pub run_at: OffsetDateTime,
+    pub run_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]
@@ -39,7 +39,7 @@ pub struct NewJob<T> {
     pub id: Uuid,
     pub state: JobState,
     pub context: Json<T>,
-    pub run_at: OffsetDateTime,
+    pub run_at: Timestamp,
 }
 
 #[derive(

--- a/kitsune-db/src/model/job.rs
+++ b/kitsune-db/src/model/job.rs
@@ -1,24 +1,24 @@
-use crate::{error::EnumConversionError, schema::jobs};
+use crate::{error::EnumConversionError, json::Json, schema::jobs};
 use diesel::{
     backend::Backend,
     deserialize::{self, FromSql},
     pg::Pg,
     serialize::{self, Output, ToSql},
     sql_types::Integer,
-    AsChangeset, AsExpression, FromSqlRow, Identifiable, Insertable, Queryable,
+    AsChangeset, AsExpression, FromSqlRow, Identifiable, Insertable, Queryable, Selectable,
 };
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-#[derive(Clone, Deserialize, Serialize, Identifiable, Queryable)]
-pub struct Job {
+#[derive(Clone, Deserialize, Serialize, Identifiable, Queryable, Selectable)]
+#[diesel(table_name = jobs)]
+pub struct Job<T> {
     pub id: Uuid,
     pub state: JobState,
-    pub context: Value,
+    pub context: Json<T>,
     pub run_at: OffsetDateTime,
     pub fail_count: i32,
     pub created_at: OffsetDateTime,
@@ -35,10 +35,10 @@ pub struct UpdateFailedJob {
 
 #[derive(Clone, Insertable)]
 #[diesel(table_name = jobs)]
-pub struct NewJob {
+pub struct NewJob<T> {
     pub id: Uuid,
     pub state: JobState,
-    pub context: Value,
+    pub context: Json<T>,
     pub run_at: OffsetDateTime,
 }
 

--- a/kitsune-db/src/model/link_preview.rs
+++ b/kitsune-db/src/model/link_preview.rs
@@ -1,7 +1,7 @@
 use crate::{json::Json, schema::link_previews};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 
 #[derive(Clone, Deserialize, Serialize, Identifiable, Queryable, Selectable)]
 #[diesel(
@@ -11,9 +11,9 @@ use time::OffsetDateTime;
 pub struct LinkPreview<T> {
     pub url: String,
     pub embed_data: Json<T>,
-    pub expires_at: OffsetDateTime,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub expires_at: Timestamp,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]
@@ -21,12 +21,12 @@ pub struct LinkPreview<T> {
 pub struct NewLinkPreview<'a, T> {
     pub url: &'a str,
     pub embed_data: Json<T>,
-    pub expires_at: OffsetDateTime,
+    pub expires_at: Timestamp,
 }
 
 #[derive(AsChangeset, Clone)]
 #[diesel(table_name = link_previews)]
 pub struct ConflictLinkPreviewChangeset<T> {
     pub embed_data: Json<T>,
-    pub expires_at: OffsetDateTime,
+    pub expires_at: Timestamp,
 }

--- a/kitsune-db/src/model/media_attachment.rs
+++ b/kitsune-db/src/model/media_attachment.rs
@@ -1,8 +1,8 @@
 use super::{account::Account, post::Post};
 use crate::schema::{media_attachments, posts_media_attachments};
 use diesel::{AsChangeset, Associations, Identifiable, Insertable, Queryable, Selectable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Associations, Clone, Deserialize, Identifiable, Selectable, Serialize, Queryable)]
@@ -15,8 +15,8 @@ pub struct MediaAttachment {
     pub blurhash: Option<String>,
     pub file_path: Option<String>,
     pub remote_url: Option<String>,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(AsChangeset, Default)]

--- a/kitsune-db/src/model/oauth2/access_token.rs
+++ b/kitsune-db/src/model/oauth2/access_token.rs
@@ -1,8 +1,8 @@
 use super::{super::user::User, application::Application};
 use crate::schema::oauth2_access_tokens;
 use diesel::{Associations, Identifiable, Insertable, Queryable, Selectable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Associations, Clone, Deserialize, Identifiable, Selectable, Serialize, Queryable)]
@@ -17,8 +17,8 @@ pub struct AccessToken {
     pub user_id: Option<Uuid>,
     pub application_id: Option<Uuid>,
     pub scopes: String,
-    pub created_at: OffsetDateTime,
-    pub expires_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub expires_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]
@@ -28,5 +28,5 @@ pub struct NewAccessToken<'a> {
     pub user_id: Option<Uuid>,
     pub application_id: Option<Uuid>,
     pub scopes: &'a str,
-    pub expires_at: OffsetDateTime,
+    pub expires_at: Timestamp,
 }

--- a/kitsune-db/src/model/oauth2/application.rs
+++ b/kitsune-db/src/model/oauth2/application.rs
@@ -1,7 +1,7 @@
 use crate::schema::oauth2_applications;
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Clone, Deserialize, Identifiable, Selectable, Serialize, Queryable)]
@@ -13,8 +13,8 @@ pub struct Application {
     pub scopes: String,
     pub redirect_uri: String,
     pub website: Option<String>,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]

--- a/kitsune-db/src/model/oauth2/authorization_code.rs
+++ b/kitsune-db/src/model/oauth2/authorization_code.rs
@@ -1,8 +1,8 @@
 use super::{super::user::User, application::Application};
 use crate::schema::oauth2_authorization_codes;
 use diesel::{Associations, Identifiable, Insertable, Queryable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Associations, Clone, Deserialize, Identifiable, Serialize, Queryable)]
@@ -17,8 +17,8 @@ pub struct AuthorizationCode {
     pub application_id: Uuid,
     pub user_id: Uuid,
     pub scopes: String,
-    pub created_at: OffsetDateTime,
-    pub expires_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub expires_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]
@@ -28,5 +28,5 @@ pub struct NewAuthorizationCode<'a> {
     pub application_id: Uuid,
     pub user_id: Uuid,
     pub scopes: &'a str,
-    pub expires_at: OffsetDateTime,
+    pub expires_at: Timestamp,
 }

--- a/kitsune-db/src/model/oauth2/refresh_token.rs
+++ b/kitsune-db/src/model/oauth2/refresh_token.rs
@@ -1,8 +1,8 @@
 use super::{access_token::AccessToken, application::Application};
 use crate::schema::oauth2_refresh_tokens;
 use diesel::{Associations, Identifiable, Insertable, Queryable, Selectable};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Associations, Clone, Deserialize, Identifiable, Selectable, Serialize, Queryable)]
@@ -19,7 +19,7 @@ pub struct RefreshToken {
     pub token: String,
     pub access_token: String,
     pub application_id: Uuid,
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]

--- a/kitsune-db/src/model/post.rs
+++ b/kitsune-db/src/model/post.rs
@@ -9,6 +9,7 @@ use diesel::{
     AsChangeset, AsExpression, Associations, FromSqlRow, Identifiable, Insertable, Queryable,
     Selectable,
 };
+use iso8601_timestamp::Timestamp;
 use kitsune_type::{
     ap::{helper::CcTo, Privacy},
     mastodon::status::Visibility as MastodonVisibility,
@@ -16,7 +17,6 @@ use kitsune_type::{
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Associations, Clone, Deserialize, Identifiable, Queryable, Selectable, Serialize)]
@@ -33,8 +33,8 @@ pub struct Post {
     pub visibility: Visibility,
     pub is_local: bool,
     pub url: String,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(AsChangeset)]
@@ -58,7 +58,7 @@ pub struct NewPost<'a> {
     pub visibility: Visibility,
     pub is_local: bool,
     pub url: &'a str,
-    pub created_at: Option<OffsetDateTime>,
+    pub created_at: Option<Timestamp>,
 }
 
 #[derive(

--- a/kitsune-db/src/model/user.rs
+++ b/kitsune-db/src/model/user.rs
@@ -1,6 +1,6 @@
 use crate::schema::users;
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
-use time::OffsetDateTime;
+use iso8601_timestamp::Timestamp;
 use uuid::Uuid;
 
 #[derive(Clone, Identifiable, Selectable, Queryable)]
@@ -13,8 +13,8 @@ pub struct User {
     pub password: Option<String>,
     pub domain: String,
     pub private_key: String,
-    pub created_at: OffsetDateTime,
-    pub updated_at: OffsetDateTime,
+    pub created_at: Timestamp,
+    pub updated_at: Timestamp,
 }
 
 #[derive(Clone, Insertable)]

--- a/kitsune-db/src/model/user_role.rs
+++ b/kitsune-db/src/model/user_role.rs
@@ -8,10 +8,10 @@ use diesel::{
     sql_types::Integer,
     AsExpression, Associations, FromSqlRow, Identifiable, Insertable, Queryable,
 };
+use iso8601_timestamp::Timestamp;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(
@@ -63,7 +63,7 @@ pub struct UserRole {
     pub id: Uuid,
     pub user_id: Uuid,
     pub role: Role,
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
 }
 
 #[derive(Clone, Deserialize, Insertable, Serialize)]

--- a/kitsune-embed/Cargo.toml
+++ b/kitsune-embed/Cargo.toml
@@ -8,7 +8,7 @@ diesel = "2.1.0"
 diesel-async = "0.3.1"
 embed-sdk = { git = "https://github.com/Lantern-chat/embed-service.git", rev = "a2b73a9b24163f20202c9b09857c29137d98708b" }
 http = "0.2.9"
-iso8601-timestamp = "0.2.10"
+iso8601-timestamp = "0.2.11"
 kitsune-db = { path = "../kitsune-db" }
 kitsune-http-client = { path = "../kitsune-http-client" }
 once_cell = "1.18.0"

--- a/kitsune-embed/Cargo.toml
+++ b/kitsune-embed/Cargo.toml
@@ -8,6 +8,7 @@ diesel = "2.1.0"
 diesel-async = "0.3.1"
 embed-sdk = { git = "https://github.com/Lantern-chat/embed-service.git", rev = "a2b73a9b24163f20202c9b09857c29137d98708b" }
 http = "0.2.9"
+iso8601-timestamp = "0.2.10"
 kitsune-db = { path = "../kitsune-db" }
 kitsune-http-client = { path = "../kitsune-http-client" }
 once_cell = "1.18.0"
@@ -15,5 +16,4 @@ scraper = { version = "0.16.0", default-features = false }
 serde_json = "1.0.97"
 smol_str = "0.2.0"
 thiserror = "1.0.40"
-time = "0.3.22"
 typed-builder = "0.14.0"

--- a/kitsune-embed/Cargo.toml
+++ b/kitsune-embed/Cargo.toml
@@ -13,7 +13,6 @@ kitsune-db = { path = "../kitsune-db" }
 kitsune-http-client = { path = "../kitsune-http-client" }
 once_cell = "1.18.0"
 scraper = { version = "0.16.0", default-features = false }
-serde_json = "1.0.97"
 smol_str = "0.2.0"
 thiserror = "1.0.40"
 typed-builder = "0.14.0"

--- a/kitsune-embed/src/lib.rs
+++ b/kitsune-embed/src/lib.rs
@@ -2,6 +2,7 @@ use diesel::{OptionalExtension, QueryDsl};
 use diesel_async::{pooled_connection::deadpool, RunQueryDsl};
 use embed_sdk::EmbedWithExpire;
 use http::{Method, Request};
+use iso8601_timestamp::Timestamp;
 use kitsune_db::{
     json::Json,
     model::link_preview::{ConflictLinkPreviewChangeset, LinkPreview, NewLinkPreview},
@@ -12,7 +13,6 @@ use kitsune_http_client::Client as HttpClient;
 use once_cell::sync::Lazy;
 use scraper::{Html, Selector};
 use smol_str::SmolStr;
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 
 pub use embed_sdk;
@@ -77,7 +77,7 @@ impl Client {
                 .await
                 .optional()?
             {
-                if data.expires_at > OffsetDateTime::now_utc() {
+                if data.expires_at > Timestamp::now_utc() {
                     return Ok(data);
                 }
             }
@@ -97,13 +97,13 @@ impl Client {
             .values(NewLinkPreview {
                 url,
                 embed_data: Json(&embed_data),
-                expires_at: expires_at.assume_utc(),
+                expires_at,
             })
             .on_conflict(link_previews::url)
             .do_update()
             .set(ConflictLinkPreviewChangeset {
                 embed_data: Json(&embed_data),
-                expires_at: expires_at.assume_utc(),
+                expires_at,
             })
             .get_result(&mut db_conn)
             .await?;

--- a/kitsune-embed/src/lib.rs
+++ b/kitsune-embed/src/lib.rs
@@ -1,3 +1,7 @@
+#![forbid(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+
 use diesel::{OptionalExtension, QueryDsl};
 use diesel_async::{pooled_connection::deadpool, RunQueryDsl};
 use embed_sdk::EmbedWithExpire;

--- a/kitsune-http-client/Cargo.toml
+++ b/kitsune-http-client/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+bytes = "1.4.0"
 derive_builder = "0.12.0"
 futures-core = "0.3.28"
 headers = "0.3.8"
@@ -19,7 +20,7 @@ hyper-rustls = { version = "0.24.0", features = ["http2"] }
 kitsune-http-signatures = { path = "../kitsune-http-signatures" }
 pin-project-lite = "0.2.9"
 serde = "1.0.164"
-serde_json = "1.0.96"
+simd-json = "0.10.3"
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = [
     "decompression-full",

--- a/kitsune-http-client/src/lib.rs
+++ b/kitsune-http-client/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(forbidden_lint_groups)]
 
 use self::util::BoxCloneService;
+use bytes::Buf;
 use futures_core::Stream;
 use headers::{Date, HeaderMapExt};
 use http_body::{combinators::BoxBody, Body as HttpBody, Limited};
@@ -358,7 +359,7 @@ impl Response {
         T: DeserializeOwned,
     {
         let bytes = self.bytes().await?;
-        Ok(serde_json::from_slice(&bytes).map_err(BoxError::from)?)
+        Ok(simd_json::from_reader(bytes.reader()).map_err(BoxError::from)?)
     }
 
     /// Get the status of the request

--- a/kitsune-http-client/tests/json.rs
+++ b/kitsune-http-client/tests/json.rs
@@ -1,6 +1,6 @@
 use hyper::{Body, Request};
 use kitsune_http_client::Client;
-use serde_json::Value;
+use simd_json::{OwnedValue, ValueAccess};
 
 #[tokio::test]
 async fn json_request() {
@@ -17,6 +17,6 @@ async fn json_request() {
     let response = client.execute(req).await.unwrap();
     assert!(response.status().is_success());
 
-    let body: Value = response.json().await.unwrap();
+    let body: OwnedValue = response.json().await.unwrap();
     assert_eq!(body["preferredUsername"].as_str(), Some("0x0"));
 }

--- a/kitsune-http-signatures/Cargo.toml
+++ b/kitsune-http-signatures/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-base64 = "0.21.2"
+base64-simd = "0.8.0"
 derive_builder = "0.12.0"
 http = "0.2.9"
 rayon = "1.7.0"

--- a/kitsune-http-signatures/src/error.rs
+++ b/kitsune-http-signatures/src/error.rs
@@ -10,7 +10,7 @@ use tokio::sync::oneshot::error::RecvError;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error(transparent)]
-    Base64Decode(#[from] base64::DecodeError),
+    Base64(#[from] base64_simd::Error),
 
     #[error("Signature is expired")]
     ExpiredSignature,

--- a/kitsune-http-signatures/src/header.rs
+++ b/kitsune-http-signatures/src/header.rs
@@ -1,5 +1,4 @@
 use crate::{util::UnixTimestampExt, Error, Result, SignatureComponent};
-use base64::{engine::general_purpose, Engine};
 use derive_builder::Builder;
 use http::{header::DATE, request::Parts};
 use std::{
@@ -36,7 +35,7 @@ impl<'a> SignatureHeader<'a> {
         for (key, value) in kv_pairs {
             match key {
                 "keyId" => builder.key_id(value),
-                "signature" => builder.signature(general_purpose::STANDARD.decode(value)?),
+                "signature" => builder.signature(base64_simd::STANDARD.decode_to_vec(value)?),
                 "headers" => {
                     let components = value
                         .split_whitespace()
@@ -117,7 +116,7 @@ impl TryFrom<SignatureHeader<'_>> for String {
     type Error = SystemTimeError;
 
     fn try_from(value: SignatureHeader<'_>) -> Result<Self, Self::Error> {
-        let signature = general_purpose::STANDARD.encode(value.signature);
+        let signature = base64_simd::STANDARD.encode_to_string(value.signature);
         let headers = value
             .signature_components
             .iter()

--- a/kitsune-messaging/Cargo.toml
+++ b/kitsune-messaging/Cargo.toml
@@ -14,7 +14,7 @@ redis = { version = "0.23.0", features = [
     "tokio-rustls-comp",
 ] }
 serde = "1.0.164"
-serde_json = "1.0.97"
+simd-json = "0.10.3"
 tokio = { version = "1.28.2", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.37"

--- a/kitsune-messaging/Cargo.toml
+++ b/kitsune-messaging/Cargo.toml
@@ -14,7 +14,7 @@ redis = { version = "0.23.0", features = [
     "tokio-rustls-comp",
 ] }
 serde = "1.0.164"
-serde_json = "1.0.96"
+serde_json = "1.0.97"
 tokio = { version = "1.28.2", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.37"

--- a/kitsune-messaging/examples/simple_redis.rs
+++ b/kitsune-messaging/examples/simple_redis.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use kitsune_messaging::{redis::RedisMessagingBackend, MessagingHub};
-use serde_json::{json, Value};
+use simd_json::{json, OwnedValue};
 use std::time::Duration;
 
 #[tokio::main(flavor = "current_thread")]
@@ -10,16 +10,16 @@ async fn main() {
         .unwrap();
     let hub = MessagingHub::new(redis_backend);
 
-    let consumer = hub.consumer::<Value>("test".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 1: {:?}]", msg) }));
 
-    let consumer = hub.consumer::<Value>("test".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 2: {:?}]", msg) }));
 
-    let consumer = hub.consumer::<Value>("test2".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test2".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 3: {:?}]", msg) }));
 
-    let consumer = hub.consumer::<Value>("test2".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test2".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 4: {:?}]", msg) }));
 
     for i in 1..=3 {

--- a/kitsune-messaging/examples/simple_tokio_broadcast.rs
+++ b/kitsune-messaging/examples/simple_tokio_broadcast.rs
@@ -1,6 +1,6 @@
 use futures_util::StreamExt;
 use kitsune_messaging::{tokio_broadcast::TokioBroadcastMessagingBackend, MessagingHub};
-use serde_json::{json, Value};
+use simd_json::{json, OwnedValue};
 use std::time::Duration;
 
 #[tokio::main(flavor = "current_thread")]
@@ -8,16 +8,16 @@ async fn main() {
     let tokio_broadcast_backend = TokioBroadcastMessagingBackend::default();
     let hub = MessagingHub::new(tokio_broadcast_backend);
 
-    let consumer = hub.consumer::<Value>("test".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 1: {:?}]", msg) }));
 
-    let consumer = hub.consumer::<Value>("test".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 2: {:?}]", msg) }));
 
-    let consumer = hub.consumer::<Value>("test2".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test2".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 3: {:?}]", msg) }));
 
-    let consumer = hub.consumer::<Value>("test2".into()).await.unwrap();
+    let consumer = hub.consumer::<OwnedValue>("test2".into()).await.unwrap();
     tokio::spawn(consumer.for_each(|msg| async move { println!("Consumer 4: {:?}]", msg) }));
 
     for i in 1..=3 {

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -12,7 +12,7 @@ enum_dispatch = "0.3.11"
 futures-util = "0.3.28"
 kitsune-db = { path = "../kitsune-db" }
 serde = { version = "1.0.164", features = ["derive"] }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.40"
 uuid = "1.3.4"
 

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -14,7 +14,7 @@ kitsune-db = { path = "../kitsune-db" }
 serde = { version = "1.0.164", features = ["derive"] }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.40"
-uuid = "1.3.4"
+uuid = { package = "kitsune-uuid", path = "../kitsune-uuid" }
 
 # "kitsune-search" feature
 bytes = { version = "1.4.0", optional = true }

--- a/kitsune-search/Cargo.toml
+++ b/kitsune-search/Cargo.toml
@@ -17,6 +17,7 @@ thiserror = "1.0.40"
 uuid = "1.3.4"
 
 # "kitsune-search" feature
+bytes = { version = "1.4.0", optional = true }
 kitsune-search-proto = { path = "../kitsune-search-server/proto", optional = true }
 tonic = { version = "0.9.2", optional = true }
 
@@ -26,5 +27,5 @@ tracing = "0.1.37"
 
 [features]
 default = []
-kitsune-search = ["dep:kitsune-search-proto", "dep:tonic"]
+kitsune-search = ["dep:bytes", "dep:kitsune-search-proto", "dep:tonic"]
 meilisearch = ["dep:meilisearch-sdk"]

--- a/kitsune-search/src/grpc.rs
+++ b/kitsune-search/src/grpc.rs
@@ -157,12 +157,7 @@ impl From<SearchIndex> for GrpcSearchIndex {
 
 impl From<GrpcSearchResult> for SearchResult {
     fn from(value: GrpcSearchResult) -> Self {
-        let id = Uuid::from_bytes(
-            value
-                .id
-                .try_into()
-                .expect("Received non-UUID from search service"),
-        );
+        let id = Uuid::from_slice(&value.id).expect("Received non-UUID from search service");
 
         Self { id }
     }

--- a/kitsune-type/Cargo.toml
+++ b/kitsune-type/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.96"
+serde_json = "1.0.97"
 smol_str = { version = "0.2.0", features = ["serde"] }
 time = { version = "0.3.22", features = ["formatting", "parsing", "serde"] }
 utoipa = { version = "3.3.0", features = ["chrono", "uuid"] }

--- a/kitsune-type/Cargo.toml
+++ b/kitsune-type/Cargo.toml
@@ -4,10 +4,10 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+iso8601-timestamp = "0.2.10"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
 smol_str = { version = "0.2.0", features = ["serde"] }
-time = { version = "0.3.22", features = ["formatting", "parsing", "serde"] }
 utoipa = { version = "3.3.0", features = ["chrono", "uuid"] }
 uuid = { version = "1.3.4", features = ["serde"] }
 

--- a/kitsune-type/Cargo.toml
+++ b/kitsune-type/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
-iso8601-timestamp = "0.2.10"
+iso8601-timestamp = "0.2.11"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.97"
 smol_str = { version = "0.2.0", features = ["serde"] }

--- a/kitsune-type/Cargo.toml
+++ b/kitsune-type/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0.164", features = ["derive"] }
 simd-json = "0.10.3"
 smol_str = { version = "0.2.0", features = ["serde"] }
 utoipa = { version = "3.3.0", features = ["chrono", "uuid"] }
-uuid = { version = "1.3.4", features = ["serde"] }
+uuid = { package = "kitsune-uuid", path = "../kitsune-uuid" }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/kitsune-type/Cargo.toml
+++ b/kitsune-type/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 iso8601-timestamp = "0.2.11"
 serde = { version = "1.0.164", features = ["derive"] }
-serde_json = "1.0.97"
+simd-json = "0.10.3"
 smol_str = { version = "0.2.0", features = ["serde"] }
 utoipa = { version = "3.3.0", features = ["chrono", "uuid"] }
 uuid = { version = "1.3.4", features = ["serde"] }

--- a/kitsune-type/src/ap/actor.rs
+++ b/kitsune-type/src/ap/actor.rs
@@ -1,7 +1,7 @@
 use super::object::MediaAttachment;
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use time::OffsetDateTime;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum ActorType {
@@ -41,8 +41,8 @@ pub struct Actor {
     pub outbox: Option<String>,
     pub followers: Option<String>,
     pub following: Option<String>,
-    #[serde(default = "OffsetDateTime::now_utc", with = "time::serde::rfc3339")]
-    pub published: OffsetDateTime,
+    #[serde(default = "Timestamp::now_utc")]
+    pub published: Timestamp,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/kitsune-type/src/ap/actor.rs
+++ b/kitsune-type/src/ap/actor.rs
@@ -1,7 +1,7 @@
 use super::object::MediaAttachment;
 use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use simd_json::OwnedValue;
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub enum ActorType {
@@ -24,7 +24,7 @@ impl ActorType {
 #[serde(rename_all = "camelCase")]
 pub struct Actor {
     #[serde(default, rename = "@context")]
-    pub context: Value,
+    pub context: OwnedValue,
     pub id: String,
     pub r#type: ActorType,
     pub name: Option<String>,

--- a/kitsune-type/src/ap/collection.rs
+++ b/kitsune-type/src/ap/collection.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use simd_json::OwnedValue;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum CollectionType {
@@ -10,7 +10,7 @@ pub enum CollectionType {
 #[serde(rename_all = "camelCase")]
 pub struct Collection {
     #[serde(default, rename = "@context")]
-    pub context: Value,
+    pub context: OwnedValue,
     pub id: String,
     pub r#type: CollectionType,
     pub total_items: u64,
@@ -25,13 +25,13 @@ pub enum PageType {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct CollectionPage {
+pub struct CollectionPage<T> {
     #[serde(default, rename = "@context")]
-    pub context: Value,
+    pub context: OwnedValue,
     pub id: String,
     pub r#type: PageType,
     pub next: String,
     pub prev: String,
     pub part_of: String,
-    pub ordered_items: Vec<Value>,
+    pub ordered_items: Vec<T>,
 }

--- a/kitsune-type/src/ap/mod.rs
+++ b/kitsune-type/src/ap/mod.rs
@@ -5,7 +5,7 @@ use self::{
 };
 use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
+use simd_json::{json, OwnedValue};
 
 pub const PUBLIC_IDENTIFIER: &str = "https://www.w3.org/ns/activitystreams#Public";
 
@@ -16,7 +16,7 @@ pub mod object;
 
 pub use self::helper::Privacy;
 
-pub fn ap_context() -> Value {
+pub fn ap_context() -> OwnedValue {
     json!([
         "https://www.w3.org/ns/activitystreams",
         "https://w3id.org/security/v1",
@@ -115,7 +115,7 @@ impl ObjectField {
 #[serde(rename_all = "camelCase")]
 pub struct Activity {
     #[serde(default, rename = "@context")]
-    pub context: Value,
+    pub context: OwnedValue,
     pub id: String,
     pub r#type: ActivityType,
     pub actor: StringOrObject<Actor>,
@@ -156,7 +156,7 @@ pub enum ObjectType {
 #[serde(rename_all = "camelCase")]
 pub struct Object {
     #[serde(default, rename = "@context")]
-    pub context: Value,
+    pub context: OwnedValue,
     pub id: String,
     pub r#type: ObjectType,
     pub attributed_to: AttributedToField,

--- a/kitsune-type/src/ap/mod.rs
+++ b/kitsune-type/src/ap/mod.rs
@@ -3,9 +3,9 @@ use self::{
     helper::StringOrObject,
     object::MediaAttachment,
 };
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use time::OffsetDateTime;
 
 pub const PUBLIC_IDENTIFIER: &str = "https://www.w3.org/ns/activitystreams#Public";
 
@@ -120,8 +120,8 @@ pub struct Activity {
     pub r#type: ActivityType,
     pub actor: StringOrObject<Actor>,
     pub object: ObjectField,
-    #[serde(default = "OffsetDateTime::now_utc", with = "time::serde::rfc3339")]
-    pub published: OffsetDateTime,
+    #[serde(default = "Timestamp::now_utc")]
+    pub published: Timestamp,
 }
 
 impl Activity {
@@ -171,8 +171,7 @@ pub struct Object {
     pub tag: Vec<Tag>,
     #[serde(default)]
     pub sensitive: bool,
-    #[serde(with = "time::serde::rfc3339")]
-    pub published: OffsetDateTime,
+    pub published: Timestamp,
     #[serde(default)]
     pub to: Vec<String>,
     #[serde(default)]

--- a/kitsune-type/src/mastodon/account.rs
+++ b/kitsune-type/src/mastodon/account.rs
@@ -1,5 +1,5 @@
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -7,7 +7,7 @@ use uuid::Uuid;
 pub struct Field {
     pub name: String,
     pub value: String,
-    pub verified_at: Option<OffsetDateTime>,
+    pub verified_at: Option<Timestamp>,
 }
 
 #[derive(Clone, Deserialize, Serialize, ToSchema)]
@@ -27,8 +27,7 @@ pub struct Account {
     pub group: bool,
     pub username: String,
     pub display_name: String,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
     pub locked: bool,
     pub note: String,
     pub url: String,

--- a/kitsune-type/src/mastodon/search.rs
+++ b/kitsune-type/src/mastodon/search.rs
@@ -1,12 +1,12 @@
 use super::{Account, Status};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use simd_json::OwnedValue;
 use utoipa::ToSchema;
 
 #[derive(Default, Deserialize, Serialize, ToSchema)]
 pub struct SearchResult {
     pub accounts: Vec<Account>,
     #[schema(value_type = Object)]
-    pub hashtags: Vec<Value>, // Placeholder
+    pub hashtags: Vec<OwnedValue>, // Placeholder
     pub statuses: Vec<Status>,
 }

--- a/kitsune-type/src/mastodon/status.rs
+++ b/kitsune-type/src/mastodon/status.rs
@@ -1,7 +1,7 @@
 use super::{Account, MediaAttachment, PreviewCard};
+use iso8601_timestamp::Timestamp;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
-use time::OffsetDateTime;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -32,8 +32,7 @@ pub enum Visibility {
 #[derive(Clone, Deserialize, Serialize, ToSchema)]
 pub struct Status {
     pub id: Uuid,
-    #[serde(with = "time::serde::rfc3339")]
-    pub created_at: OffsetDateTime,
+    pub created_at: Timestamp,
     pub in_reply_to_id: Option<Uuid>,
     pub in_reply_to_account_id: Option<Uuid>,
     pub sensitive: bool,

--- a/kitsune-type/src/nodeinfo/two_one.rs
+++ b/kitsune-type/src/nodeinfo/two_one.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use simd_json::OwnedValue;
 use utoipa::ToSchema;
 
 #[derive(Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize, ToSchema)]
@@ -105,7 +105,7 @@ pub struct Usage {
     pub local_comments: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq, Serialize, ToSchema)]
+#[derive(Debug, Deserialize, PartialEq, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 /// Definitions of Nodeinfo 2.1
 pub struct TwoOne {
@@ -116,7 +116,7 @@ pub struct TwoOne {
     pub open_registrations: bool,
     pub usage: Usage,
     #[schema(value_type = Object)]
-    pub metadata: Value,
+    pub metadata: OwnedValue,
 }
 
 #[cfg(test)]
@@ -127,8 +127,8 @@ mod test {
 
     #[test]
     fn deserialize_akkoma_nodeinfo() {
-        let raw = include_str!("../../tests/nodeinfo_2.1.json");
-        let two_one: TwoOne = serde_json::from_str(raw).unwrap();
+        let mut raw = include_bytes!("../../tests/nodeinfo_2.1.json").to_vec();
+        let two_one: TwoOne = simd_json::from_slice(&mut raw).unwrap();
 
         assert_str_eq!(two_one.software.name, "akkoma");
         assert_eq!(two_one.protocols, [Protocol::ActivityPub]);

--- a/kitsune-type/src/webfinger.rs
+++ b/kitsune-type/src/webfinger.rs
@@ -20,7 +20,7 @@ mod test {
     use crate::webfinger::Resource;
     use pretty_assertions::assert_eq;
 
-    const GARGRON_WEBFINGER_RESOURCE: &str = r#"
+    const GARGRON_WEBFINGER_RESOURCE: &[u8] = br#"
     {
         "subject": "acct:Gargron@mastodon.social",
         "aliases": [
@@ -48,8 +48,9 @@ mod test {
 
     #[test]
     fn deserialise_gargron() {
-        let deserialised: Resource = serde_json::from_str(GARGRON_WEBFINGER_RESOURCE)
-            .expect("Failed to deserialise resource");
+        let mut webfinger_resource = GARGRON_WEBFINGER_RESOURCE.to_vec();
+        let deserialised: Resource =
+            simd_json::from_slice(&mut webfinger_resource).expect("Failed to deserialise resource");
 
         assert_eq!(deserialised.subject, "acct:Gargron@mastodon.social");
         assert_eq!(

--- a/kitsune-uuid/Cargo.toml
+++ b/kitsune-uuid/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kitsune-uuid"
+edition = "2021"
+version.workspace = true
+
+[dependencies]
+diesel = { version = "2.1.0", features = ["postgres_backend"] }
+serde = "1.0.164"
+uuid = "1.3.4"
+uuid-simd = { version = "0.8.0", features = ["uuid"] }

--- a/kitsune-uuid/Cargo.toml
+++ b/kitsune-uuid/Cargo.toml
@@ -4,7 +4,9 @@ edition = "2021"
 version.workspace = true
 
 [dependencies]
-diesel = { version = "2.1.0", features = ["postgres_backend"] }
+async-graphql = { version = "5.0.10", default-features = false, optional = true }
+diesel = { version = "2.1.0", features = ["postgres_backend", "uuid"] }
 serde = "1.0.164"
-uuid = "1.3.4"
+thiserror = "1.0.40"
+uuid = { version = "1.3.4", features = ["fast-rng", "v7"] }
 uuid-simd = { version = "0.8.0", features = ["uuid"] }

--- a/kitsune-uuid/src/lib.rs
+++ b/kitsune-uuid/src/lib.rs
@@ -1,0 +1,188 @@
+#![forbid(rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+
+use diesel::{AsExpression, FromSqlRow};
+use serde::{
+    de::{self, Error as _},
+    Deserialize, Serialize,
+};
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    str::{self, FromStr},
+};
+use uuid_simd::{format_hyphenated, AsciiCase, Out, UuidExt};
+
+macro_rules! next_element {
+    ($seq:ident, $self:ident) => {
+        match $seq.next_element()? {
+            Some(e) => e,
+            None => return Err(A::Error::invalid_length(16, &$self)),
+        }
+    };
+}
+
+#[derive(AsExpression, Clone, Copy, Debug, FromSqlRow, PartialEq, Eq, PartialOrd, Ord)]
+#[diesel(sql_type = diesel::sql_types::Uuid)]
+#[repr(transparent)]
+pub struct Uuid(pub uuid::Uuid);
+
+impl AsRef<uuid::Uuid> for Uuid {
+    fn as_ref(&self) -> &uuid::Uuid {
+        &self.0
+    }
+}
+
+impl Deref for Uuid {
+    type Target = uuid::Uuid;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Uuid {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for Uuid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        fn de_error<E: de::Error>(e: impl fmt::Display) -> E {
+            E::custom(format_args!("UUID parsing failed: {e}"))
+        }
+
+        if deserializer.is_human_readable() {
+            struct UuidVisitor;
+
+            impl<'vi> de::Visitor<'vi> for UuidVisitor {
+                type Value = Uuid;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(formatter, "a UUID string")
+                }
+
+                fn visit_str<E: de::Error>(self, value: &str) -> Result<Uuid, E> {
+                    value.parse().map_err(de_error)
+                }
+
+                fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Uuid, E> {
+                    uuid::Uuid::from_slice(value).map(Uuid).map_err(de_error)
+                }
+
+                fn visit_seq<A>(self, mut seq: A) -> Result<Uuid, A::Error>
+                where
+                    A: de::SeqAccess<'vi>,
+                {
+                    let bytes = [
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                        next_element!(seq, self),
+                    ];
+
+                    Ok(Uuid(uuid::Uuid::from_bytes(bytes)))
+                }
+            }
+
+            deserializer.deserialize_str(UuidVisitor)
+        } else {
+            struct UuidBytesVisitor;
+
+            impl<'vi> de::Visitor<'vi> for UuidBytesVisitor {
+                type Value = Uuid;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    write!(formatter, "bytes")
+                }
+
+                fn visit_bytes<E: de::Error>(self, value: &[u8]) -> Result<Uuid, E> {
+                    uuid::Uuid::from_slice(value).map(Uuid).map_err(de_error)
+                }
+            }
+
+            deserializer.deserialize_bytes(UuidBytesVisitor)
+        }
+    }
+}
+
+impl fmt::Display for Uuid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut dst = [0; 36];
+        let display = unsafe {
+            str::from_utf8_unchecked(format_hyphenated(
+                self.0.as_bytes(),
+                Out::from_mut(&mut dst),
+                AsciiCase::Lower,
+            ))
+        };
+
+        write!(f, "{display}")
+    }
+}
+
+impl From<uuid::Uuid> for Uuid {
+    fn from(value: uuid::Uuid) -> Self {
+        Self(value)
+    }
+}
+
+impl From<Uuid> for uuid::Uuid {
+    fn from(value: Uuid) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for Uuid {
+    type Err = uuid_simd::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(uuid::Uuid::parse(s)?))
+    }
+}
+
+impl Serialize for Uuid {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut dst = [0; 36];
+        serializer.serialize_str(unsafe {
+            str::from_utf8_unchecked(format_hyphenated(
+                self.0.as_bytes(),
+                Out::from_mut(&mut dst),
+                AsciiCase::Lower,
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::Uuid;
+    use std::str::FromStr;
+
+    const UUID_1: &str = "38058daf-b2cd-4832-902a-83583ac07e28";
+
+    #[test]
+    fn parse_1() {
+        let uuid = Uuid::from_str(UUID_1).unwrap();
+        assert_eq!(UUID_1, uuid.to_string());
+    }
+}

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -78,7 +78,6 @@ redis = "0.23.0"
 rsa = "0.9.2"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_dhall = { version = "0.12.1", default-features = false }
-serde_json = "1.0.97"
 sha2 = "0.10.7"
 simd-json = "0.10.3"
 smol_str = "0.2.0"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -100,7 +100,7 @@ typed-builder = "0.14.0"
 url = "2.4.0"
 utoipa = { version = "3.3.0", features = ["axum_extras", "time", "uuid"] }
 utoipa-swagger-ui = { version = "3.1.3", features = ["axum"] }
-uuid = { version = "1.3.4", features = ["fast-rng", "v7"] }
+uuid = { package = "kitsune-uuid", path = "../kitsune-uuid" }
 zxcvbn = { version = "2.2.2", default-features = false }
 
 # --- Optional dependencies ---
@@ -133,7 +133,11 @@ serial_test = "2.0.0"
 
 [features]
 default = ["graphql-api", "kitsune-search", "mastodon-api", "metrics"]
-graphql-api = ["dep:async-graphql", "dep:async-graphql-axum"]
+graphql-api = [
+    "dep:async-graphql",
+    "dep:async-graphql-axum",
+    "uuid/async-graphql",
+]
 kitsune-search = ["kitsune-search/kitsune-search"]
 mastodon-api = []
 meilisearch = ["kitsune-search/meilisearch"]

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -29,7 +29,7 @@ axum-extra = { version = "0.7.4", features = [
     "query",
 ] }
 axum-flash = "0.7.0"
-base64 = "0.21.2"
+base64-simd = "0.8.0"
 bytes = "1.4.0"
 chrono = { version = "0.4.26", default-features = false } # Needed because of oxide-auth. Thinking about forking and porting to time..
 const_format = "0.2.31"
@@ -46,7 +46,7 @@ enum_dispatch = "0.3.11"
 futures-util = "0.3.28"
 globset = { version = "0.4.10", features = ["simd-accel"] }
 headers = "0.3.8"
-hex = "0.4.3"
+hex-simd = "0.8.0"
 http = "0.2.9"
 hyper = { version = "0.14.26", features = ["deprecated"] }
 iso8601-timestamp = "0.2.11"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -49,6 +49,7 @@ headers = "0.3.8"
 hex = "0.4.3"
 http = "0.2.9"
 hyper = { version = "0.14.26", features = ["deprecated"] }
+iso8601-timestamp = "0.2.10"
 kitsune-cache = { path = "../kitsune-cache" }
 kitsune-db = { path = "../kitsune-db" }
 kitsune-embed = { path = "../kitsune-embed" }

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -49,7 +49,7 @@ headers = "0.3.8"
 hex = "0.4.3"
 http = "0.2.9"
 hyper = { version = "0.14.26", features = ["deprecated"] }
-iso8601-timestamp = "0.2.10"
+iso8601-timestamp = "0.2.11"
 kitsune-cache = { path = "../kitsune-cache" }
 kitsune-db = { path = "../kitsune-db" }
 kitsune-embed = { path = "../kitsune-embed" }

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -77,9 +77,11 @@ redis = "0.23.0"
 rsa = "0.9.2"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_dhall = { version = "0.12.1", default-features = false }
-serde_json = "1.0.96"
-sha2 = "0.10.6"
-strum = { version = "0.24.1", features = ["derive", "phf"] }
+serde_json = "1.0.97"
+sha2 = "0.10.7"
+simd-json = "0.10.3"
+smol_str = "0.2.0"
+strum = { version = "0.25.0", features = ["derive", "phf"] }
 tempfile = "3.6.0"
 thiserror = "1.0.40"
 time = "0.3.22"
@@ -124,7 +126,6 @@ metrics-util = { version = "0.15.0", optional = true }
 
 # "oidc" feature
 openidconnect = { version = "3.2.0", default-features = false, optional = true }
-smol_str = "0.2.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/kitsune/src/activitypub/deliverer.rs
+++ b/kitsune/src/activitypub/deliverer.rs
@@ -4,7 +4,6 @@ use crate::{
     service::federation_filter::FederationFilterService,
 };
 use autometrics::autometrics;
-use base64::{engine::general_purpose, Engine};
 use futures_util::{stream::FuturesUnordered, Stream, StreamExt};
 use http::{Method, Request};
 use kitsune_db::model::{account::Account, user::User};
@@ -49,7 +48,7 @@ impl Deliverer {
         }
 
         let body = simd_json::to_string(&activity)?;
-        let body_digest = general_purpose::STANDARD.encode(Sha256::digest(body.as_bytes()));
+        let body_digest = base64_simd::STANDARD.encode_to_string(Sha256::digest(body.as_bytes()));
         let digest_header = format!("sha-256={body_digest}");
 
         let request = Request::builder()

--- a/kitsune/src/activitypub/deliverer.rs
+++ b/kitsune/src/activitypub/deliverer.rs
@@ -48,7 +48,7 @@ impl Deliverer {
             return Ok(());
         }
 
-        let body = serde_json::to_string(&activity)?;
+        let body = simd_json::to_string(&activity)?;
         let body_digest = general_purpose::STANDARD.encode(Sha256::digest(body.as_bytes()));
         let digest_header = format!("sha-256={body_digest}");
 

--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -138,7 +138,7 @@ impl Fetcher {
                                 .as_deref(),
                             public_key_id: actor.public_key.id.as_str(),
                             public_key: actor.public_key.public_key_pem.as_str(),
-                            created_at: Some(actor.published.assume_utc()),
+                            created_at: Some(actor.published),
                         })
                         .on_conflict(accounts::url)
                         .do_update()

--- a/kitsune/src/activitypub/mod.rs
+++ b/kitsune/src/activitypub/mod.rs
@@ -185,7 +185,7 @@ pub async fn process_new_object(
                         visibility,
                         is_local: false,
                         url: object.id.as_str(),
-                        created_at: Some(object.published.assume_utc()),
+                        created_at: Some(object.published),
                     })
                     .on_conflict(posts::url)
                     .do_update()

--- a/kitsune/src/activitypub/mod.rs
+++ b/kitsune/src/activitypub/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::{ApiError, Error, Result},
     sanitize::CleanHtmlExt,
+    util::timestamp_to_uuid,
 };
 use diesel::SelectableHelper;
 use diesel_async::{
@@ -20,7 +21,7 @@ use kitsune_search::{SearchBackend, SearchService};
 use kitsune_type::ap::{object::MediaAttachment, Object, Tag, TagType};
 use pulldown_cmark::{html, Options, Parser};
 use typed_builder::TypedBuilder;
-use uuid::{Timestamp, Uuid};
+use uuid::Uuid;
 
 pub mod deliverer;
 pub mod fetcher;
@@ -135,14 +136,6 @@ pub async fn process_new_object(
     };
 
     let visibility = Visibility::from_activitypub(&user, &object).unwrap();
-
-    #[allow(clippy::cast_sign_loss)]
-    let uuid_timestamp = Timestamp::from_unix(
-        uuid::NoContext,
-        object.published.unix_timestamp() as u64,
-        object.published.nanosecond(),
-    );
-
     let in_reply_to_id = if let Some(ref in_reply_to) = object.in_reply_to {
         fetcher
             .fetch_object_inner(in_reply_to, call_depth + 1)
@@ -181,7 +174,7 @@ pub async fn process_new_object(
             async move {
                 let new_post = diesel::insert_into(posts::table)
                     .values(NewPost {
-                        id: Uuid::new_v7(uuid_timestamp),
+                        id: timestamp_to_uuid(object.published),
                         account_id: user.id,
                         in_reply_to_id,
                         reposted_post_id: None,
@@ -192,7 +185,7 @@ pub async fn process_new_object(
                         visibility,
                         is_local: false,
                         url: object.id.as_str(),
-                        created_at: Some(object.published),
+                        created_at: Some(object.published.assume_utc()),
                     })
                     .on_conflict(posts::url)
                     .do_update()

--- a/kitsune/src/config.rs
+++ b/kitsune/src/config.rs
@@ -1,76 +1,76 @@
 use serde::{Deserialize, Serialize};
-use serde_dhall::StaticType;
+use smol_str::SmolStr;
 use std::path::Path;
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct RedisCacheConfiguration {
-    pub redis_url: String,
+    pub redis_url: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum CacheConfiguration {
     Redis(RedisCacheConfiguration),
     InMemory,
     None,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct DatabaseConfiguration {
-    pub url: String,
+    pub url: SmolStr,
     pub max_connections: u32,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct EmbedConfiguration {
-    pub url: String,
+    pub url: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum FederationFilterConfiguration {
-    Allow { domains: Vec<String> },
-    Deny { domains: Vec<String> },
+    Allow { domains: Vec<SmolStr> },
+    Deny { domains: Vec<SmolStr> },
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct InstanceConfiguration {
-    pub name: String,
-    pub description: String,
+    pub name: SmolStr,
+    pub description: SmolStr,
     pub character_limit: usize,
     pub federation_filter: FederationFilterConfiguration,
     pub registrations_open: bool,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct OidcConfiguration {
-    pub server_url: String,
-    pub client_id: String,
-    pub client_secret: String,
+    pub server_url: SmolStr,
+    pub client_id: SmolStr,
+    pub client_secret: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct RedisMessagingConfiguration {
-    pub redis_url: String,
+    pub redis_url: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum MessagingConfiguration {
     Redis(RedisMessagingConfiguration),
     InProcess,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct KitsuneSearchConfiguration {
-    pub index_server: String,
-    pub search_servers: Vec<String>,
+    pub index_server: SmolStr,
+    pub search_servers: Vec<SmolStr>,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct MeiliSearchConfiguration {
-    pub instance_url: String,
-    pub api_key: String,
+    pub instance_url: SmolStr,
+    pub api_key: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum SearchConfiguration {
     Kitsune(KitsuneSearchConfiguration),
     Meilisearch(MeiliSearchConfiguration),
@@ -78,9 +78,9 @@ pub enum SearchConfiguration {
     None,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ServerConfiguration {
-    pub frontend_dir: String,
+    pub frontend_dir: SmolStr,
     pub job_workers: usize,
     pub max_upload_size: usize,
     pub media_proxy_enabled: bool,
@@ -90,34 +90,34 @@ pub struct ServerConfiguration {
     pub request_timeout_sec: u64,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct FsStorageConfiguration {
-    pub upload_dir: String,
+    pub upload_dir: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct S3StorageConfiguration {
-    pub bucket_name: String,
-    pub endpoint_url: String,
-    pub region: String,
+    pub bucket_name: SmolStr,
+    pub endpoint_url: SmolStr,
+    pub region: SmolStr,
     pub force_path_style: bool,
-    pub access_key: String,
-    pub secret_access_key: String,
+    pub access_key: SmolStr,
+    pub secret_access_key: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub enum StorageConfiguration {
     Fs(FsStorageConfiguration),
     S3(S3StorageConfiguration),
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct UrlConfiguration {
-    pub scheme: String,
-    pub domain: String,
+    pub scheme: SmolStr,
+    pub domain: SmolStr,
 }
 
-#[derive(Clone, Deserialize, Serialize, StaticType)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct Configuration {
     pub cache: CacheConfiguration,
     pub database: DatabaseConfiguration,
@@ -137,7 +137,7 @@ impl Configuration {
         P: AsRef<Path>,
     {
         serde_dhall::from_file(path)
-            .static_type_annotation()
+            //.static_type_annotation() // SmolStr usage makes this impossible (unfortunately)
             .parse()
     }
 }

--- a/kitsune/src/error.rs
+++ b/kitsune/src/error.rs
@@ -203,9 +203,6 @@ pub enum Error {
     Search(#[from] kitsune_search::Error),
 
     #[error(transparent)]
-    SerdeJson(#[from] serde_json::Error),
-
-    #[error(transparent)]
     SimdJson(#[from] simd_json::Error),
 
     #[error(transparent)]

--- a/kitsune/src/error.rs
+++ b/kitsune/src/error.rs
@@ -206,6 +206,9 @@ pub enum Error {
     SerdeJson(#[from] serde_json::Error),
 
     #[error(transparent)]
+    SimdJson(#[from] simd_json::Error),
+
+    #[error(transparent)]
     Spki(#[from] spki::Error),
 
     #[error(transparent)]

--- a/kitsune/src/http/extractor/json.rs
+++ b/kitsune/src/http/extractor/json.rs
@@ -1,0 +1,113 @@
+use askama_axum::IntoResponse;
+use async_trait::async_trait;
+use axum::{extract::FromRequest, response::Response, BoxError};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use http::{header, HeaderMap, HeaderValue, Request, StatusCode};
+use hyper::body::HttpBody;
+use serde::{de::DeserializeOwned, Serialize};
+use std::ops::{Deref, DerefMut};
+
+#[derive(Debug, Clone, Copy, Default)]
+#[must_use]
+pub struct Json<T>(pub T);
+
+#[async_trait]
+impl<T, S, B> FromRequest<S, B> for Json<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+    B: HttpBody + Send + 'static,
+    <B as HttpBody>::Data: Send,
+    <B as HttpBody>::Error: Into<BoxError>,
+{
+    type Rejection = Response;
+
+    async fn from_request(req: Request<B>, state: &S) -> Result<Self, Self::Rejection> {
+        if json_content_type(req.headers()) {
+            let bytes = Bytes::from_request(req, state)
+                .await
+                .map_err(IntoResponse::into_response)?;
+
+            let value = match simd_json::from_reader(bytes.reader()) {
+                Ok(value) => value,
+                Err(error) => {
+                    debug!(?error, "Failed to parse JSON payload");
+                    return Err(StatusCode::BAD_REQUEST.into_response());
+                }
+            };
+
+            Ok(Json(value))
+        } else {
+            Err(StatusCode::UNSUPPORTED_MEDIA_TYPE.into_response())
+        }
+    }
+}
+
+fn json_content_type(headers: &HeaderMap) -> bool {
+    let Some(content_type) = headers.get(header::CONTENT_TYPE) else {
+        return false;
+    };
+
+    let Ok(content_type) = content_type.to_str() else {
+        return false;
+    };
+
+    let Ok(mime) = content_type.parse::<mime::Mime>() else {
+        return false;
+    };
+
+    let is_json_content_type = mime.type_() == "application"
+        && (mime.subtype() == "json" || mime.suffix().map_or(false, |name| name == "json"));
+
+    is_json_content_type
+}
+
+impl<T> Deref for Json<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Json<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl<T> From<T> for Json<T> {
+    fn from(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T> IntoResponse for Json<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        // Use a small initial capacity of 128 bytes like serde_json::to_vec
+        // https://docs.rs/serde_json/1.0.82/src/serde_json/ser.rs.html#2189
+        let mut buf = BytesMut::with_capacity(128).writer();
+        match simd_json::to_writer(&mut buf, &self.0) {
+            Ok(()) => (
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::APPLICATION_JSON.as_ref()),
+                )],
+                buf.into_inner().freeze(),
+            )
+                .into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static(mime::TEXT_PLAIN_UTF_8.as_ref()),
+                )],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}

--- a/kitsune/src/http/extractor/mod.rs
+++ b/kitsune/src/http/extractor/mod.rs
@@ -4,7 +4,7 @@ use axum::{
     body::Body,
     extract::FromRequest,
     response::{IntoResponse, Response},
-    Form, Json, RequestExt, TypedHeader,
+    Form, RequestExt, TypedHeader,
 };
 use headers::ContentType;
 use mime::Mime;
@@ -12,6 +12,7 @@ use serde::de::DeserializeOwned;
 
 pub use self::{
     auth::{AuthExtractor, UserData},
+    json::Json,
     signed_activity::SignedActivity,
 };
 
@@ -19,6 +20,7 @@ pub use self::{
 pub use self::auth::MastodonAuthExtractor;
 
 mod auth;
+mod json;
 mod signed_activity;
 
 pub struct FormOrJson<T>(pub T);

--- a/kitsune/src/http/graphql/types/account.rs
+++ b/kitsune/src/http/graphql/types/account.rs
@@ -88,8 +88,8 @@ impl From<DbAccount> for Account {
             username: value.username,
             locked: value.locked,
             url: value.url,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
+            created_at: value.created_at.assume_utc(),
+            updated_at: value.updated_at.assume_utc(),
         }
     }
 }

--- a/kitsune/src/http/graphql/types/media_attachment.rs
+++ b/kitsune/src/http/graphql/types/media_attachment.rs
@@ -56,7 +56,7 @@ impl From<DbMediaAttachment> for MediaAttachment {
             content_type: value.content_type,
             description: value.description,
             blurhash: value.blurhash,
-            created_at: value.created_at,
+            created_at: value.created_at.assume_utc(),
         }
     }
 }

--- a/kitsune/src/http/graphql/types/oauth2_application.rs
+++ b/kitsune/src/http/graphql/types/oauth2_application.rs
@@ -21,8 +21,8 @@ impl From<oauth2::Application> for OAuth2Application {
             name: value.name,
             secret: value.secret,
             redirect_uri: value.redirect_uri,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
+            created_at: value.created_at.assume_utc(),
+            updated_at: value.updated_at.assume_utc(),
         }
     }
 }

--- a/kitsune/src/http/graphql/types/post.rs
+++ b/kitsune/src/http/graphql/types/post.rs
@@ -51,8 +51,8 @@ impl From<DbPost> for Post {
             content: value.content,
             visibility: value.visibility.into(),
             url: value.url,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
+            created_at: value.created_at.assume_utc(),
+            updated_at: value.updated_at.assume_utc(),
         }
     }
 }

--- a/kitsune/src/http/graphql/types/user.rs
+++ b/kitsune/src/http/graphql/types/user.rs
@@ -45,8 +45,8 @@ impl From<DbUser> for User {
             account_id: value.account_id,
             username: value.username,
             email: value.email,
-            created_at: value.created_at,
-            updated_at: value.updated_at,
+            created_at: value.created_at.assume_utc(),
+            updated_at: value.updated_at.assume_utc(),
         }
     }
 }

--- a/kitsune/src/http/handler/nodeinfo/two_one.rs
+++ b/kitsune/src/http/handler/nodeinfo/two_one.rs
@@ -9,7 +9,7 @@ use kitsune_db::{
 use kitsune_type::nodeinfo::two_one::{
     Protocol, Services, Software, TwoOne, Usage, UsageUsers, Version,
 };
-use serde_json::Value;
+use simd_json::{Builder, OwnedValue};
 
 #[debug_handler(state = crate::state::Zustand)]
 #[utoipa::path(
@@ -55,7 +55,7 @@ async fn get(
             local_comments: None,
             local_posts: local_posts as u64,
         },
-        metadata: Value::Null,
+        metadata: OwnedValue::null(),
     }))
 }
 

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -125,7 +125,7 @@ async fn follow_activity(state: &Zustand, author: Account, activity: Activity) -
             follower_id: author.id,
             approved_at,
             url: activity.id.as_str(),
-            created_at: Some(activity.published),
+            created_at: Some(activity.published.assume_utc()),
         })
         .returning(accounts_follows::id)
         .get_result(&mut db_conn)

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -10,6 +10,7 @@ use crate::{
 use axum::{debug_handler, extract::State};
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
+use iso8601_timestamp::Timestamp;
 use kitsune_db::{
     model::{
         account::Account,
@@ -22,13 +23,12 @@ use kitsune_db::{
 };
 use kitsune_type::ap::{Activity, ActivityType};
 use std::ops::Not;
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 async fn accept_activity(state: &Zustand, activity: Activity) -> Result<()> {
     let mut db_conn = state.db_conn.get().await?;
     diesel::update(accounts_follows::table.filter(accounts_follows::url.eq(activity.object())))
-        .set(accounts_follows::approved_at.eq(OffsetDateTime::now_utc()))
+        .set(accounts_follows::approved_at.eq(Timestamp::now_utc()))
         .execute(&mut db_conn)
         .await?;
 
@@ -115,7 +115,7 @@ async fn delete_activity(state: &Zustand, author: Account, activity: Activity) -
 
 async fn follow_activity(state: &Zustand, author: Account, activity: Activity) -> Result<()> {
     let followed_user = state.fetcher.fetch_actor(activity.object().into()).await?;
-    let approved_at = followed_user.locked.not().then(OffsetDateTime::now_utc);
+    let approved_at = followed_user.locked.not().then(Timestamp::now_utc);
 
     let mut db_conn = state.db_conn.get().await?;
     let follow_id = diesel::insert_into(accounts_follows::table)
@@ -125,7 +125,7 @@ async fn follow_activity(state: &Zustand, author: Account, activity: Activity) -
             follower_id: author.id,
             approved_at,
             url: activity.id.as_str(),
-            created_at: Some(activity.published.assume_utc()),
+            created_at: Some(activity.published),
         })
         .returning(accounts_follows::id)
         .get_result(&mut db_conn)
@@ -162,7 +162,7 @@ async fn like_activity(state: &Zustand, author: Account, activity: Activity) -> 
             account_id: author.id,
             post_id: post.id,
             url: activity.id,
-            created_at: Some(OffsetDateTime::now_utc()),
+            created_at: Some(Timestamp::now_utc()),
         })
         .execute(&mut db_conn)
         .await?;

--- a/kitsune/src/http/mod.rs
+++ b/kitsune/src/http/mod.rs
@@ -27,7 +27,7 @@ mod util;
 pub fn create_router(state: Zustand, server_config: &ServerConfiguration) -> Router {
     let frontend_dir = &server_config.frontend_dir;
     let frontend_index_path = {
-        let mut tmp = frontend_dir.clone();
+        let mut tmp = frontend_dir.to_string();
         tmp.push_str("index.html");
         tmp
     };
@@ -66,7 +66,7 @@ pub fn create_router(state: Zustand, server_config: &ServerConfiguration) -> Rou
             server_config.request_timeout_sec,
         )))
         .fallback_service(
-            ServeDir::new(frontend_dir).fallback(ServeFile::new(frontend_index_path)),
+            ServeDir::new(frontend_dir.as_str()).fallback(ServeFile::new(frontend_index_path)),
         );
 
     #[cfg(feature = "metrics")]

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -9,13 +9,13 @@ use diesel::{
     SelectableHelper,
 };
 use diesel_async::RunQueryDsl;
+use iso8601_timestamp::Timestamp;
 use kitsune_db::{
     model::{account::Account, follower::Follow, user::User},
     schema::{accounts, accounts_follows, users},
 };
 use kitsune_type::ap::{ap_context, helper::StringOrObject, Activity, ActivityType, ObjectField};
 use serde::{Deserialize, Serialize};
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -63,7 +63,7 @@ impl Runnable for DeliverAccept {
             r#type: ActivityType::Accept,
             actor: StringOrObject::String(followed_account_url),
             object: ObjectField::Url(follow.url),
-            published: OffsetDateTime::now_utc(),
+            published: Timestamp::now_utc(),
         };
 
         ctx.deliverer

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverAccept {
     pub follow_id: Uuid,
 }

--- a/kitsune/src/job/deliver/create.rs
+++ b/kitsune/src/job/deliver/create.rs
@@ -15,7 +15,7 @@ use kitsune_db::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverCreate {
     pub post_id: Uuid,
 }

--- a/kitsune/src/job/deliver/delete.rs
+++ b/kitsune/src/job/deliver/delete.rs
@@ -15,7 +15,7 @@ use kitsune_db::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverDelete {
     pub post_id: Uuid,
 }

--- a/kitsune/src/job/deliver/favourite.rs
+++ b/kitsune/src/job/deliver/favourite.rs
@@ -14,7 +14,7 @@ use kitsune_db::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverFavourite {
     pub favourite_id: Uuid,
 }

--- a/kitsune/src/job/deliver/follow.rs
+++ b/kitsune/src/job/deliver/follow.rs
@@ -14,7 +14,7 @@ use kitsune_db::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverFollow {
     pub follow_id: Uuid,
 }

--- a/kitsune/src/job/deliver/unfavourite.rs
+++ b/kitsune/src/job/deliver/unfavourite.rs
@@ -14,7 +14,7 @@ use kitsune_db::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverUnfavourite {
     pub favourite_id: Uuid,
 }

--- a/kitsune/src/job/deliver/unfollow.rs
+++ b/kitsune/src/job/deliver/unfollow.rs
@@ -14,7 +14,7 @@ use kitsune_db::{
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverUnfollow {
     pub follow_id: Uuid,
 }

--- a/kitsune/src/job/deliver/update.rs
+++ b/kitsune/src/job/deliver/update.rs
@@ -16,13 +16,13 @@ use kitsune_type::ap::ActivityType;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub enum UpdateEntity {
     Account,
     Status,
 }
 
-#[derive(Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct DeliverUpdate {
     pub entity: UpdateEntity,
     pub id: Uuid,

--- a/kitsune/src/mapping/activitypub/activity.rs
+++ b/kitsune/src/mapping/activitypub/activity.rs
@@ -67,7 +67,7 @@ impl IntoActivity for Favourite {
             r#type: ActivityType::Like,
             actor: StringOrObject::String(account_url),
             object: ObjectField::Url(post_url),
-            published: self.created_at.into(),
+            published: self.created_at,
         })
     }
 
@@ -115,7 +115,7 @@ impl IntoActivity for Follow {
             actor: StringOrObject::String(attributed_to),
             r#type: ActivityType::Follow,
             object: ObjectField::Url(object),
-            published: self.created_at.into(),
+            published: self.created_at,
         })
     }
 
@@ -132,7 +132,7 @@ impl IntoActivity for Follow {
             id: format!("{}#undo", self.url),
             r#type: ActivityType::Undo,
             actor: StringOrObject::String(attributed_to),
-            published: self.created_at.into(),
+            published: self.created_at,
             object: ObjectField::Activity(self.into_activity(state).await?.into()),
         })
     }
@@ -160,7 +160,7 @@ impl IntoActivity for Post {
                 r#type: ActivityType::Announce,
                 actor: StringOrObject::String(account_url),
                 object: ObjectField::Url(reposted_post_url),
-                published: self.created_at.into(),
+                published: self.created_at,
             })
         } else {
             let created_at = self.created_at;
@@ -171,7 +171,7 @@ impl IntoActivity for Post {
                 id: format!("{}/activity", object.id),
                 r#type: ActivityType::Create,
                 actor: StringOrObject::String(account_url),
-                published: created_at.into(),
+                published: created_at,
                 object: ObjectField::Object(object),
             })
         }

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -143,7 +143,7 @@ impl IntoObject for Post {
             media_type: None,
             attachment,
             tag,
-            published: self.created_at.into(),
+            published: self.created_at,
             to,
             cc,
         })
@@ -204,7 +204,7 @@ impl IntoObject for Account {
                 owner: user_url,
                 public_key_pem: self.public_key,
             },
-            published: self.created_at.into(),
+            published: self.created_at,
         })
     }
 }

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -143,7 +143,7 @@ impl IntoObject for Post {
             media_type: None,
             attachment,
             tag,
-            published: self.created_at,
+            published: self.created_at.into(),
             to,
             cc,
         })
@@ -204,7 +204,7 @@ impl IntoObject for Account {
                 owner: user_url,
                 public_key_pem: self.public_key,
             },
-            published: self.created_at,
+            published: self.created_at.into(),
         })
     }
 }

--- a/kitsune/src/mapping/mastodon/mod.rs
+++ b/kitsune/src/mapping/mastodon/mod.rs
@@ -63,17 +63,17 @@ pub struct MastodonMapper {
         field(
             type = "Option<PostEventConsumer>",
             build = "CacheInvalidationActor::builder()
-                        .cache(
-                            self.mastodon_cache
-                                .clone()
-                                .ok_or(MastodonMapperBuilderError::UninitializedField(\"mastodon_cache\"))?
-                        )
-                        .event_consumer(
-                            self._cache_invalidator
-                                .ok_or(MastodonMapperBuilderError::UninitializedField(\"cache_invalidator\"))?
-                        )
-                        .build()
-                        .spawn();",
+                .cache(
+                    self.mastodon_cache
+                        .clone()
+                        .ok_or(MastodonMapperBuilderError::UninitializedField(\"mastodon_cache\"))?
+                )
+                .event_consumer(
+                    self._cache_invalidator
+                        .ok_or(MastodonMapperBuilderError::UninitializedField(\"cache_invalidator\"))?
+                )
+                .build()
+                .spawn();",
         ),
         setter(name = "cache_invalidator", strip_option)
     )]

--- a/kitsune/src/mapping/mastodon/sealed.rs
+++ b/kitsune/src/mapping/mastodon/sealed.rs
@@ -113,7 +113,7 @@ impl IntoMastodon for DbAccount {
             group: self.actor_type.is_group(),
             username: self.username,
             display_name: self.display_name.unwrap_or_default(),
-            created_at: self.created_at,
+            created_at: self.created_at.into(),
             locked: self.locked,
             note: self.note.unwrap_or_default(),
             url: self.url,
@@ -387,7 +387,7 @@ impl IntoMastodon for DbPost {
 
         Ok(Status {
             id: self.id,
-            created_at: self.created_at,
+            created_at: self.created_at.into(),
             in_reply_to_account_id: None,
             in_reply_to_id: self.in_reply_to_id,
             sensitive: self.is_sensitive,

--- a/kitsune/src/mapping/mastodon/sealed.rs
+++ b/kitsune/src/mapping/mastodon/sealed.rs
@@ -113,7 +113,7 @@ impl IntoMastodon for DbAccount {
             group: self.actor_type.is_group(),
             username: self.username,
             display_name: self.display_name.unwrap_or_default(),
-            created_at: self.created_at.into(),
+            created_at: self.created_at,
             locked: self.locked,
             note: self.note.unwrap_or_default(),
             url: self.url,
@@ -387,7 +387,7 @@ impl IntoMastodon for DbPost {
 
         Ok(Status {
             id: self.id,
-            created_at: self.created_at.into(),
+            created_at: self.created_at,
             in_reply_to_account_id: None,
             in_reply_to_id: self.in_reply_to_id,
             sensitive: self.is_sensitive,

--- a/kitsune/src/service/account.rs
+++ b/kitsune/src/service/account.rs
@@ -22,6 +22,7 @@ use diesel::{
 };
 use diesel_async::RunQueryDsl;
 use futures_util::{Stream, TryStreamExt};
+use iso8601_timestamp::Timestamp;
 use kitsune_db::{
     model::{
         account::{Account, UpdateAccount},
@@ -33,7 +34,6 @@ use kitsune_db::{
     schema::{accounts, accounts_follows, posts},
     PgPool,
 };
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -158,7 +158,7 @@ impl AccountService {
         };
 
         if account.local && !account.locked {
-            follow_model.approved_at = Some(OffsetDateTime::now_utc());
+            follow_model.approved_at = Some(Timestamp::now_utc());
         }
 
         let follow_id = diesel::insert_into(accounts_follows::table)

--- a/kitsune/src/service/instance.rs
+++ b/kitsune/src/service/instance.rs
@@ -5,16 +5,16 @@ use kitsune_db::{
     schema::{accounts, posts, users},
     PgPool,
 };
-use std::sync::Arc;
+use smol_str::SmolStr;
 use typed_builder::TypedBuilder;
 
 #[derive(Clone, TypedBuilder)]
 pub struct InstanceService {
     db_conn: PgPool,
     #[builder(setter(into))]
-    name: Arc<str>,
+    name: SmolStr,
     #[builder(setter(into))]
-    description: Arc<str>,
+    description: SmolStr,
     character_limit: usize,
 }
 

--- a/kitsune/src/service/job.rs
+++ b/kitsune/src/service/job.rs
@@ -1,12 +1,12 @@
 use crate::{error::Result, job::Job};
 use diesel_async::RunQueryDsl;
+use iso8601_timestamp::Timestamp;
 use kitsune_db::{
     json::Json,
     model::job::{JobState, NewJob},
     schema::jobs,
     PgPool,
 };
-use time::OffsetDateTime;
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -14,7 +14,7 @@ use uuid::Uuid;
 pub struct Enqueue<T> {
     job: T,
     #[builder(default, setter(strip_option))]
-    run_at: Option<OffsetDateTime>,
+    run_at: Option<Timestamp>,
 }
 
 #[derive(Clone, TypedBuilder)]
@@ -33,7 +33,7 @@ impl JobService {
                 id: Uuid::now_v7(),
                 state: JobState::Queued,
                 context: Json(Job::from(enqueue.job)),
-                run_at: enqueue.run_at.unwrap_or_else(OffsetDateTime::now_utc),
+                run_at: enqueue.run_at.unwrap_or_else(Timestamp::now_utc),
             })
             .on_conflict_do_nothing()
             .execute(&mut db_conn)

--- a/kitsune/src/service/job.rs
+++ b/kitsune/src/service/job.rs
@@ -1,6 +1,7 @@
 use crate::{error::Result, job::Job};
 use diesel_async::RunQueryDsl;
 use kitsune_db::{
+    json::Json,
     model::job::{JobState, NewJob},
     schema::jobs,
     PgPool,
@@ -24,18 +25,17 @@ pub struct JobService {
 impl JobService {
     pub async fn enqueue<T>(&self, enqueue: Enqueue<T>) -> Result<()>
     where
-        T: Into<Job>,
+        Job: From<T>,
     {
-        let context = serde_json::to_value(enqueue.job.into())?;
-
         let mut db_conn = self.db_conn.get().await?;
         diesel::insert_into(jobs::table)
             .values(NewJob {
                 id: Uuid::now_v7(),
                 state: JobState::Queued,
-                context,
+                context: Json(Job::from(enqueue.job)),
                 run_at: enqueue.run_at.unwrap_or_else(OffsetDateTime::now_utc),
             })
+            .on_conflict_do_nothing()
             .execute(&mut db_conn)
             .await?;
 

--- a/kitsune/src/service/oauth2/authorizer.rs
+++ b/kitsune/src/service/oauth2/authorizer.rs
@@ -1,4 +1,4 @@
-use super::{chrono_to_time, time_to_chrono};
+use super::{chrono_to_timestamp, timestamp_to_chrono};
 use crate::util::generate_secret;
 use async_trait::async_trait;
 use diesel::{OptionalExtension, QueryDsl};
@@ -22,7 +22,7 @@ impl Authorizer for OAuthAuthorizer {
         let application_id = grant.client_id.parse().map_err(|_| ())?;
         let user_id = grant.owner_id.parse().map_err(|_| ())?;
         let scopes = grant.scope.to_string();
-        let expires_at = chrono_to_time(grant.until);
+        let expires_at = chrono_to_timestamp(grant.until);
 
         let mut db_conn = self.db_pool.get().await.map_err(|_| ())?;
         diesel::insert_into(oauth2_authorization_codes::table)
@@ -58,7 +58,7 @@ impl Authorizer for OAuthAuthorizer {
                 client_id: code.application_id.to_string(),
                 scope,
                 redirect_uri,
-                until: time_to_chrono(code.expires_at),
+                until: timestamp_to_chrono(code.expires_at),
                 extensions: Extensions::default(),
             }
         });

--- a/kitsune/src/service/oauth2/issuer.rs
+++ b/kitsune/src/service/oauth2/issuer.rs
@@ -1,4 +1,4 @@
-use super::{chrono_to_time, time_to_chrono};
+use super::{chrono_to_timestamp, timestamp_to_chrono};
 use crate::{error::Error, util::generate_secret};
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
@@ -26,7 +26,7 @@ impl Issuer for OAuthIssuer {
         let application_id = grant.client_id.parse().map_err(|_| ())?;
         let user_id = grant.owner_id.parse().map_err(|_| ())?;
         let scopes = grant.scope.to_string();
-        let expires_at = chrono_to_time(grant.until);
+        let expires_at = chrono_to_timestamp(grant.until);
 
         let mut db_conn = self.db_pool.get().await.map_err(|_| ())?;
         let (access_token, refresh_token) = db_conn
@@ -88,7 +88,7 @@ impl Issuer for OAuthIssuer {
                             token: generate_secret().as_str(),
                             application_id: access_token.application_id,
                             scopes: access_token.scopes.as_str(),
-                            expires_at: chrono_to_time(grant.until),
+                            expires_at: chrono_to_timestamp(grant.until),
                         })
                         .get_result::<oauth2::AccessToken>(tx)
                         .await?;
@@ -112,7 +112,7 @@ impl Issuer for OAuthIssuer {
         Ok(RefreshedToken {
             token: access_token.token,
             refresh: Some(refresh_token.token),
-            until: time_to_chrono(access_token.expires_at),
+            until: timestamp_to_chrono(access_token.expires_at),
             token_type: TokenType::Bearer,
         })
     }
@@ -131,7 +131,7 @@ impl Issuer for OAuthIssuer {
         let oauth_data = oauth_data.map(|(access_token, app)| {
             let scope = app.scopes.parse().unwrap();
             let redirect_uri = app.redirect_uri.parse().unwrap();
-            let until = time_to_chrono(access_token.expires_at);
+            let until = timestamp_to_chrono(access_token.expires_at);
 
             Grant {
                 owner_id: access_token

--- a/kitsune/src/service/url.rs
+++ b/kitsune/src/service/url.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use smol_str::SmolStr;
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -9,9 +9,9 @@ use uuid::Uuid;
 #[derive(Clone, TypedBuilder)]
 pub struct UrlService {
     #[builder(setter(into))]
-    scheme: Arc<str>,
+    scheme: SmolStr,
     #[builder(setter(into))]
-    domain: Arc<str>,
+    domain: SmolStr,
 }
 
 impl UrlService {

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -2,7 +2,6 @@ use crate::state::Zustand;
 use iso8601_timestamp::Timestamp;
 use kitsune_db::model::{account::Account, oauth2::access_token::AccessToken, post::Visibility};
 use kitsune_type::ap::PUBLIC_IDENTIFIER;
-use time::OffsetDateTime;
 use uuid::Uuid;
 
 #[inline]
@@ -31,7 +30,7 @@ pub trait AccessTokenTtl {
 impl AccessTokenTtl for AccessToken {
     #[inline]
     fn ttl(&self) -> time::Duration {
-        self.expires_at - OffsetDateTime::now_utc()
+        *self.expires_at - *Timestamp::now_utc()
     }
 }
 

--- a/kitsune/src/util.rs
+++ b/kitsune/src/util.rs
@@ -1,14 +1,20 @@
 use crate::state::Zustand;
+use base64_simd::AsOut;
+use hex_simd::AsciiCase;
 use iso8601_timestamp::Timestamp;
 use kitsune_db::model::{account::Account, oauth2::access_token::AccessToken, post::Visibility};
 use kitsune_type::ap::PUBLIC_IDENTIFIER;
 use uuid::Uuid;
 
+const TOKEN_LENGTH: usize = 32;
+
 #[inline]
 #[must_use]
 pub fn generate_secret() -> String {
-    let token_data: [u8; 32] = rand::random();
-    hex::encode(token_data)
+    let token_data: [u8; TOKEN_LENGTH] = rand::random();
+    let mut buf = [0_u8; TOKEN_LENGTH * 2];
+    (*hex_simd::encode_as_str(&token_data, buf.as_mut_slice().as_out(), AsciiCase::Lower))
+        .to_string()
 }
 
 #[inline]

--- a/post-process/Cargo.toml
+++ b/post-process/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 futures-util = "0.3.28"
-pest = "2.6.0"
-pest_derive = "2.6.0"
+pest = "2.6.1"
+pest_derive = "2.6.1"
 
 [dev-dependencies]
 insta = { version = "1.29.0", features = ["glob"] }


### PR DESCRIPTION
- Use `iso8601_timestamp` for fast timestamp de-/serialisation
- Use `simd_json` for parsing JSON documents fetched over the network
- Use an own wrapper around the `uuid` crate which utilises SIMD to quickly parse and format UUIDs
- Use `base64-simd` to quickly encode and decode data using SIMD
- Use `hex-simd` to quickly encode and decode data using SIMD
- Set `codegen-units` to 1