### PR TITLE
Do not assume CPU support for aes instructions

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,8 +4,6 @@ rustflags = [
     "--cfg",
     "uuid_unstable",
     "-C",
-    "target-feature=+aes",
-    "-C",
     "target-cpu=native",   # This probably isn't good, could lead to some weird issues but better than end-users having to struggle with arcane `simd-json` errors
 ]
 


### PR DESCRIPTION
Because Intel Core i3 for example does not have them.