### PR TITLE
Layered docker images and improved docker-compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 **/node_modules
 target/
-kitsune-fe/
 Dockerfile.dev
 Dockerfile.prod

--- a/config.docker.toml
+++ b/config.docker.toml
@@ -1,0 +1,42 @@
+[cache]
+type = "in-memory"
+
+[database]
+url = "postgres://kitsune:password@db/kitsune"
+max-connections = 20
+
+[instance]
+name = "Kitsune"
+description = "https://www.youtube.com/watch?v=6lnnPnr_0SU"
+character-limit = 5000
+registrations-open = true
+
+[instance.federation-filter]
+type = "deny"
+domains = []
+
+[job-queue]
+redis-url = "redis://redis"
+num-workers = 20
+
+[messaging]
+type = "in-process"
+
+[server]
+frontend-dir = "./kitsune-fe/dist"
+max-upload-size = 5242880          # 5MB
+media-proxy-enabled = false
+port = 5000
+prometheus-port = 9000
+request-timeout-secs = 60
+
+[search]
+type = "sql"
+
+[storage]
+type = "fs"
+upload-dir = "./uploads"
+
+[url]
+scheme = "http"
+domain = "localhost:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.1'
 services:
   backend:
     image: kitsune
+    command: 
+      - config.toml
     ports:
       - "5000:5000"
     networks:
@@ -18,6 +20,13 @@ services:
       SEARCH_SERVERS: http://backend-search:8080
     volumes:
       - upload-data:/app/uploads
+      - type: bind
+        source: ${KITSUNE_CONFIG}
+        target: /app/config.toml
+        read_only: true
+    depends_on:
+      - db
+      - redis
 
   backend-search:
     image: kitsune-search

--- a/kitsune-search-server/Dockerfile.dev
+++ b/kitsune-search-server/Dockerfile.dev
@@ -1,11 +1,20 @@
-FROM rust:1-alpine AS build
+FROM rust:1-alpine as base
 RUN rustup default nightly
-RUN apk add --no-cache musl-dev
-COPY . /build
-WORKDIR /build
-RUN cargo -Z sparse-registry build
+RUN apk add --no-cache musl-dev make protobuf-dev
+RUN cargo install cargo-chef
+WORKDIR app
+
+FROM base as planner 
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM base AS build
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --recipe-path recipe.json
+COPY . .
+RUN cargo build --bin kitsune-search-server
 
 FROM alpine:latest
-WORKDIR /app
-COPY --from=build /build/target/debug/kitsune-search .
-CMD ["/app/kitsune-search"]
+WORKDIR app
+COPY --from=build /app/target/debug/kitsune-search-server .
+ENTRYPOINT ["./kitsune-search-server"]

--- a/kitsune-search-server/Dockerfile.dev
+++ b/kitsune-search-server/Dockerfile.dev
@@ -1,10 +1,10 @@
-FROM rust:1-alpine as base
+FROM rust:1-alpine AS base
 RUN rustup default nightly
 RUN apk add --no-cache musl-dev make protobuf-dev
 RUN cargo install cargo-chef
 WORKDIR app
 
-FROM base as planner 
+FROM base AS planner 
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 

--- a/kitsune-search-server/Dockerfile.dev
+++ b/kitsune-search-server/Dockerfile.dev
@@ -1,5 +1,4 @@
 FROM rust:1-alpine AS base
-RUN rustup default nightly
 RUN apk add --no-cache musl-dev make protobuf-dev
 RUN cargo install cargo-chef
 WORKDIR app

--- a/kitsune-search-server/Dockerfile.prod
+++ b/kitsune-search-server/Dockerfile.prod
@@ -1,11 +1,20 @@
-FROM rust:1-alpine AS build
+FROM rust:1-alpine as base
 RUN rustup default nightly
-RUN apk add --no-cache musl-dev
-COPY . /build
-WORKDIR /build
-RUN cargo -Z sparse-registry build --release
+RUN apk add --no-cache musl-dev make protobuf-dev
+RUN cargo install cargo-chef
+WORKDIR app
+
+FROM base as planner 
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM base AS build
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin kitsune-search-server
 
 FROM alpine:latest
-WORKDIR /app
-COPY --from=build /build/target/release/kitsune-search .
-CMD ["/app/kitsune-search"]
+WORKDIR app
+COPY --from=build /app/target/release/kitsune-search-server .
+ENTRYPOINT ["./kitsune-search-server"]

--- a/kitsune-search-server/Dockerfile.prod
+++ b/kitsune-search-server/Dockerfile.prod
@@ -1,10 +1,10 @@
-FROM rust:1-alpine as base
+FROM rust:1-alpine AS base
 RUN rustup default nightly
 RUN apk add --no-cache musl-dev make protobuf-dev
 RUN cargo install cargo-chef
 WORKDIR app
 
-FROM base as planner 
+FROM base AS planner 
 COPY . .
 RUN cargo chef prepare --recipe-path recipe.json
 

--- a/kitsune-search-server/Dockerfile.prod
+++ b/kitsune-search-server/Dockerfile.prod
@@ -1,5 +1,4 @@
 FROM rust:1-alpine AS base
-RUN rustup default nightly
 RUN apk add --no-cache musl-dev make protobuf-dev
 RUN cargo install cargo-chef
 WORKDIR app

--- a/kitsune/Dockerfile.dev
+++ b/kitsune/Dockerfile.dev
@@ -1,11 +1,27 @@
-FROM rust:1-alpine AS build
+FROM rust:1-alpine AS base
 RUN rustup default nightly
-RUN apk add --no-cache musl-dev
-COPY . /build
-WORKDIR /build
-RUN cargo -Z sparse-registry build
+RUN apk add --no-cache musl-dev make protobuf-dev
+RUN cargo install cargo-chef
+WORKDIR app
+
+FROM base AS planner 
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM base AS build
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --recipe-path recipe.json
+COPY . .
+RUN cargo build --bin kitsune
+
+FROM base AS frontend
+RUN apk add --no-cache yarn
+COPY kitsune-fe .
+WORKDIR kitsune-fe
+RUN yarn install && yarn build
 
 FROM alpine:latest
-WORKDIR /app
-COPY --from=build /build/target/debug/kitsune .
-CMD ["/app/kitsune"]
+WORKDIR app
+COPY --from=build /app/target/debug/kitsune .
+COPY --from=frontend /app kitsune-fe
+ENTRYPOINT ["./kitsune"]

--- a/kitsune/Dockerfile.dev
+++ b/kitsune/Dockerfile.dev
@@ -1,5 +1,4 @@
 FROM rust:1-alpine AS base
-RUN rustup default nightly
 RUN apk add --no-cache musl-dev make protobuf-dev
 RUN cargo install cargo-chef
 WORKDIR app

--- a/kitsune/Dockerfile.prod
+++ b/kitsune/Dockerfile.prod
@@ -1,11 +1,27 @@
-FROM rust:1-alpine AS build
+FROM rust:1-alpine AS base
 RUN rustup default nightly
-RUN apk add --no-cache musl-dev
-COPY . /build
-WORKDIR /build
-RUN cargo -Z sparse-registry build --release
+RUN apk add --no-cache musl-dev make protobuf-dev
+RUN cargo install cargo-chef
+WORKDIR app
+
+FROM base AS planner 
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM base AS build
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin kitsune
+
+FROM base AS frontend
+RUN apk add --no-cache yarn
+COPY kitsune-fe .
+WORKDIR kitsune-fe
+RUN yarn install && yarn build
 
 FROM alpine:latest
-WORKDIR /app
-COPY --from=build /build/target/release/kitsune .
-CMD ["/app/kitsune"]
+WORKDIR app
+COPY --from=build /app/target/release/kitsune .
+COPY --from=frontend /app kitsune-fe
+ENTRYPOINT ["./kitsune"]

--- a/kitsune/Dockerfile.prod
+++ b/kitsune/Dockerfile.prod
@@ -1,5 +1,4 @@
 FROM rust:1-alpine AS base
-RUN rustup default nightly
 RUN apk add --no-cache musl-dev make protobuf-dev
 RUN cargo install cargo-chef
 WORKDIR app


### PR DESCRIPTION
Changes include:
- multi-layered build process for docker:
  - use cargo chef to gather dependencies into a recipe
  - use cargo chef to install said dependencies
  - build kitsune
  - build frontend
  - include the app and frontend files in the final image
This makes it so only the project libraries and binaries are rebuilt after making changes, instead of the whole dependency tree speeding up the build process from around 15m to 3m and saving space.
- docker-compose can now receive the app config as a mounted readonly file, like so
`KITSUNE_CONFIG=/home/user/kitsune/config.docker.toml docker-compose up`
- I made kitsune depend on db and redis in the docker compose stack because otherwise it would sometimes panic if these components haven't properly initialized before the app started