### PR TITLE
Add `target-cpu=native` to the RUSTFLAGS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,13 @@
 [build]
 rustdocflags = ["--document-private-items"]
-rustflags = ["--cfg", "uuid_unstable", "-C", "target-feature=+aes"]
+rustflags = [
+    "--cfg",
+    "uuid_unstable",
+    "-C",
+    "target-feature=+aes",
+    "-C",
+    "target-cpu=native",   # This probably isn't good, could lead to some weird issues but better than end-users having to struggle with arcane `simd-json` errors
+]
 
 [registries.crates-io]
 protocol = "sparse"


### PR DESCRIPTION
This could potentially lead to some weird compilation mismatches if the CPU of the machine compiling the code differs from the CPU running the machine, but I'll take my chances here.

Better have working builds for most end-users for now than broken builds for everyone