### PR TITLE
Add middleware for handling JSON to OAuth endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3684,6 +3684,7 @@ dependencies = [
  "rsa 0.9.2",
  "serde",
  "serde_dhall",
+ "serde_urlencoded",
  "serial_test",
  "sha2",
  "simd-json",

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -83,6 +83,7 @@ redis = "0.23.0"
 rsa = "0.9.2"
 serde = { version = "1.0.167", features = ["derive"] }
 serde_dhall = { version = "0.12.1", default-features = false }
+serde_urlencoded = "0.7.1"
 sha2 = "0.10.7"
 simd-json = "0.10.3"
 smol_str = "0.2.0"

--- a/kitsune/config/types/instance.dhall
+++ b/kitsune/config/types/instance.dhall
@@ -3,7 +3,6 @@ let FederationFilter = ./federation_filter.dhall
 in  { name : Text
     , description : Text
     , character_limit : Natural
-    , email_confirmation : Bool
     , registrations_open : Bool
     , federation_filter : FederationFilter
     }

--- a/kitsune/src/config.rs
+++ b/kitsune/src/config.rs
@@ -44,7 +44,6 @@ pub struct InstanceConfiguration {
     pub name: SmolStr,
     pub description: SmolStr,
     pub character_limit: usize,
-    pub email_confirmation: bool,
     pub federation_filter: FederationFilterConfiguration,
     pub registrations_open: bool,
 }

--- a/kitsune/src/http/handler/oauth/token.rs
+++ b/kitsune/src/http/handler/oauth/token.rs
@@ -23,10 +23,12 @@ pub async fn post(
     match grant_type.as_ref() {
         "authorization_code" => {
             let mut flow = AccessTokenFlow::prepare(oauth_endpoint)?;
+            flow.allow_credentials_in_body(true);
             AccessTokenFlow::execute(&mut flow, oauth_req).await
         }
         "client_credentials" => {
             let mut flow = ClientCredentialsFlow::prepare(oauth_endpoint)?;
+            flow.allow_credentials_in_body(true);
             ClientCredentialsFlow::execute(&mut flow, oauth_req).await
         }
         "refresh_token" => {

--- a/kitsune/src/http/middleware.rs
+++ b/kitsune/src/http/middleware.rs
@@ -1,0 +1,50 @@
+use axum::{
+    middleware::Next,
+    response::{IntoResponse, Response},
+    RequestExt,
+};
+use bytes::Buf;
+use headers::{ContentType, HeaderMapExt};
+use http::{Request, StatusCode};
+use hyper::Body;
+use simd_json::OwnedValue;
+
+pub async fn json_to_urlencoded(req: Request<Body>, next: Next<Body>) -> Response {
+    if req.headers().typed_get::<ContentType>() != Some(ContentType::json()) {
+        return next.run(req).await;
+    }
+
+    let Ok(req) = req.with_limited_body() else {
+        panic!("[Bug] Body is not limited. Please fix IMMEDIATELY! (annoy the devs)");
+    };
+    let (parts, body) = req.into_parts();
+
+    let json_value = match hyper::body::to_bytes(body)
+        .await
+        .map(|bytes| simd_json::from_reader::<_, OwnedValue>(bytes.reader()))
+    {
+        Ok(Ok(value)) => value,
+        Ok(Err(error)) => {
+            error!(?error, "failed to deserialise json body");
+            return (StatusCode::BAD_REQUEST, error.to_string()).into_response();
+        }
+        Err(error) => {
+            error!(?error, "failed to buffer body into memory");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let body = match serde_urlencoded::to_string(json_value) {
+        Ok(reencoded_body) => Body::from(reencoded_body),
+        Err(error) => {
+            error!(?error, "failed to reencode json body into urlencoded");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let mut req = Request::from_parts(parts, body);
+    req.headers_mut()
+        .typed_insert(ContentType::form_url_encoded());
+
+    next.run(req).await
+}

--- a/kitsune/src/http/middleware.rs
+++ b/kitsune/src/http/middleware.rs
@@ -9,6 +9,9 @@ use http::{Request, StatusCode};
 use hyper::Body;
 use simd_json::OwnedValue;
 
+/// Some clients send their OAuth credentials as JSON payloads. This against the OAuth2 RFC but alas, we want high compatibility with Mastodon clients
+///
+/// This middleware deserialises the body into its DOM representation if the header "Content-Type" is set to "application/json" and reencodes it into the URL-encoded version
 pub async fn json_to_urlencoded(req: Request<Body>, next: Next<Body>) -> Response {
     if req.headers().typed_get::<ContentType>() != Some(ContentType::json()) {
         return next.run(req).await;

--- a/kitsune/src/http/mod.rs
+++ b/kitsune/src/http/mod.rs
@@ -19,6 +19,7 @@ mod extractor;
 #[cfg(feature = "graphql-api")]
 mod graphql;
 mod handler;
+mod middleware;
 mod openapi;
 mod page;
 mod responder;
@@ -38,7 +39,10 @@ pub fn create_router(state: Zustand, server_config: &ServerConfiguration) -> Rou
         .nest("/confirm-account", confirm_account::routes())
         .nest("/media", media::routes())
         .nest("/nodeinfo", nodeinfo::routes())
-        .nest("/oauth", oauth::routes())
+        .nest(
+            "/oauth",
+            oauth::routes().layer(axum::middleware::from_fn(middleware::json_to_urlencoded)),
+        )
         .nest("/posts", posts::routes())
         .nest("/users", users::routes())
         .nest("/.well-known", well_known::routes())


### PR DESCRIPTION
Some clients send their OAuth credentials as JSON payloads. This against the OAuth2 RFC but alas, we want high compatibility with Mastodon clients.  

This middleware deserialises the body into its DOM representation if the header "Content-Type" is set to "application/json" and reencodes it into the URL-encoded version