### PR TITLE
Add nixos service module to the flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -119,5 +119,15 @@
           };
         };
       }
-    );
+    ) // {
+      overlays = rec {
+        default = kitsune;
+        kitsune = (import ./overlay.nix self);
+      };
+
+      nixosModules = rec {
+        default = kitsune;
+        kitsune = (import ./module.nix);
+      };
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -23,9 +23,9 @@
           zlib
         ];
         cargoConfig = builtins.fromTOML (builtins.readFile ./.cargo/config.toml);  # TODO: Set the target CPU conditionally
-        cargoToml = builtins.fromTOML (builtins.readFile ./kitsune/Cargo.toml);
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         basePackage = {
-          inherit (cargoToml.package) version;
+          inherit (cargoToml.workspace.package) version;
 
           meta = {
             description = "ActivityPub-federated microblogging";

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,12 @@
             allowBuiltinFetchGit = true;
           };
 
-          src = pkgs.lib.cleanSource ./.;
+          src = pkgs.lib.cleanSourceWith {
+            src = pkgs.lib.cleanSource ./.;
+            filter = name: type:
+              let baseName = baseNameOf (toString name);
+              in !(baseName == "flake.lock" || pkgs.lib.hasSuffix ".nix" baseName);
+          };
           nativeBuildInputs = baseDependencies;
 
           PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig"; # Not sure why this is broken but it is

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,135 @@
+{ config, lib, pkgs, ... }:
+let
+  inherit (lib) types mkEnableOption mkOption;
+  inherit (builtins) toJSON;
+  cfg = config.services.kitsune;
+  configFile = pkgs.writeText "config.dhall" ''
+    let types = ${cfg.packages.service}/config/types.dhall
+    in    { cache =
+                types.Cache.Redis { redis_url = "redis+unix:///run/redis-kitsune-cache/redis.sock" }
+              : types.Cache
+          , database =
+                { url = "postgres://kitsune:kitsune@localhost/kitsune", max_connections = 20 }
+              : types.Database
+          , email = None types.Email
+          , embed = None types.Embed
+          , instance =
+                { name = ${toJSON cfg.name}
+                , description = ${toJSON cfg.description}
+                , character_limit = 5000
+                , federation_filter =
+                      types.FederationFilter.Deny { domains = [] : List Text }
+                    : types.FederationFilter
+                , registrations_open = ${if cfg.registrationsOpen then "True" else "False"}
+                }
+              : types.Instance
+          , job_queue = { redis_url = "redis+unix:///run/redis-kitsune-jobqueue/redis.sock" } : types.JobQueue
+          , messaging = types.Messaging.InProcess
+          , server =
+                { frontend_dir = "${cfg.packages.service}/kitsune-fe"
+                , job_workers = 20
+                , max_upload_size = 5 * 1024 * 1024
+                , media_proxy_enabled = False
+                , oidc = None types.Oidc
+                , port = 5000
+                , prometheus_port = 9000
+                , request_timeout_sec = 60
+                }
+              : types.Server
+          , search = types.Search.Sql
+          , storage = types.Storage.Fs { upload_dir = ${toJSON "${cfg.dataDir}/uploads"} } : types.Storage
+          , url = { scheme = ${toJSON cfg.url.scheme}, domain = ${toJSON cfg.url.domain} } : types.Url
+          }
+        : types.Config
+  '';
+in {
+  options = {
+    services.kitsune = {
+      enable = mkEnableOption ''
+        Kitsune: an open-souce social media server utilising the ActivityPub protocol.
+      '';
+
+      packages = {
+        service = mkOption {
+          type = types.package;
+          default = pkgs.kitsune;
+        };
+        cli = mkOption {
+          type = types.package;
+          default = pkgs.kitsune-cli;
+        };
+      };
+
+      dataDir = mkOption {
+        type = types.str;
+        default = "/var/lib/kitsune";
+        readOnly = true;
+      };
+
+      name = mkOption {
+        type = types.str;
+      };
+
+      description = mkOption {
+        type = types.str;
+      };
+
+      registrationsOpen = mkOption {
+        type = types.bool;
+      };
+
+      url = {
+        scheme = mkOption {
+          type = types.str;
+        };
+
+        domain = mkOption {
+          type = types.str;
+        };
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.packages.cli ];
+
+    users.users.kitsune = {
+      isSystemUser = true;
+      group = "kitsune";
+      extraGroups = [
+        "redis-kitsune-cache"
+        "redis-kitsune-jobqueue"
+      ];
+      home = cfg.dataDir;
+    };
+
+    users.groups.kitsune = { };
+
+    services.redis = {
+      servers."kitsune-cache".enable = true;
+      servers."kitsune-jobqueue".enable = true;
+    };
+
+    systemd.services.kitsune = {
+      wantedBy = [ "multi-user.target" ];
+      after = [
+        "network.target"
+        "postgresql.service"
+        "redis-kitsune-cache.service"
+        "redis-kitsune-jobqueue.service"
+      ];
+
+      wants = [ "network-online.target" ];
+
+      serviceConfig = {
+        User = "kitsune";
+        Group = "kitsune";
+        Restart = "always";
+        # Necessary because /public routes are served cwd relative
+        WorkingDirectory = "${cfg.packages.service}";
+        ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p ${cfg.dataDir}/uploads";
+        ExecStart = "${cfg.packages.service}/bin/kitsune ${configFile}";
+      };
+    };
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,18 @@
+self: final: prev:
+let
+  packages = self.packages.${prev.stdenv.targetPlatform.system};
+in {
+  kitsune = prev.stdenv.mkDerivation {
+    inherit (packages.main) name version meta src;
+
+    installPhase = ''
+      mkdir -p $out
+      cp -R ${packages.main}/bin $out
+      cp -R ${packages.main.src}/kitsune/config $out
+      cp -R ${packages.main.src}/public $out
+      cp -R ${packages.frontend}/dist $out/kitsune-fe
+    '';
+  };
+
+  kitsune-cli = packages.cli;
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -8,7 +8,6 @@ in {
     installPhase = ''
       mkdir -p $out
       cp -R ${packages.main}/bin $out
-      cp -R ${packages.main.src}/kitsune/config $out
       cp -R ${packages.main.src}/public $out
       cp -R ${packages.frontend}/dist $out/kitsune-fe
     '';


### PR DESCRIPTION
I use `deploy-rs` for deploying my machines, this is how I use this module with it, with other ways to configure it's likely to be a little different:

Apply the overlay and module to the system before loading its configuration:
```nix
        kitsune-test = nixpkgs.lib.nixosSystem {
          system = "x86_64-linux";
          modules = [
            ({ ... }: { nixpkgs.overlays = [ kitsune.overlays.default ]; })
            kitsune.nixosModules.default
            kitsune-test/configuration.nix
          ];
        };
```

Configure postgres, kitsune, caddy:

```nix
  services.postgresql = {
    enable = true;
    initialScript = pkgs.writeText "kitsune-init.sql" ''
      CREATE ROLE "kitsune" WITH LOGIN PASSWORD 'kitsune';
      CREATE DATABASE "kitsune" WITH OWNER "kitsune"
        TEMPLATE template0
        LC_COLLATE = "C"
        LC_CTYPE = "C";
    '';
  };

  services.kitsune = {
    enable = true;
    config = {
      instance = {
        name = "Kitsune Test Instance";
        description = "A test of deploying kitsune to nixos";
        registrations-open = false;
      };
      url = {
        scheme = "https";
        domain = "kitsune-test.nemo157.com";
      };
    };
  };

  networking.firewall.allowedTCPPorts = [ 80 443 ];
  services.caddy = {
    enable = true;
    extraConfig = ''
      kitsune-test.example.org {
        reverse_proxy localhost:5000
      }
    '';
  };
```

I decided to hardcode using redis in the module for now, since it needs to do some extra configuration around systemd service dependencies and adding groups to access them.