### PR TITLE
Build for x86-64-v3 in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-C debuginfo=0 -C target-cpu=native --cfg uuid_unstable"
+  RUSTFLAGS: "-C debuginfo=0 -C target-cpu=x86-64-v3 --cfg uuid_unstable"
 
 jobs:
   clippy:


### PR DESCRIPTION
There have been CI failures related to illegal instructions. My guess is that this is because we optimized builds for one very specific CPU in particular and the GitHub actions runners span over multiple different x86 CPU architectures.

This PR optimizes for `x86-64-v3` and no one specific CPU in particular which should hopefully prevent these `SIGILL`s from happening