### PR TITLE
Define a fallback value in the build scripts

### DIFF
--- a/kitsune-cli/build.rs
+++ b/kitsune-cli/build.rs
@@ -5,5 +5,5 @@ fn main() {
         .all_git()
         .git_sha(true)
         .emit_and_set()
-        .unwrap();
+        .unwrap_or_else(|_| println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown"));
 }

--- a/kitsune/build.rs
+++ b/kitsune/build.rs
@@ -7,5 +7,5 @@ fn main() {
         .all_git()
         .git_sha(true)
         .emit_and_set()
-        .unwrap();
+        .unwrap_or_else(|_| println!("cargo:rustc-env=VERGEN_GIT_SHA=unknown"));
 }


### PR DESCRIPTION
Nix doesn't copy the `.git` directory into the build environment and therefore the build scripts can't retrieve the Git commit.

For these cases we define a fallback value in the build scripts and set the `VERGEN_GIT_SHA` value to `unknown`