### PR TITLE
Add `webfinger-domain` configuration

### DIFF
--- a/crates/kitsune-type/src/webfinger.rs
+++ b/crates/kitsune-type/src/webfinger.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-#[derive(Deserialize, Serialize, ToSchema)]
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
 pub struct Link {
     pub rel: String,
     pub r#type: Option<String>,

--- a/kitsune/src/config.rs
+++ b/kitsune/src/config.rs
@@ -52,6 +52,7 @@ pub enum FederationFilterConfiguration {
 pub struct InstanceConfiguration {
     pub name: SmolStr,
     pub description: SmolStr,
+    pub webfinger_domain: Option<SmolStr>,
     pub character_limit: usize,
     pub federation_filter: FederationFilterConfiguration,
     pub registrations_open: bool,

--- a/kitsune/src/http/graphql/query/instance.rs
+++ b/kitsune/src/http/graphql/query/instance.rs
@@ -16,7 +16,7 @@ impl InstanceQuery {
         let url_service = &state.service.url;
 
         let description = instance_service.description().into();
-        let domain = url_service.domain().into();
+        let domain = url_service.webfinger_domain().into();
         let local_post_count = instance_service.local_post_count().await?;
         let name = instance_service.name().into();
         let registrations_open = instance_service.registrations_open();

--- a/kitsune/src/http/handler/mastodon/api/v1/instance.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/instance.rs
@@ -26,7 +26,7 @@ async fn get(
     let domain_count = instance_service.known_instances().await?;
 
     Ok(Json(Instance {
-        uri: url_service.domain().into(),
+        uri: url_service.webfinger_domain().into(),
         title: instance_service.name().into(),
         short_description: instance_service.description().into(),
         description: String::new(),

--- a/kitsune/src/lib.rs
+++ b/kitsune/src/lib.rs
@@ -308,6 +308,7 @@ pub async fn initialise_state(
     let url_service = UrlService::builder()
         .scheme(config.url.scheme.as_str())
         .domain(config.url.domain.as_str())
+        .webfinger_domain(config.instance.webfinger_domain.clone())
         .build();
 
     let attachment_service = AttachmentService::builder()

--- a/kitsune/src/service/url.rs
+++ b/kitsune/src/service/url.rs
@@ -12,9 +12,16 @@ pub struct UrlService {
     scheme: SmolStr,
     #[builder(setter(into))]
     domain: SmolStr,
+    #[builder(default)]
+    webfinger_domain: Option<SmolStr>,
 }
 
 impl UrlService {
+    #[must_use]
+    pub fn acct_uri(&self, username: &str) -> String {
+        format!("acct:{username}@{}", self.webfinger_domain())
+    }
+
     #[must_use]
     pub fn base_url(&self) -> String {
         format!("{}://{}", self.scheme, self.domain)
@@ -93,5 +100,10 @@ impl UrlService {
     #[must_use]
     pub fn user_url(&self, user_id: Uuid) -> String {
         format!("{}/users/{user_id}", self.base_url())
+    }
+
+    #[must_use]
+    pub fn webfinger_domain(&self) -> &str {
+        self.webfinger_domain.as_ref().unwrap_or(&self.domain)
     }
 }


### PR DESCRIPTION
This adds ~~`instance.webfinger_domain`~~ `instance.webfinger-domain` configuration option to set a custom domain name for the `subject` of local WebFinger resources. See #285 for the background.

The configuration will look like the following:

```toml
[instance]
# ...
webfinger-domain = "example.com"

[url]
scheme = "https"
domain = "social.example.com"
```

This example will run the server at `social.example.com` and make the WebFinger handler resolve local actors as `acct:{username}@example.com` instead of `acct:{username}@social.example.com`.

`GET /api/v1/instance` of Mastodon API and its counterpart in GraphQL API is updated to use the new configuration value to make it align with Mastodon's implementation (though Mastodon doesn't provide a GraphQL API. But since the old value can trivially be known from the endpoint URL, I think the change makes sense for the GraphQL API as well).

## The name?

The configuration name is up for bikeshedding. There are few alternatives in my mind:

- `local-domain` (consistent with Mastodon, arguably the most popular implementaion. Might be confusing though)
- `webfinger-host`(might be more accurate since it may contain a port in addition to the domain, but is inconsistent with the existing `url.domain` config)
- `acct-domain` or `acct-host` (in reference to the `acct` field of Mastodon API)
- `display-domain` (adopted from [Takahē][takahe-doc-domains]. Personally I like it too because of consistency with the term "display name" for `@user` handle name)
- `account-domain` (adopted from [GoToSocial][gts-doc-split-domain])

[takahe-doc-domains]: <https://docs.jointakahe.org/en/stable/domains/>
[gts-doc-split-domain]: <https://docs.gotosocial.org/en/latest/advanced/host-account-domain/#configuration>

I chose the name `webfinger-domain` because it is consitent with `url.domain` and also helpfully reminds the administrator that it's about WebFinger, for which they need to set up an HTTP redirection at the pointed domain.