### PR TITLE
Wrapper around the Postgres connection pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3838,6 +3838,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "embed-sdk",
+ "futures-util",
  "http",
  "iso8601-timestamp",
  "kitsune-db",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,6 +3785,7 @@ name = "kitsune-cli"
 version = "0.0.1-pre.2"
 dependencies = [
  "clap",
+ "color-eyre",
  "diesel",
  "diesel-async",
  "dotenvy",
@@ -3838,7 +3839,6 @@ dependencies = [
  "diesel",
  "diesel-async",
  "embed-sdk",
- "futures-util",
  "http",
  "iso8601-timestamp",
  "kitsune-db",

--- a/crates/kitsune-db/src/lib.rs
+++ b/crates/kitsune-db/src/lib.rs
@@ -14,9 +14,13 @@ use diesel_async::{
 use diesel_migrations_async::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use tracing_log::LogTracer;
 
-pub use crate::error::{Error, Result};
+pub use crate::{
+    error::{Error, Result},
+    pool::PgPool,
+};
 
 mod error;
+mod pool;
 
 pub mod function;
 pub mod json;
@@ -27,7 +31,6 @@ pub mod post_permission_check;
 pub mod schema;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
-pub type PgPool = Pool<AsyncPgConnection>;
 
 /// Connect to the database and run any pending migrations
 pub async fn connect(conn_str: &str, max_pool_size: usize) -> Result<PgPool> {
@@ -52,5 +55,5 @@ pub async fn connect(conn_str: &str, max_pool_size: usize) -> Result<PgPool> {
     )
     .await?;
 
-    Ok(pool)
+    Ok(pool.into())
 }

--- a/crates/kitsune-db/src/lib.rs
+++ b/crates/kitsune-db/src/lib.rs
@@ -16,7 +16,7 @@ use tracing_log::LogTracer;
 
 pub use crate::{
     error::{Error, Result},
-    pool::PgPool,
+    pool::{PgPool, PoolError},
 };
 
 mod error;

--- a/crates/kitsune-db/src/pool.rs
+++ b/crates/kitsune-db/src/pool.rs
@@ -1,9 +1,19 @@
 use diesel_async::{
-    pooled_connection::deadpool::{Object, Pool, PoolError},
+    pooled_connection::deadpool::{Object, Pool, PoolError as DeadpoolError},
     scoped_futures::ScopedBoxFuture,
     AsyncConnection, AsyncPgConnection,
 };
 use std::future::Future;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum PoolError<E> {
+    #[error(transparent)]
+    Pool(#[from] DeadpoolError),
+
+    #[error("{0}")]
+    User(E),
+}
 
 #[derive(Clone)]
 pub struct PgPool {
@@ -12,31 +22,30 @@ pub struct PgPool {
 
 impl PgPool {
     /// Run the code inside a context with a database connection
-    pub async fn with_connection<F, Fut, T, E>(&self, func: F) -> Result<T, E>
+    pub async fn with_connection<F, Fut, T, E>(&self, func: F) -> Result<T, PoolError<E>>
     where
         // Yes, this is *technically* leaky since a user could just move the object out of the closure
         // Just don't. kthx.
         F: FnOnce(Object<AsyncPgConnection>) -> Fut,
         Fut: Future<Output = Result<T, E>>,
-        E: From<PoolError>,
     {
         let conn = self.inner.get().await?;
-        func(conn).await
+        func(conn).await.map_err(PoolError::User)
     }
 
     /// Run the code inside a context with a database transaction
-    pub async fn with_transaction<'a, R, E, F>(&self, func: F) -> Result<R, E>
+    pub async fn with_transaction<'a, R, E, F>(&self, func: F) -> Result<R, PoolError<E>>
     where
         F: for<'r> FnOnce(
                 &'r mut Object<AsyncPgConnection>,
             ) -> ScopedBoxFuture<'a, 'r, Result<R, E>>
             + Send
             + 'a,
-        E: From<diesel::result::Error> + From<PoolError> + Send + 'a,
+        E: From<diesel::result::Error> + Send + 'a,
         R: Send + 'a,
     {
         let mut conn = self.inner.get().await?;
-        conn.transaction(func).await
+        conn.transaction(func).await.map_err(PoolError::User)
     }
 }
 

--- a/crates/kitsune-db/src/pool.rs
+++ b/crates/kitsune-db/src/pool.rs
@@ -14,6 +14,8 @@ impl PgPool {
     /// Run the code inside a context with a database connection
     pub async fn with_connection<F, Fut, T, E>(&self, func: F) -> Result<T, E>
     where
+        // Yes, this is *technically* leaky since a user could just move the object out of the closure
+        // Just don't. kthx.
         F: FnOnce(Object<AsyncPgConnection>) -> Fut,
         Fut: Future<Output = Result<T, E>>,
         E: From<PoolError>,

--- a/crates/kitsune-db/src/pool.rs
+++ b/crates/kitsune-db/src/pool.rs
@@ -1,0 +1,45 @@
+use diesel_async::{
+    pooled_connection::deadpool::{Object, Pool, PoolError},
+    scoped_futures::ScopedBoxFuture,
+    AsyncConnection, AsyncPgConnection,
+};
+use std::future::Future;
+
+#[derive(Clone)]
+pub struct PgPool {
+    inner: Pool<AsyncPgConnection>,
+}
+
+impl PgPool {
+    /// Run the code inside a context with a database connection
+    pub async fn with_connection<F, Fut, T, E>(&self, func: F) -> Result<T, E>
+    where
+        F: FnOnce(Object<AsyncPgConnection>) -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+        E: From<PoolError>,
+    {
+        let conn = self.inner.get().await?;
+        func(conn).await
+    }
+
+    /// Run the code inside a context with a database transaction
+    pub async fn with_transaction<'a, R, E, F>(&self, func: F) -> Result<R, E>
+    where
+        F: for<'r> FnOnce(
+                &'r mut Object<AsyncPgConnection>,
+            ) -> ScopedBoxFuture<'a, 'r, Result<R, E>>
+            + Send
+            + 'a,
+        E: From<diesel::result::Error> + From<PoolError> + Send + 'a,
+        R: Send + 'a,
+    {
+        let mut conn = self.inner.get().await?;
+        conn.transaction(func).await
+    }
+}
+
+impl From<Pool<AsyncPgConnection>> for PgPool {
+    fn from(value: Pool<AsyncPgConnection>) -> Self {
+        Self { inner: value }
+    }
+}

--- a/crates/kitsune-db/src/pool.rs
+++ b/crates/kitsune-db/src/pool.rs
@@ -15,6 +15,14 @@ pub enum PoolError<E> {
     User(E),
 }
 
+/// Small wrapper around [`Pool<AsyncPgConnection>`]
+///
+/// The intent of this API is to encourage and make short-livel ownership of connections easier.
+/// With the traditional RAII guard based approach, it is rather hard (and/or ugly) to define clear scopes for connections
+/// (especially when they are used *a lot* throughout the code).
+///
+/// The API of this wrapper is based on closures, meaning you have no choice but to be aware of the scope.
+/// And the extra level of indentation this forces is supposed to coerce users to keep the scope as small as possible.
 #[derive(Clone)]
 pub struct PgPool {
     inner: Pool<AsyncPgConnection>,

--- a/crates/kitsune-embed/Cargo.toml
+++ b/crates/kitsune-embed/Cargo.toml
@@ -7,7 +7,6 @@ version.workspace = true
 diesel = "2.1.0"
 diesel-async = "0.3.2"
 embed-sdk = { git = "https://github.com/Lantern-chat/embed-service.git", rev = "a2b73a9b24163f20202c9b09857c29137d98708b" }
-futures-util = "0.3.28"
 http = "0.2.9"
 iso8601-timestamp = "0.2.11"
 kitsune-db = { path = "../kitsune-db" }

--- a/crates/kitsune-embed/Cargo.toml
+++ b/crates/kitsune-embed/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 diesel = "2.1.0"
 diesel-async = "0.3.2"
 embed-sdk = { git = "https://github.com/Lantern-chat/embed-service.git", rev = "a2b73a9b24163f20202c9b09857c29137d98708b" }
+futures-util = "0.3.28"
 http = "0.2.9"
 iso8601-timestamp = "0.2.11"
 kitsune-db = { path = "../kitsune-db" }

--- a/crates/kitsune-search/src/error.rs
+++ b/crates/kitsune-search/src/error.rs
@@ -20,3 +20,15 @@ pub enum Error {
     #[error(transparent)]
     TonicTransport(#[from] tonic::transport::Error),
 }
+
+impl<E> From<kitsune_db::PoolError<E>> for Error
+where
+    E: Into<Error>,
+{
+    fn from(value: kitsune_db::PoolError<E>) -> Self {
+        match value {
+            kitsune_db::PoolError::Pool(err) => err.into(),
+            kitsune_db::PoolError::User(err) => err.into(),
+        }
+    }
+}

--- a/crates/kitsune-search/src/sql.rs
+++ b/crates/kitsune-search/src/sql.rs
@@ -1,4 +1,4 @@
-use super::{Error, Result, SearchBackend, SearchIndex, SearchItem, SearchResult};
+use super::{Result, SearchBackend, SearchIndex, SearchItem, SearchResult};
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -21,8 +21,8 @@ pub struct SearchService {
 
 impl SearchService {
     #[must_use]
-    pub fn new(db_conn: PgPool) -> Self {
-        Self { db_pool: db_conn }
+    pub fn new(db_pool: PgPool) -> Self {
+        Self { db_pool }
     }
 }
 
@@ -81,7 +81,6 @@ impl SearchBackend for SearchService {
                             .map_ok(|id| SearchResult { id })
                             .try_collect()
                             .await
-                            .map_err(Error::from)
                     })
                     .await?;
 
@@ -115,7 +114,6 @@ impl SearchBackend for SearchService {
                             .map_ok(|id| SearchResult { id })
                             .try_collect()
                             .await
-                            .map_err(Error::from)
                     })
                     .await?;
 

--- a/kitsune-cli/Cargo.toml
+++ b/kitsune-cli/Cargo.toml
@@ -6,6 +6,7 @@ build = "build.rs"
 
 [dependencies]
 clap = { version = "4.3.23", features = ["derive"] }
+color-eyre = "0.6.2"
 diesel = "2.1.0"
 diesel-async = "0.3.2"
 dotenvy = "0.15.7"

--- a/kitsune-cli/src/main.rs
+++ b/kitsune-cli/src/main.rs
@@ -4,9 +4,7 @@
 
 use self::{config::Configuration, role::RoleSubcommand};
 use clap::{Parser, Subcommand};
-use std::error::Error;
-
-type Result<T, E = Box<dyn Error>> = std::result::Result<T, E>;
+use color_eyre::eyre::{self, Result};
 
 mod config;
 mod role;
@@ -28,6 +26,7 @@ struct App {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    color_eyre::install()?;
     dotenvy::dotenv().ok();
     tracing_subscriber::fmt::init();
 
@@ -41,7 +40,9 @@ async fn main() -> Result<()> {
                 AppSubcommand::Role(cmd) => self::role::handle(cmd, &mut db_conn).await?,
             }
 
-            Ok(())
+            Ok::<_, eyre::Report>(())
         })
-        .await
+        .await?;
+
+    Ok(())
 }

--- a/kitsune-cli/src/main.rs
+++ b/kitsune-cli/src/main.rs
@@ -33,12 +33,15 @@ async fn main() -> Result<()> {
 
     let config: Configuration = envy::from_env()?;
     let db_conn = kitsune_db::connect(&config.database_url, 1).await?;
-    let mut db_conn = db_conn.get().await?;
     let cmd = App::parse();
 
-    match cmd.subcommand {
-        AppSubcommand::Role(cmd) => self::role::handle(cmd, &mut db_conn).await?,
-    }
+    db_conn
+        .with_connection(|mut db_conn| async move {
+            match cmd.subcommand {
+                AppSubcommand::Role(cmd) => self::role::handle(cmd, &mut db_conn).await?,
+            }
 
-    Ok(())
+            Ok(())
+        })
+        .await
 }

--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -231,7 +231,7 @@ impl Fetcher {
 
         let post = self
             .db_pool
-            .with_connection(|db_conn| async move {
+            .with_connection(|mut db_conn| async move {
                 posts::table
                     .filter(posts::url.eq(url))
                     .select(Post::as_select())

--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -102,7 +102,6 @@ impl Fetcher {
                         .first(&mut db_conn)
                         .await
                         .optional()
-                        .map_err(Error::from)
                 })
                 .await?;
 
@@ -238,7 +237,6 @@ impl Fetcher {
                     .first(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Error::from)
             })
             .await?;
 
@@ -287,7 +285,6 @@ mod test {
     use core::convert::Infallible;
     use diesel::{QueryDsl, SelectableHelper};
     use diesel_async::RunQueryDsl;
-    use futures_util::future::TryFutureExt;
     use hyper::{Body, Request, Response};
     use kitsune_cache::NoopCache;
     use kitsune_db::{model::account::Account, schema::accounts};
@@ -370,7 +367,6 @@ mod test {
                         .find(note.account_id)
                         .select(Account::as_select())
                         .get_result::<Account>(&mut db_conn)
-                        .map_err(Error::from)
                 })
                 .await
                 .expect("Get author");

--- a/kitsune/src/activitypub/fetcher.rs
+++ b/kitsune/src/activitypub/fetcher.rs
@@ -10,7 +10,7 @@ use crate::{
 use async_recursion::async_recursion;
 use autometrics::autometrics;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
+use diesel_async::{scoped_futures::ScopedFutureExt, RunQueryDsl};
 use http::HeaderValue;
 use kitsune_cache::{ArcCache, CacheBackend};
 use kitsune_db::{
@@ -67,7 +67,7 @@ pub struct Fetcher {
             .build()
     )]
     client: Client,
-    db_conn: PgPool,
+    db_pool: PgPool,
     embed_client: Option<EmbedClient>,
     federation_filter: FederationFilterService,
     #[builder(setter(into))]
@@ -87,20 +87,26 @@ impl Fetcher {
     #[instrument(skip(self))]
     #[autometrics(track_concurrency)]
     pub async fn fetch_actor(&self, opts: FetchOptions<'_>) -> Result<Account> {
-        let mut db_conn = self.db_conn.get().await?;
         // Obviously we can't hit the cache nor the database if we wanna refetch the actor
         if !opts.refetch {
             if let Some(user) = self.user_cache.get(opts.url).await? {
                 return Ok(user);
             }
 
-            if let Some(user) = accounts::table
-                .filter(accounts::url.eq(opts.url))
-                .select(Account::as_select())
-                .first(&mut db_conn)
-                .await
-                .optional()?
-            {
+            let user_data = self
+                .db_pool
+                .with_connection(|mut db_conn| async move {
+                    accounts::table
+                        .filter(accounts::url.eq(opts.url))
+                        .select(Account::as_select())
+                        .first(&mut db_conn)
+                        .await
+                        .optional()
+                        .map_err(Error::from)
+                })
+                .await?;
+
+            if let Some(user) = user_data {
                 return Ok(user);
             }
         }
@@ -113,8 +119,9 @@ impl Fetcher {
         let mut actor: Actor = self.client.get(url.as_str()).await?.json().await?;
         actor.clean_html();
 
-        let account: Account = db_conn
-            .transaction(|tx| {
+        let account: Account = self
+            .db_pool
+            .with_transaction(|tx| {
                 async move {
                     let account = diesel::insert_into(accounts::table)
                         .values(NewAccount {
@@ -222,14 +229,20 @@ impl Fetcher {
             return Ok(Some(post));
         }
 
-        let mut db_conn = self.db_conn.get().await?;
-        if let Some(post) = posts::table
-            .filter(posts::url.eq(url))
-            .select(Post::as_select())
-            .first(&mut db_conn)
-            .await
-            .optional()?
-        {
+        let post = self
+            .db_pool
+            .with_connection(|db_conn| async move {
+                posts::table
+                    .filter(posts::url.eq(url))
+                    .select(Post::as_select())
+                    .first(&mut db_conn)
+                    .await
+                    .optional()
+                    .map_err(Error::from)
+            })
+            .await?;
+
+        if let Some(post) = post {
             self.post_cache.set(url, &post).await?;
             return Ok(Some(post));
         }
@@ -239,7 +252,7 @@ impl Fetcher {
 
         let process_data = ProcessNewObject::builder()
             .call_depth(call_depth)
-            .db_conn(&mut db_conn)
+            .db_pool(&self.db_pool)
             .embed_client(self.embed_client.as_ref())
             .fetcher(self)
             .object(object)
@@ -274,6 +287,7 @@ mod test {
     use core::convert::Infallible;
     use diesel::{QueryDsl, SelectableHelper};
     use diesel_async::RunQueryDsl;
+    use futures_util::future::TryFutureExt;
     use hyper::{Body, Request, Response};
     use kitsune_cache::NoopCache;
     use kitsune_db::{model::account::Account, schema::accounts};
@@ -286,12 +300,12 @@ mod test {
     #[tokio::test]
     #[serial_test::serial]
     async fn fetch_actor() {
-        database_test(|db_conn| async move {
+        database_test(|db_pool| async move {
             let client = Client::builder().service(service_fn(handle));
 
             let fetcher = Fetcher::builder()
                 .client(client)
-                .db_conn(db_conn)
+                .db_pool(db_pool)
                 .embed_client(None)
                 .federation_filter(
                     FederationFilterService::new(&FederationFilterConfiguration::Deny {
@@ -323,12 +337,12 @@ mod test {
     #[tokio::test]
     #[serial_test::serial]
     async fn fetch_note() {
-        database_test(|db_conn| async move {
+        database_test(|db_pool| async move {
             let client = Client::builder().service(service_fn(handle));
 
             let fetcher = Fetcher::builder()
                 .client(client)
-                .db_conn(db_conn.clone())
+                .db_pool(db_pool.clone())
                 .embed_client(None)
                 .federation_filter(
                     FederationFilterService::new(&FederationFilterConfiguration::Deny {
@@ -350,10 +364,14 @@ mod test {
                 "https://corteximplant.com/users/0x0/statuses/109501674056556919"
             );
 
-            let author = accounts::table
-                .find(note.account_id)
-                .select(Account::as_select())
-                .get_result::<Account>(&mut db_conn.get().await.unwrap())
+            let author = db_pool
+                .with_connection(|mut db_conn| {
+                    accounts::table
+                        .find(note.account_id)
+                        .select(Account::as_select())
+                        .get_result::<Account>(&mut db_conn)
+                        .map_err(Error::from)
+                })
                 .await
                 .expect("Get author");
 
@@ -366,9 +384,9 @@ mod test {
     #[tokio::test]
     #[serial_test::serial]
     async fn federation_allow() {
-        database_test(|db_conn| async move {
+        database_test(|db_pool| async move {
             let builder = Fetcher::builder()
-                .db_conn(db_conn)
+                .db_pool(db_pool)
                 .embed_client(None)
                 .federation_filter(
                     FederationFilterService::new(&FederationFilterConfiguration::Allow {
@@ -416,7 +434,7 @@ mod test {
     #[tokio::test]
     #[serial_test::serial]
     async fn federation_deny() {
-        database_test(|db_conn| async move {
+        database_test(|db_pool| async move {
             let client = service_fn(
                 #[allow(unreachable_code)]
                 |_: Request<_>| async {
@@ -427,7 +445,7 @@ mod test {
 
             let fetcher = Fetcher::builder()
                 .client(client)
-                .db_conn(db_conn)
+                .db_pool(db_pool)
                 .embed_client(None)
                 .federation_filter(
                     FederationFilterService::new(&FederationFilterConfiguration::Deny {

--- a/kitsune/src/error.rs
+++ b/kitsune/src/error.rs
@@ -239,6 +239,18 @@ impl From<Error> for Response {
     }
 }
 
+impl<E> From<kitsune_db::PoolError<E>> for Error
+where
+    E: Into<Error>,
+{
+    fn from(value: kitsune_db::PoolError<E>) -> Self {
+        match value {
+            kitsune_db::PoolError::Pool(err) => err.into(),
+            kitsune_db::PoolError::User(err) => err.into(),
+        }
+    }
+}
+
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self {

--- a/kitsune/src/http/extractor/auth.rs
+++ b/kitsune/src/http/extractor/auth.rs
@@ -60,10 +60,15 @@ impl<const ENFORCE_EXPIRATION: bool> FromRequestParts<Zustand>
                 .filter(oauth2_access_tokens::expires_at.gt(OffsetDateTime::now_utc()));
         }
 
-        let mut db_conn = state.db_conn.get().await.map_err(Error::from)?;
-        let (user, account) = user_account_query
-            .select(<(User, Account)>::as_select())
-            .get_result(&mut db_conn)
+        let (user, account) = state
+            .db_conn
+            .with_connection(|mut db_conn| async move {
+                user_account_query
+                    .select(<(User, Account)>::as_select())
+                    .get_result(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await
             .map_err(Error::from)?;
 

--- a/kitsune/src/http/extractor/auth.rs
+++ b/kitsune/src/http/extractor/auth.rs
@@ -61,7 +61,7 @@ impl<const ENFORCE_EXPIRATION: bool> FromRequestParts<Zustand>
         }
 
         let (user, account) = state
-            .db_conn
+            .db_pool
             .with_connection(|mut db_conn| async move {
                 user_account_query
                     .select(<(User, Account)>::as_select())

--- a/kitsune/src/http/extractor/auth.rs
+++ b/kitsune/src/http/extractor/auth.rs
@@ -62,12 +62,10 @@ impl<const ENFORCE_EXPIRATION: bool> FromRequestParts<Zustand>
 
         let (user, account) = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 user_account_query
                     .select(<(User, Account)>::as_select())
                     .get_result(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await
             .map_err(Error::from)?;

--- a/kitsune/src/http/extractor/signed_activity.rs
+++ b/kitsune/src/http/extractor/signed_activity.rs
@@ -62,12 +62,12 @@ impl FromRequest<Zustand, Body> for SignedActivity {
 
         let ap_id = activity.actor();
         let remote_user = state.fetcher.fetch_actor(ap_id.into()).await?;
-        if !verify_signature(&parts, &state.db_conn, Some(&remote_user)).await? {
+        if !verify_signature(&parts, &state.db_pool, Some(&remote_user)).await? {
             // Refetch the user and try again. Maybe they rekeyed
             let opts = FetchOptions::builder().refetch(true).url(ap_id).build();
             let remote_user = state.fetcher.fetch_actor(opts).await?;
 
-            if !verify_signature(&parts, &state.db_conn, Some(&remote_user)).await? {
+            if !verify_signature(&parts, &state.db_pool, Some(&remote_user)).await? {
                 return Err(StatusCode::UNAUTHORIZED.into_response());
             }
         }

--- a/kitsune/src/http/extractor/signed_activity.rs
+++ b/kitsune/src/http/extractor/signed_activity.rs
@@ -13,9 +13,9 @@ use axum::{
 use bytes::Buf;
 use const_oid::db::rfc8410::ID_ED_25519;
 use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
-use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use diesel_async::RunQueryDsl;
 use http::{request::Parts, StatusCode};
-use kitsune_db::{model::account::Account, schema::accounts};
+use kitsune_db::{model::account::Account, schema::accounts, PgPool};
 use kitsune_http_signatures::{
     ring::signature::{
         UnparsedPublicKey, VerificationAlgorithm, ED25519, RSA_PKCS1_2048_8192_SHA256,
@@ -62,13 +62,12 @@ impl FromRequest<Zustand, Body> for SignedActivity {
 
         let ap_id = activity.actor();
         let remote_user = state.fetcher.fetch_actor(ap_id.into()).await?;
-        let mut db_conn = state.db_conn.get().await.map_err(Error::from)?;
-        if !verify_signature(&parts, &mut db_conn, Some(&remote_user)).await? {
+        if !verify_signature(&parts, &state.db_conn, Some(&remote_user)).await? {
             // Refetch the user and try again. Maybe they rekeyed
             let opts = FetchOptions::builder().refetch(true).url(ap_id).build();
             let remote_user = state.fetcher.fetch_actor(opts).await?;
 
-            if !verify_signature(&parts, &mut db_conn, Some(&remote_user)).await? {
+            if !verify_signature(&parts, &state.db_conn, Some(&remote_user)).await? {
                 return Err(StatusCode::UNAUTHORIZED.into_response());
             }
         }
@@ -79,15 +78,20 @@ impl FromRequest<Zustand, Body> for SignedActivity {
 
 async fn verify_signature(
     parts: &Parts,
-    db_conn: &mut AsyncPgConnection,
+    db_conn: &PgPool,
     expected_account: Option<&Account>,
 ) -> Result<bool> {
     let is_valid = HttpVerifier::default()
         .verify(parts, |key_id| async move {
-            let remote_user: Account = accounts::table
-                .filter(accounts::public_key_id.eq(key_id))
-                .select(Account::as_select())
-                .first(db_conn)
+            let remote_user: Account = db_conn
+                .with_connection(|mut db_conn| async move {
+                    accounts::table
+                        .filter(accounts::public_key_id.eq(key_id))
+                        .select(Account::as_select())
+                        .first(&mut db_conn)
+                        .await
+                        .map_err(Error::from)
+                })
                 .await?;
 
             // If we have an expected account, which we have in the case of an incoming new activity,

--- a/kitsune/src/http/extractor/signed_activity.rs
+++ b/kitsune/src/http/extractor/signed_activity.rs
@@ -84,13 +84,11 @@ async fn verify_signature(
     let is_valid = HttpVerifier::default()
         .verify(parts, |key_id| async move {
             let remote_user: Account = db_conn
-                .with_connection(|mut db_conn| async move {
+                .with_connection(|mut db_conn| {
                     accounts::table
                         .filter(accounts::public_key_id.eq(key_id))
                         .select(Account::as_select())
                         .first(&mut db_conn)
-                        .await
-                        .map_err(Error::from)
                 })
                 .await?;
 

--- a/kitsune/src/http/graphql/query/account.rs
+++ b/kitsune/src/http/graphql/query/account.rs
@@ -1,8 +1,5 @@
 use crate::http::graphql::{types::Account, ContextExt};
 use async_graphql::{Context, Object, Result};
-use diesel::{QueryDsl, SelectableHelper};
-use diesel_async::RunQueryDsl;
-use kitsune_db::{model::account::Account as DbAccount, schema::accounts};
 use speedy_uuid::Uuid;
 
 #[derive(Default)]
@@ -10,19 +7,18 @@ pub struct AccountQuery;
 
 #[Object]
 impl AccountQuery {
-    pub async fn get_account_by_id(&self, ctx: &Context<'_>, id: Uuid) -> Result<Account> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
-
-        Ok(accounts::table
-            .find(id)
-            .select(DbAccount::as_select())
-            .get_result::<DbAccount>(&mut db_conn)
-            .await
-            .map(Into::into)?)
+    pub async fn get_account_by_id(&self, ctx: &Context<'_>, id: Uuid) -> Result<Option<Account>> {
+        Ok(ctx
+            .state()
+            .service
+            .account
+            .get_by_id(id)
+            .await?
+            .map(Into::into))
     }
 
     pub async fn my_account(&self, ctx: &Context<'_>) -> Result<Account> {
         let account = &ctx.user_data()?.account;
-        self.get_account_by_id(ctx, account.id).await
+        Ok(account.clone().into())
     }
 }

--- a/kitsune/src/http/graphql/query/account.rs
+++ b/kitsune/src/http/graphql/query/account.rs
@@ -17,6 +17,7 @@ impl AccountQuery {
             .map(Into::into))
     }
 
+    #[allow(clippy::unused_async)]
     pub async fn my_account(&self, ctx: &Context<'_>) -> Result<Account> {
         let account = &ctx.user_data()?.account;
         Ok(account.clone().into())

--- a/kitsune/src/http/graphql/types/account.rs
+++ b/kitsune/src/http/graphql/types/account.rs
@@ -47,9 +47,9 @@ impl Account {
                         .await
                         .optional()
                         .map(|attachment| attachment.map(Into::into))
-                        .map_err(Into::into)
                 })
                 .await
+                .map_err(Into::into)
         } else {
             Ok(None)
         }
@@ -67,9 +67,9 @@ impl Account {
                         .await
                         .optional()
                         .map(|attachment| attachment.map(Into::into))
-                        .map_err(Into::into)
                 })
                 .await
+                .map_err(Into::into)
         } else {
             Ok(None)
         }

--- a/kitsune/src/http/graphql/types/account.rs
+++ b/kitsune/src/http/graphql/types/account.rs
@@ -36,32 +36,40 @@ pub struct Account {
 #[ComplexObject]
 impl Account {
     pub async fn avatar(&self, ctx: &Context<'_>) -> Result<Option<MediaAttachment>> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
+        let db_pool = &ctx.state().db_pool;
 
         if let Some(avatar_id) = self.avatar_id {
-            media_attachments::table
-                .find(avatar_id)
-                .get_result::<DbMediaAttachment>(&mut db_conn)
+            db_pool
+                .with_connection(|mut db_conn| async move {
+                    media_attachments::table
+                        .find(avatar_id)
+                        .get_result::<DbMediaAttachment>(&mut db_conn)
+                        .await
+                        .optional()
+                        .map(|attachment| attachment.map(Into::into))
+                        .map_err(Into::into)
+                })
                 .await
-                .optional()
-                .map(|attachment| attachment.map(Into::into))
-                .map_err(Into::into)
         } else {
             Ok(None)
         }
     }
 
     pub async fn header(&self, ctx: &Context<'_>) -> Result<Option<MediaAttachment>> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
+        let db_pool = &ctx.state().db_pool;
 
         if let Some(header_id) = self.header_id {
-            media_attachments::table
-                .find(header_id)
-                .get_result::<DbMediaAttachment>(&mut db_conn)
+            db_pool
+                .with_connection(|mut db_conn| async move {
+                    media_attachments::table
+                        .find(header_id)
+                        .get_result::<DbMediaAttachment>(&mut db_conn)
+                        .await
+                        .optional()
+                        .map(|attachment| attachment.map(Into::into))
+                        .map_err(Into::into)
+                })
                 .await
-                .optional()
-                .map(|attachment| attachment.map(Into::into))
-                .map_err(Into::into)
         } else {
             Ok(None)
         }

--- a/kitsune/src/http/graphql/types/media_attachment.rs
+++ b/kitsune/src/http/graphql/types/media_attachment.rs
@@ -1,14 +1,7 @@
 use super::Account;
 use crate::http::graphql::ContextExt;
 use async_graphql::{ComplexObject, Context, Result, SimpleObject};
-use diesel::{QueryDsl, SelectableHelper};
-use diesel_async::RunQueryDsl;
-use kitsune_db::{
-    model::{
-        account::Account as DbAccount, media_attachment::MediaAttachment as DbMediaAttachment,
-    },
-    schema::accounts,
-};
+use kitsune_db::model::media_attachment::MediaAttachment as DbMediaAttachment;
 use speedy_uuid::Uuid;
 use time::OffsetDateTime;
 
@@ -27,13 +20,12 @@ pub struct MediaAttachment {
 #[ComplexObject]
 impl MediaAttachment {
     pub async fn uploader(&self, ctx: &Context<'_>) -> Result<Account> {
-        let mut db_conn = ctx.state().db_pool.get().await?;
-
-        accounts::table
-            .find(self.account_id)
-            .select(DbAccount::as_select())
-            .get_result::<DbAccount>(&mut db_conn)
+        ctx.state()
+            .service
+            .account
+            .get_by_id(self.account_id)
             .await
+            .map(Option::unwrap)
             .map(Into::into)
             .map_err(Into::into)
     }

--- a/kitsune/src/http/graphql/types/media_attachment.rs
+++ b/kitsune/src/http/graphql/types/media_attachment.rs
@@ -27,7 +27,7 @@ pub struct MediaAttachment {
 #[ComplexObject]
 impl MediaAttachment {
     pub async fn uploader(&self, ctx: &Context<'_>) -> Result<Account> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
+        let mut db_conn = ctx.state().db_pool.get().await?;
 
         accounts::table
             .find(self.account_id)

--- a/kitsune/src/http/graphql/types/post.rs
+++ b/kitsune/src/http/graphql/types/post.rs
@@ -5,11 +5,8 @@ use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use futures_util::TryStreamExt;
 use kitsune_db::{
-    model::{
-        account::Account as DbAccount, media_attachment::MediaAttachment as DbMediaAttachment,
-        post::Post as DbPost,
-    },
-    schema::{accounts, media_attachments, posts_media_attachments},
+    model::{media_attachment::MediaAttachment as DbMediaAttachment, post::Post as DbPost},
+    schema::{media_attachments, posts_media_attachments},
 };
 use speedy_uuid::Uuid;
 use time::OffsetDateTime;
@@ -34,27 +31,31 @@ pub struct Post {
 #[ComplexObject]
 impl Post {
     pub async fn account(&self, ctx: &Context<'_>) -> Result<Account> {
-        let mut db_conn = ctx.state().db_pool.get().await?;
-
-        Ok(accounts::table
-            .find(self.account_id)
-            .select(DbAccount::as_select())
-            .get_result::<DbAccount>(&mut db_conn)
-            .await?
-            .into())
+        ctx.state()
+            .service
+            .account
+            .get_by_id(self.account_id)
+            .await
+            .map(Option::unwrap)
+            .map(Into::into)
+            .map_err(Into::into)
     }
 
     pub async fn attachments(&self, ctx: &Context<'_>) -> Result<Vec<MediaAttachment>> {
-        let mut db_conn = ctx.state().db_pool.get().await?;
-
-        let attachments = media_attachments::table
-            .inner_join(posts_media_attachments::table)
-            .filter(posts_media_attachments::post_id.eq(self.id))
-            .select(DbMediaAttachment::as_select())
-            .load_stream(&mut db_conn)
-            .await?
-            .map_ok(Into::into)
-            .try_collect()
+        let db_pool = &ctx.state().db_pool;
+        let attachments = db_pool
+            .with_connection(|mut db_conn| async move {
+                media_attachments::table
+                    .inner_join(posts_media_attachments::table)
+                    .filter(posts_media_attachments::post_id.eq(self.id))
+                    .select(DbMediaAttachment::as_select())
+                    .load_stream(&mut db_conn)
+                    .await?
+                    .map_ok(Into::into)
+                    .try_collect()
+                    .await
+                    .map_err(async_graphql::Error::from)
+            })
             .await?;
 
         Ok(attachments)

--- a/kitsune/src/http/graphql/types/post.rs
+++ b/kitsune/src/http/graphql/types/post.rs
@@ -54,7 +54,6 @@ impl Post {
                     .map_ok(Into::into)
                     .try_collect()
                     .await
-                    .map_err(async_graphql::Error::from)
             })
             .await?;
 

--- a/kitsune/src/http/graphql/types/post.rs
+++ b/kitsune/src/http/graphql/types/post.rs
@@ -34,7 +34,7 @@ pub struct Post {
 #[ComplexObject]
 impl Post {
     pub async fn account(&self, ctx: &Context<'_>) -> Result<Account> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
+        let mut db_conn = ctx.state().db_pool.get().await?;
 
         Ok(accounts::table
             .find(self.account_id)
@@ -45,7 +45,7 @@ impl Post {
     }
 
     pub async fn attachments(&self, ctx: &Context<'_>) -> Result<Vec<MediaAttachment>> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
+        let mut db_conn = ctx.state().db_pool.get().await?;
 
         let attachments = media_attachments::table
             .inner_join(posts_media_attachments::table)

--- a/kitsune/src/http/graphql/types/user.rs
+++ b/kitsune/src/http/graphql/types/user.rs
@@ -25,7 +25,7 @@ pub struct User {
 #[ComplexObject]
 impl User {
     pub async fn account(&self, ctx: &Context<'_>) -> Result<Account> {
-        let mut db_conn = ctx.state().db_conn.get().await?;
+        let mut db_conn = ctx.state().db_pool.get().await?;
 
         users::table
             .find(self.id)

--- a/kitsune/src/http/graphql/types/user.rs
+++ b/kitsune/src/http/graphql/types/user.rs
@@ -1,6 +1,6 @@
 use super::Account;
 use crate::http::graphql::ContextExt;
-use async_graphql::{ComplexObject, Context, Error, Result, SimpleObject};
+use async_graphql::{ComplexObject, Context, Result, SimpleObject};
 use diesel::{QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use kitsune_db::{
@@ -35,9 +35,9 @@ impl User {
                     .get_result::<DbAccount>(&mut db_conn)
                     .await
                     .map(Into::into)
-                    .map_err(Error::from)
             })
             .await
+            .map_err(Into::into)
     }
 }
 

--- a/kitsune/src/http/handler/mastodon/api/v1/accounts/relationships.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/accounts/relationships.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, Result},
+    error::Result,
     http::extractor::{AuthExtractor, MastodonAuthExtractor},
     mapping::MastodonMapper,
 };
@@ -40,16 +40,10 @@ pub async fn get(
 ) -> Result<Json<Vec<Relationship>>> {
     let mut account_stream = db_pool
         .with_connection(|mut db_conn| {
-            let query = &query;
-
-            async move {
-                accounts::table
-                    .filter(accounts::id.eq_any(&query.id))
-                    .select(Account::as_select())
-                    .load_stream::<Account>(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
-            }
+            accounts::table
+                .filter(accounts::id.eq_any(&query.id))
+                .select(Account::as_select())
+                .load_stream::<Account>(&mut db_conn)
         })
         .await?;
 

--- a/kitsune/src/http/handler/mastodon/api/v2/search.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/search.rs
@@ -67,7 +67,7 @@ async fn get(
     AuthExtractor(user_data): MastodonAuthExtractor,
     Query(query): Query<SearchQuery>,
 ) -> Result<Either<Json<SearchResult>, StatusCode>> {
-    let mut db_conn = state.db_conn.get().await?;
+    let mut db_conn = state.db_pool.get().await?;
 
     let indices = if let Some(r#type) = query.r#type {
         let index = match r#type {

--- a/kitsune/src/http/handler/mastodon/api/v2/search.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/search.rs
@@ -1,8 +1,6 @@
-use std::cmp::min;
-
 use crate::{
     consts::{API_DEFAULT_LIMIT, API_MAX_LIMIT},
-    error::Result,
+    error::{Error, Result},
     http::extractor::{AuthExtractor, MastodonAuthExtractor},
     state::Zustand,
 };
@@ -19,6 +17,7 @@ use kitsune_search::{SearchBackend, SearchIndex, SearchService};
 use kitsune_type::mastodon::SearchResult;
 use serde::Deserialize;
 use speedy_uuid::Uuid;
+use std::cmp::min;
 use url::Url;
 use utoipa::{IntoParams, ToSchema};
 
@@ -67,8 +66,6 @@ async fn get(
     AuthExtractor(user_data): MastodonAuthExtractor,
     Query(query): Query<SearchQuery>,
 ) -> Result<Either<Json<SearchResult>, StatusCode>> {
-    let mut db_conn = state.db_pool.get().await?;
-
     let indices = if let Some(r#type) = query.r#type {
         let index = match r#type {
             SearchType::Accounts => SearchIndex::Account,
@@ -96,30 +93,41 @@ async fn get(
             .await?;
 
         for result in results {
-            match index {
-                SearchIndex::Account => {
-                    let account = accounts::table
-                        .find(result.id)
-                        .select(Account::as_select())
-                        .get_result::<Account>(&mut db_conn)
-                        .await?;
+            search_result = state
+                .db_pool
+                .with_connection(|mut db_conn| {
+                    let state = &state;
 
-                    search_result
-                        .accounts
-                        .push(state.mastodon_mapper.map(account).await?);
-                }
-                SearchIndex::Post => {
-                    let post = posts::table
-                        .find(result.id)
-                        .select(Post::as_select())
-                        .get_result::<Post>(&mut db_conn)
-                        .await?;
+                    async move {
+                        match index {
+                            SearchIndex::Account => {
+                                let account = accounts::table
+                                    .find(result.id)
+                                    .select(Account::as_select())
+                                    .get_result::<Account>(&mut db_conn)
+                                    .await?;
 
-                    search_result
-                        .statuses
-                        .push(state.mastodon_mapper.map(post).await?);
-                }
-            }
+                                search_result
+                                    .accounts
+                                    .push(state.mastodon_mapper.map(account).await?);
+                            }
+                            SearchIndex::Post => {
+                                let post = posts::table
+                                    .find(result.id)
+                                    .select(Post::as_select())
+                                    .get_result::<Post>(&mut db_conn)
+                                    .await?;
+
+                                search_result
+                                    .statuses
+                                    .push(state.mastodon_mapper.map(post).await?);
+                            }
+                        }
+
+                        Ok::<_, Error>(search_result)
+                    }
+                })
+                .await?;
         }
     }
 

--- a/kitsune/src/http/handler/nodeinfo/two_one.rs
+++ b/kitsune/src/http/handler/nodeinfo/two_one.rs
@@ -1,4 +1,10 @@
-use crate::{consts::VERSION, error::Result, service::user::UserService, state::Zustand};
+use crate::{
+    consts::VERSION,
+    error::{Error, Result},
+    service::user::UserService,
+    state::Zustand,
+    try_join,
+};
 use axum::{debug_handler, extract::State, routing, Json, Router};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -20,16 +26,19 @@ use simd_json::{Builder, OwnedValue};
     ),
 )]
 async fn get(
-    State(db_conn): State<PgPool>,
+    State(db_pool): State<PgPool>,
     State(user_service): State<UserService>,
 ) -> Result<Json<TwoOne>> {
-    let mut db_conn = db_conn.get().await?;
+    let (total, local_posts) = db_pool
+        .with_connection(|mut db_conn| async move {
+            let total_fut = users::table.count().get_result::<i64>(&mut db_conn);
+            let local_posts_fut = posts::table
+                .filter(posts::is_local.eq(true))
+                .count()
+                .get_result::<i64>(&mut db_conn);
 
-    let total = users::table.count().get_result::<i64>(&mut db_conn).await?;
-    let local_posts = posts::table
-        .filter(posts::is_local.eq(true))
-        .count()
-        .get_result::<i64>(&mut db_conn)
+            try_join!(total_fut, local_posts_fut).map_err(Error::from)
+        })
         .await?;
 
     Ok(Json(TwoOne {

--- a/kitsune/src/http/handler/nodeinfo/two_one.rs
+++ b/kitsune/src/http/handler/nodeinfo/two_one.rs
@@ -1,10 +1,4 @@
-use crate::{
-    consts::VERSION,
-    error::{Error, Result},
-    service::user::UserService,
-    state::Zustand,
-    try_join,
-};
+use crate::{consts::VERSION, error::Result, service::user::UserService, state::Zustand, try_join};
 use axum::{debug_handler, extract::State, routing, Json, Router};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -37,7 +31,7 @@ async fn get(
                 .count()
                 .get_result::<i64>(&mut db_conn);
 
-            try_join!(total_fut, local_posts_fut).map_err(Error::from)
+            try_join!(total_fut, local_posts_fut)
         })
         .await?;
 

--- a/kitsune/src/http/handler/oauth/authorize.rs
+++ b/kitsune/src/http/handler/oauth/authorize.rs
@@ -65,11 +65,15 @@ pub async fn get(
 ) -> Result<Either3<OAuthResponse, LoginPage, Redirect>> {
     #[cfg(feature = "oidc")]
     if let Some(oidc_service) = oidc_service {
-        let mut db_conn = db_pool.get().await?;
-        let application = oauth2_applications::table
-            .find(query.client_id)
-            .filter(oauth2_applications::redirect_uri.eq(query.redirect_uri))
-            .get_result::<oauth2::Application>(&mut db_conn)
+        let application = db_pool
+            .with_connection(|mut db_conn| async move {
+                oauth2_applications::table
+                    .find(query.client_id)
+                    .filter(oauth2_applications::redirect_uri.eq(query.redirect_uri))
+                    .get_result::<oauth2::Application>(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await?;
 
         let auth_url = oidc_service
@@ -80,9 +84,17 @@ pub async fn get(
     }
 
     let authenticated_user = if let Some(user_id) = cookies.get("user_id") {
-        let mut db_conn = db_pool.get().await?;
         let id = user_id.value().parse::<Uuid>()?;
-        users::table.find(id).get_result(&mut db_conn).await?
+
+        db_pool
+            .with_connection(|mut db_conn| async move {
+                users::table
+                    .find(id)
+                    .get_result(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
+            .await?
     } else {
         return Ok(Either3::E2(LoginPage { flash_messages }));
     };
@@ -101,7 +113,7 @@ pub async fn get(
 
 #[debug_handler(state = crate::state::Zustand)]
 pub async fn post(
-    State(db_conn): State<PgPool>,
+    State(db_pool): State<PgPool>,
     OriginalUri(original_url): OriginalUri,
     cookies: SignedCookieJar,
     flash: Flash,
@@ -113,13 +125,18 @@ pub async fn post(
         original_url.path()
     };
 
-    let mut db_conn = db_conn.get().await?;
-    let Some(user) = users::table
-        .filter(users::username.eq(form.username))
-        .first::<User>(&mut db_conn)
-        .await
-        .optional()?
-    else {
+    let user = db_pool
+        .with_connection(|mut db_conn| async move {
+            users::table
+                .filter(users::username.eq(form.username))
+                .first::<User>(&mut db_conn)
+                .await
+                .optional()
+                .map_err(Error::from)
+        })
+        .await?;
+
+    let Some(user) = user else {
         return Ok(Either::E2((
             flash.error(Error::PasswordMismatch.to_string()),
             Redirect::to(redirect_to),

--- a/kitsune/src/http/handler/oauth/authorize.rs
+++ b/kitsune/src/http/handler/oauth/authorize.rs
@@ -66,13 +66,11 @@ pub async fn get(
     #[cfg(feature = "oidc")]
     if let Some(oidc_service) = oidc_service {
         let application = db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 oauth2_applications::table
                     .find(query.client_id)
                     .filter(oauth2_applications::redirect_uri.eq(query.redirect_uri))
                     .get_result::<oauth2::Application>(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 
@@ -87,13 +85,7 @@ pub async fn get(
         let id = user_id.value().parse::<Uuid>()?;
 
         db_pool
-            .with_connection(|mut db_conn| async move {
-                users::table
-                    .find(id)
-                    .get_result(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
-            })
+            .with_connection(|mut db_conn| users::table.find(id).get_result(&mut db_conn))
             .await?
     } else {
         return Ok(Either3::E2(LoginPage { flash_messages }));
@@ -132,7 +124,6 @@ pub async fn post(
                 .first::<User>(&mut db_conn)
                 .await
                 .optional()
-                .map_err(Error::from)
         })
         .await?;
 

--- a/kitsune/src/http/handler/oidc/callback.rs
+++ b/kitsune/src/http/handler/oidc/callback.rs
@@ -37,12 +37,16 @@ pub async fn get(
 
     let user_info = oidc_service.get_user_info(query.state, query.code).await?;
     let user = db_pool
-        .with_connection(|mut db_conn| async move {
-            users::table
-                .filter(users::oidc_id.eq(&user_info.subject))
-                .get_result(&mut db_conn)
-                .await
-                .optional()
+        .with_connection(|mut db_conn| {
+            let user_info = &user_info;
+
+            async move {
+                users::table
+                    .filter(users::oidc_id.eq(&user_info.subject))
+                    .get_result(&mut db_conn)
+                    .await
+                    .optional()
+            }
         })
         .await?;
 

--- a/kitsune/src/http/handler/oidc/callback.rs
+++ b/kitsune/src/http/handler/oidc/callback.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{ApiError, Error, Result},
+    error::{ApiError, Result},
     service::{
         oauth2::{AuthorisationCode, OAuth2Service},
         oidc::OidcService,
@@ -43,7 +43,6 @@ pub async fn get(
                 .get_result(&mut db_conn)
                 .await
                 .optional()
-                .map_err(Error::from)
         })
         .await?;
 
@@ -60,12 +59,10 @@ pub async fn get(
     };
 
     let application = db_pool
-        .with_connection(|mut db_conn| async move {
+        .with_connection(|mut db_conn| {
             oauth2_applications::table
                 .find(user_info.oauth2.application_id)
                 .get_result(&mut db_conn)
-                .await
-                .map_err(Error::from)
         })
         .await?;
 

--- a/kitsune/src/http/handler/users/followers.rs
+++ b/kitsune/src/http/handler/users/followers.rs
@@ -1,8 +1,5 @@
 use crate::{
-    error::{Error, Result},
-    http::responder::ActivityPubJson,
-    service::url::UrlService,
-    state::Zustand,
+    error::Result, http::responder::ActivityPubJson, service::url::UrlService, state::Zustand,
 };
 use axum::extract::{OriginalUri, Path, State};
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
@@ -22,7 +19,7 @@ pub async fn get(
 ) -> Result<ActivityPubJson<Collection>> {
     let follower_count = state
         .db_pool
-        .with_connection(|mut db_conn| async move {
+        .with_connection(|mut db_conn| {
             accounts_follows::table
                 .inner_join(
                     accounts::table.on(accounts_follows::account_id
@@ -33,8 +30,6 @@ pub async fn get(
                 )
                 .count()
                 .get_result::<i64>(&mut db_conn)
-                .await
-                .map_err(Error::from)
         })
         .await?;
 

--- a/kitsune/src/http/handler/users/followers.rs
+++ b/kitsune/src/http/handler/users/followers.rs
@@ -1,5 +1,8 @@
 use crate::{
-    error::Result, http::responder::ActivityPubJson, service::url::UrlService, state::Zustand,
+    error::{Error, Result},
+    http::responder::ActivityPubJson,
+    service::url::UrlService,
+    state::Zustand,
 };
 use axum::extract::{OriginalUri, Path, State};
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
@@ -17,17 +20,22 @@ pub async fn get(
     OriginalUri(original_uri): OriginalUri,
     Path(account_id): Path<Uuid>,
 ) -> Result<ActivityPubJson<Collection>> {
-    let mut db_conn = state.db_pool.get().await?;
-    let follower_count = accounts_follows::table
-        .inner_join(
-            accounts::table.on(accounts_follows::account_id
-                .eq(accounts::id)
-                .and(accounts_follows::approved_at.is_not_null())
-                .and(accounts::id.eq(account_id))
-                .and(accounts::local.eq(true))),
-        )
-        .count()
-        .get_result::<i64>(&mut db_conn)
+    let follower_count = state
+        .db_pool
+        .with_connection(|mut db_conn| async move {
+            accounts_follows::table
+                .inner_join(
+                    accounts::table.on(accounts_follows::account_id
+                        .eq(accounts::id)
+                        .and(accounts_follows::approved_at.is_not_null())
+                        .and(accounts::id.eq(account_id))
+                        .and(accounts::local.eq(true))),
+                )
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .await
+                .map_err(Error::from)
+        })
         .await?;
 
     let mut id = url_service.base_url();

--- a/kitsune/src/http/handler/users/followers.rs
+++ b/kitsune/src/http/handler/users/followers.rs
@@ -17,7 +17,7 @@ pub async fn get(
     OriginalUri(original_uri): OriginalUri,
     Path(account_id): Path<Uuid>,
 ) -> Result<ActivityPubJson<Collection>> {
-    let mut db_conn = state.db_conn.get().await?;
+    let mut db_conn = state.db_pool.get().await?;
     let follower_count = accounts_follows::table
         .inner_join(
             accounts::table.on(accounts_follows::account_id

--- a/kitsune/src/http/handler/users/following.rs
+++ b/kitsune/src/http/handler/users/following.rs
@@ -1,8 +1,5 @@
 use crate::{
-    error::{Error, Result},
-    http::responder::ActivityPubJson,
-    service::url::UrlService,
-    state::Zustand,
+    error::Result, http::responder::ActivityPubJson, service::url::UrlService, state::Zustand,
 };
 use axum::extract::{OriginalUri, Path, State};
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
@@ -22,7 +19,7 @@ pub async fn get(
 ) -> Result<ActivityPubJson<Collection>> {
     let following_count = state
         .db_pool
-        .with_connection(|mut db_conn| async move {
+        .with_connection(|mut db_conn| {
             accounts_follows::table
                 .inner_join(
                     accounts::table.on(accounts_follows::follower_id
@@ -33,8 +30,6 @@ pub async fn get(
                 )
                 .count()
                 .get_result::<i64>(&mut db_conn)
-                .await
-                .map_err(Error::from)
         })
         .await?;
 

--- a/kitsune/src/http/handler/users/following.rs
+++ b/kitsune/src/http/handler/users/following.rs
@@ -1,5 +1,8 @@
 use crate::{
-    error::Result, http::responder::ActivityPubJson, service::url::UrlService, state::Zustand,
+    error::{Error, Result},
+    http::responder::ActivityPubJson,
+    service::url::UrlService,
+    state::Zustand,
 };
 use axum::extract::{OriginalUri, Path, State};
 use diesel::{BoolExpressionMethods, ExpressionMethods, JoinOnDsl, QueryDsl};
@@ -17,17 +20,22 @@ pub async fn get(
     OriginalUri(original_uri): OriginalUri,
     Path(account_id): Path<Uuid>,
 ) -> Result<ActivityPubJson<Collection>> {
-    let mut db_conn = state.db_pool.get().await?;
-    let following_count = accounts_follows::table
-        .inner_join(
-            accounts::table.on(accounts_follows::follower_id
-                .eq(accounts::id)
-                .and(accounts_follows::approved_at.is_not_null())
-                .and(accounts::id.eq(account_id))
-                .and(accounts::local.eq(true))),
-        )
-        .count()
-        .get_result::<i64>(&mut db_conn)
+    let following_count = state
+        .db_pool
+        .with_connection(|mut db_conn| async move {
+            accounts_follows::table
+                .inner_join(
+                    accounts::table.on(accounts_follows::follower_id
+                        .eq(accounts::id)
+                        .and(accounts_follows::approved_at.is_not_null())
+                        .and(accounts::id.eq(account_id))
+                        .and(accounts::local.eq(true))),
+                )
+                .count()
+                .get_result::<i64>(&mut db_conn)
+                .await
+                .map_err(Error::from)
+        })
         .await?;
 
     let id = format!("{}{}", url_service.base_url(), original_uri.path());

--- a/kitsune/src/http/handler/users/following.rs
+++ b/kitsune/src/http/handler/users/following.rs
@@ -17,7 +17,7 @@ pub async fn get(
     OriginalUri(original_uri): OriginalUri,
     Path(account_id): Path<Uuid>,
 ) -> Result<ActivityPubJson<Collection>> {
-    let mut db_conn = state.db_conn.get().await?;
+    let mut db_conn = state.db_pool.get().await?;
     let following_count = accounts_follows::table
         .inner_join(
             accounts::table.on(accounts_follows::follower_id

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, Result},
+    error::Result,
     http::responder::ActivityPubJson,
     mapping::IntoActivity,
     service::{account::GetPosts, url::UrlService},
@@ -42,14 +42,12 @@ pub async fn get(
 ) -> Result<Either<ActivityPubJson<CollectionPage<Activity>>, ActivityPubJson<Collection>>> {
     let account = state
         .db_pool
-        .with_connection(|mut db_conn| async move {
+        .with_connection(|mut db_conn| {
             accounts::table
                 .find(account_id)
                 .filter(accounts::local.eq(true))
                 .select(Account::as_select())
                 .get_result::<Account>(&mut db_conn)
-                .await
-                .map_err(Error::from)
         })
         .await?;
 
@@ -97,13 +95,11 @@ pub async fn get(
     } else {
         let public_post_count = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 Post::belonging_to(&account)
                     .add_post_permission_check(PermissionCheck::default())
                     .count()
                     .get_result::<i64>(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::Result,
+    error::{Error, Result},
     http::responder::ActivityPubJson,
     mapping::IntoActivity,
     service::{account::GetPosts, url::UrlService},
@@ -40,13 +40,17 @@ pub async fn get(
     Path(account_id): Path<Uuid>,
     Query(query): Query<OutboxQuery>,
 ) -> Result<Either<ActivityPubJson<CollectionPage<Activity>>, ActivityPubJson<Collection>>> {
-    let mut db_conn = state.db_pool.get().await?;
-
-    let account = accounts::table
-        .find(account_id)
-        .filter(accounts::local.eq(true))
-        .select(Account::as_select())
-        .get_result::<Account>(&mut db_conn)
+    let account = state
+        .db_pool
+        .with_connection(|mut db_conn| async move {
+            accounts::table
+                .find(account_id)
+                .filter(accounts::local.eq(true))
+                .select(Account::as_select())
+                .get_result::<Account>(&mut db_conn)
+                .await
+                .map_err(Error::from)
+        })
         .await?;
 
     let base_url = format!("{}{}", url_service.base_url(), original_uri.path());
@@ -91,10 +95,16 @@ pub async fn get(
             ordered_items,
         })))
     } else {
-        let public_post_count = Post::belonging_to(&account)
-            .add_post_permission_check(PermissionCheck::default())
-            .count()
-            .get_result::<i64>(&mut db_conn)
+        let public_post_count = state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                Post::belonging_to(&account)
+                    .add_post_permission_check(PermissionCheck::default())
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await?;
 
         let first = format!("{base_url}?page=true");

--- a/kitsune/src/http/handler/users/outbox.rs
+++ b/kitsune/src/http/handler/users/outbox.rs
@@ -40,7 +40,7 @@ pub async fn get(
     Path(account_id): Path<Uuid>,
     Query(query): Query<OutboxQuery>,
 ) -> Result<Either<ActivityPubJson<CollectionPage<Activity>>, ActivityPubJson<Collection>>> {
-    let mut db_conn = state.db_conn.get().await?;
+    let mut db_conn = state.db_pool.get().await?;
 
     let account = accounts::table
         .find(account_id)

--- a/kitsune/src/http/handler/well_known/webfinger.rs
+++ b/kitsune/src/http/handler/well_known/webfinger.rs
@@ -1,8 +1,4 @@
-use crate::{
-    error::{Error, Result},
-    service::url::UrlService,
-    state::Zustand,
-};
+use crate::{error::Result, service::url::UrlService, state::Zustand};
 use axum::{
     extract::{Query, State},
     routing, Json, Router,
@@ -50,7 +46,7 @@ async fn get(
     };
 
     let account = db_pool
-        .with_connection(|mut db_conn| async move {
+        .with_connection(|mut db_conn| {
             accounts::table
                 .filter(
                     accounts::username
@@ -59,8 +55,6 @@ async fn get(
                 )
                 .select(Account::as_select())
                 .first::<Account>(&mut db_conn)
-                .await
-                .map_err(Error::from)
         })
         .await?;
     let account_url = url_service.user_url(account.id);

--- a/kitsune/src/http/handler/well_known/webfinger.rs
+++ b/kitsune/src/http/handler/well_known/webfinger.rs
@@ -1,4 +1,8 @@
-use crate::{error::Result, service::url::UrlService, state::Zustand};
+use crate::{
+    error::{Error, Result},
+    service::url::UrlService,
+    state::Zustand,
+};
 use axum::{
     extract::{Query, State},
     routing, Json, Router,
@@ -27,7 +31,7 @@ struct WebfingerQuery {
     )
 )]
 async fn get(
-    State(db_conn): State<PgPool>,
+    State(db_pool): State<PgPool>,
     State(url_service): State<UrlService>,
     Query(query): Query<WebfingerQuery>,
 ) -> Result<Either<Json<Resource>, StatusCode>> {
@@ -45,14 +49,19 @@ async fn get(
         return Ok(Either::E2(StatusCode::NOT_FOUND));
     };
 
-    let account = accounts::table
-        .filter(
-            accounts::username
-                .eq(username)
-                .and(accounts::local.eq(true)),
-        )
-        .select(Account::as_select())
-        .first::<Account>(&mut db_conn.get().await?)
+    let account = db_pool
+        .with_connection(|mut db_conn| async move {
+            accounts::table
+                .filter(
+                    accounts::username
+                        .eq(username)
+                        .and(accounts::local.eq(true)),
+                )
+                .select(Account::as_select())
+                .first::<Account>(&mut db_conn)
+                .await
+                .map_err(Error::from)
+        })
         .await?;
     let account_url = url_service.user_url(account.id);
 
@@ -94,11 +103,16 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn basic() {
-        database_test(|db_conn| async move {
-            let account_id = prepare_db(&mut db_conn.get().await.unwrap()).await;
+        database_test(|db_pool| async move {
+            let account_id = db_pool
+                .with_connection(|mut db_conn| async move {
+                    Ok::<_, eyre::Report>(prepare_db(&mut db_conn).await)
+                })
+                .await
+                .unwrap();
             let account_url = format!("https://example.com/users/{account_id}");
 
-            let db_conn = State(db_conn);
+            let db_conn = State(db_pool);
             let url_service = UrlService::builder()
                 .scheme("https")
                 .domain("example.com")
@@ -116,9 +130,12 @@ mod tests {
                 Either::E1(Json(resource)) => resource,
                 Either::E2(status) => panic!("Unexpected status code: {}", status),
             };
+
             assert_eq!(resource.subject, "acct:alice@example.com");
             assert_eq!(resource.aliases, [account_url.clone()]);
+
             let [Link { rel, r#type, href }] = <[_; 1]>::try_from(resource.links).unwrap();
+
             assert_eq!(rel, "self");
             assert_eq!(r#type.unwrap(), "application/activity+json");
             assert_eq!(href.unwrap(), account_url);
@@ -130,6 +147,7 @@ mod tests {
             let response = get(db_conn.clone(), url_service.clone(), Query(query))
                 .await
                 .unwrap();
+
             assert!(matches!(response, Either::E2(StatusCode::NOT_FOUND)));
 
             // Should not resolve a remote account
@@ -137,6 +155,7 @@ mod tests {
                 resource: "acct:bob@example.net".into(),
             };
             let response = get(db_conn, url_service, Query(query)).await.unwrap();
+
             assert!(matches!(response, Either::E2(StatusCode::NOT_FOUND)));
         })
         .await;
@@ -145,10 +164,16 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn custom_domain() {
-        database_test(|db_conn| async move {
-            prepare_db(&mut db_conn.get().await.unwrap()).await;
+        database_test(|db_pool| async move {
+            db_pool
+                .with_connection(|mut db_conn| async move {
+                    prepare_db(&mut db_conn).await;
+                    Ok::<_, eyre::Report>(())
+                })
+                .await
+                .unwrap();
 
-            let db_conn = State(db_conn);
+            let db_pool = State(db_pool);
             let url_service = UrlService::builder()
                 .scheme("https")
                 .domain("example.com")
@@ -160,24 +185,26 @@ mod tests {
             let query = WebfingerQuery {
                 resource: "acct:alice@example.com".into(),
             };
-            let response = get(db_conn.clone(), url_service.clone(), Query(query))
+            let response = get(db_pool.clone(), url_service.clone(), Query(query))
                 .await
                 .unwrap();
             let resource = match response {
                 Either::E1(Json(resource)) => resource,
                 Either::E2(status) => panic!("Unexpected status code: {}", status),
             };
+
             assert_eq!(resource.subject, "acct:alice@alice.example");
 
             // Should return the canonical domain as-is
             let query = WebfingerQuery {
                 resource: "acct:alice@alice.example".into(),
             };
-            let response = get(db_conn, url_service, Query(query)).await.unwrap();
+            let response = get(db_pool, url_service, Query(query)).await.unwrap();
             let resource = match response {
                 Either::E1(Json(resource)) => resource,
                 Either::E2(status) => panic!("Unexpected status code: {}", status),
             };
+
             assert_eq!(resource.subject, "acct:alice@alice.example");
         })
         .await;
@@ -212,6 +239,7 @@ mod tests {
                         })
                         .execute(tx)
                         .await?;
+
                     diesel::insert_into(accounts::table)
                         .values(NewAccount {
                             id: Uuid::now_v7(),

--- a/kitsune/src/http/page.rs
+++ b/kitsune/src/http/page.rs
@@ -53,7 +53,7 @@ impl PostComponent {
                         .select(DbMediaAttachment::as_select())
                         .load_stream::<DbMediaAttachment>(&mut db_conn);
 
-                    try_join!(author_fut, attachments_stream_fut).map_err(Error::from)
+                    try_join!(author_fut, attachments_stream_fut)
                 }
             })
             .await?;

--- a/kitsune/src/http/page.rs
+++ b/kitsune/src/http/page.rs
@@ -38,7 +38,7 @@ pub struct PostComponent {
 impl PostComponent {
     pub async fn prepare(state: &Zustand, post: Post) -> Result<Self> {
         let (author, attachments_stream) = state
-            .db_conn
+            .db_pool
             .with_connection(|mut db_conn| {
                 let post = &post;
 

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -39,7 +39,6 @@ impl Runnable for DeliverAccept {
                     .get_result::<Follow>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -62,7 +61,7 @@ impl Runnable for DeliverAccept {
                     .select(<(Account, User)>::as_select())
                     .get_result::<(Account, User)>(&mut db_conn);
 
-                try_join!(follower_inbox_url_fut, followed_info_fut).map_err(Self::Error::from)
+                try_join!(follower_inbox_url_fut, followed_info_fut)
             })
             .await?;
 

--- a/kitsune/src/job/deliver/accept.rs
+++ b/kitsune/src/job/deliver/accept.rs
@@ -30,7 +30,7 @@ impl Runnable for DeliverAccept {
 
     #[instrument(skip_all, fields(follow_id = %self.follow_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(follow) = accounts_follows::table
             .find(self.follow_id)
             .get_result::<Follow>(&mut db_conn)

--- a/kitsune/src/job/deliver/create.rs
+++ b/kitsune/src/job/deliver/create.rs
@@ -37,7 +37,6 @@ impl Runnable for DeliverCreate {
                     .get_result::<Post>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -48,14 +47,12 @@ impl Runnable for DeliverCreate {
         let (account, user) = ctx
             .state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 accounts::table
                     .find(post.account_id)
                     .inner_join(users::table)
                     .select(<(Account, User)>::as_select())
                     .get_result::<(Account, User)>(&mut db_conn)
-                    .await
-                    .map_err(Self::Error::from)
             })
             .await?;
 

--- a/kitsune/src/job/deliver/create.rs
+++ b/kitsune/src/job/deliver/create.rs
@@ -27,7 +27,7 @@ impl Runnable for DeliverCreate {
 
     #[instrument(skip_all, fields(post_id = %self.post_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(post) = posts::table
             .find(self.post_id)
             .select(Post::as_select())
@@ -45,7 +45,7 @@ impl Runnable for DeliverCreate {
             .get_result::<(Account, User)>(&mut db_conn)
             .await?;
 
-        let inbox_resolver = InboxResolver::new(ctx.state.db_conn.clone());
+        let inbox_resolver = InboxResolver::new(ctx.state.db_pool.clone());
         let inbox_stream = inbox_resolver
             .resolve(&post)
             .await?

--- a/kitsune/src/job/deliver/delete.rs
+++ b/kitsune/src/job/deliver/delete.rs
@@ -37,7 +37,6 @@ impl Runnable for DeliverDelete {
                     .get_result::<Post>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -56,7 +55,6 @@ impl Runnable for DeliverDelete {
                     .get_result::<(Account, User)>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -81,11 +79,8 @@ impl Runnable for DeliverDelete {
 
         ctx.state
             .db_pool
-            .with_connection(|mut db_conn| async move {
-                diesel::delete(posts::table.find(post_id))
-                    .execute(&mut db_conn)
-                    .await
-                    .map_err(Self::Error::from)
+            .with_connection(|mut db_conn| {
+                diesel::delete(posts::table.find(post_id)).execute(&mut db_conn)
             })
             .await?;
 

--- a/kitsune/src/job/deliver/delete.rs
+++ b/kitsune/src/job/deliver/delete.rs
@@ -27,7 +27,7 @@ impl Runnable for DeliverDelete {
 
     #[instrument(skip_all, fields(post_id = %self.post_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(post) = posts::table
             .find(self.post_id)
             .select(Post::as_select())
@@ -49,7 +49,7 @@ impl Runnable for DeliverDelete {
             return Ok(());
         };
 
-        let inbox_resolver = InboxResolver::new(ctx.state.db_conn.clone());
+        let inbox_resolver = InboxResolver::new(ctx.state.db_pool.clone());
         let inbox_stream = inbox_resolver
             .resolve(&post)
             .await?

--- a/kitsune/src/job/deliver/delete.rs
+++ b/kitsune/src/job/deliver/delete.rs
@@ -27,25 +27,40 @@ impl Runnable for DeliverDelete {
 
     #[instrument(skip_all, fields(post_id = %self.post_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_pool.get().await?;
-        let Some(post) = posts::table
-            .find(self.post_id)
-            .select(Post::as_select())
-            .get_result::<Post>(&mut db_conn)
-            .await
-            .optional()?
-        else {
+        let post = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                posts::table
+                    .find(self.post_id)
+                    .select(Post::as_select())
+                    .get_result::<Post>(&mut db_conn)
+                    .await
+                    .optional()
+                    .map_err(Self::Error::from)
+            })
+            .await?;
+
+        let Some(post) = post else {
             return Ok(());
         };
 
-        let Some((account, user)) = accounts::table
-            .find(post.account_id)
-            .inner_join(users::table)
-            .select(<(Account, User)>::as_select())
-            .get_result::<(Account, User)>(&mut db_conn)
-            .await
-            .optional()?
-        else {
+        let account_user_data = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                accounts::table
+                    .find(post.account_id)
+                    .inner_join(users::table)
+                    .select(<(Account, User)>::as_select())
+                    .get_result::<(Account, User)>(&mut db_conn)
+                    .await
+                    .optional()
+                    .map_err(Self::Error::from)
+            })
+            .await?;
+
+        let Some((account, user)) = account_user_data else {
             return Ok(());
         };
 
@@ -64,8 +79,14 @@ impl Runnable for DeliverDelete {
             .deliver_many(&account, &user, &delete_activity, inbox_stream)
             .await?;
 
-        diesel::delete(posts::table.find(post_id))
-            .execute(&mut db_conn)
+        ctx.state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                diesel::delete(posts::table.find(post_id))
+                    .execute(&mut db_conn)
+                    .await
+                    .map_err(Self::Error::from)
+            })
             .await?;
 
         Ok(())

--- a/kitsune/src/job/deliver/favourite.rs
+++ b/kitsune/src/job/deliver/favourite.rs
@@ -22,7 +22,7 @@ impl Runnable for DeliverFavourite {
 
     #[instrument(skip_all, fields(favourite_id = %self.favourite_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let favourite = posts_favourites::table
             .find(self.favourite_id)
             .get_result::<Favourite>(&mut db_conn)

--- a/kitsune/src/job/deliver/favourite.rs
+++ b/kitsune/src/job/deliver/favourite.rs
@@ -22,25 +22,30 @@ impl Runnable for DeliverFavourite {
 
     #[instrument(skip_all, fields(favourite_id = %self.favourite_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_pool.get().await?;
-        let favourite = posts_favourites::table
-            .find(self.favourite_id)
-            .get_result::<Favourite>(&mut db_conn)
+        let (favourite, ((account, user), inbox_url)) = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                let favourite = posts_favourites::table
+                    .find(self.favourite_id)
+                    .get_result::<Favourite>(&mut db_conn)
+                    .await?;
+
+                let account_user_fut = accounts::table
+                    .find(favourite.account_id)
+                    .inner_join(users::table)
+                    .select(<(Account, User)>::as_select())
+                    .get_result(&mut db_conn);
+
+                let inbox_url_fut = posts::table
+                    .find(favourite.post_id)
+                    .inner_join(accounts::table)
+                    .select(accounts::inbox_url)
+                    .get_result::<Option<String>>(&mut db_conn);
+
+                Ok::<_, Self::Error>((favourite, try_join!(account_user_fut, inbox_url_fut)?))
+            })
             .await?;
-
-        let account_user_fut = accounts::table
-            .find(favourite.account_id)
-            .inner_join(users::table)
-            .select(<(Account, User)>::as_select())
-            .get_result(&mut db_conn);
-
-        let inbox_url_fut = posts::table
-            .find(favourite.post_id)
-            .inner_join(accounts::table)
-            .select(accounts::inbox_url)
-            .get_result::<Option<String>>(&mut db_conn);
-
-        let ((account, user), inbox_url) = try_join!(account_user_fut, inbox_url_fut)?;
 
         if let Some(ref inbox_url) = inbox_url {
             let activity = favourite.into_activity(&ctx.state).await?;

--- a/kitsune/src/job/deliver/follow.rs
+++ b/kitsune/src/job/deliver/follow.rs
@@ -22,7 +22,7 @@ impl Runnable for DeliverFollow {
 
     #[instrument(skip_all, fields(follow_id = %self.follow_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(follow) = accounts_follows::table
             .find(self.follow_id)
             .get_result::<Follow>(&mut db_conn)

--- a/kitsune/src/job/deliver/follow.rs
+++ b/kitsune/src/job/deliver/follow.rs
@@ -22,29 +22,41 @@ impl Runnable for DeliverFollow {
 
     #[instrument(skip_all, fields(follow_id = %self.follow_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_pool.get().await?;
-        let Some(follow) = accounts_follows::table
-            .find(self.follow_id)
-            .get_result::<Follow>(&mut db_conn)
-            .await
-            .optional()?
-        else {
+        let follow = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                accounts_follows::table
+                    .find(self.follow_id)
+                    .get_result::<Follow>(&mut db_conn)
+                    .await
+                    .optional()
+                    .map_err(Self::Error::from)
+            })
+            .await?;
+
+        let Some(follow) = follow else {
             return Ok(());
         };
 
-        let follower_info_fut = accounts::table
-            .find(follow.follower_id)
-            .inner_join(users::table)
-            .select(<(Account, User)>::as_select())
-            .get_result::<(Account, User)>(&mut db_conn);
+        let ((follower, follower_user), followed_inbox) = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                let follower_info_fut = accounts::table
+                    .find(follow.follower_id)
+                    .inner_join(users::table)
+                    .select(<(Account, User)>::as_select())
+                    .get_result::<(Account, User)>(&mut db_conn);
 
-        let followed_inbox_fut = accounts::table
-            .find(follow.account_id)
-            .select(accounts::inbox_url)
-            .get_result::<Option<String>>(&mut db_conn);
+                let followed_inbox_fut = accounts::table
+                    .find(follow.account_id)
+                    .select(accounts::inbox_url)
+                    .get_result::<Option<String>>(&mut db_conn);
 
-        let ((follower, follower_user), followed_inbox) =
-            try_join!(follower_info_fut, followed_inbox_fut)?;
+                try_join!(follower_info_fut, followed_inbox_fut).map_err(Self::Error::from)
+            })
+            .await?;
 
         if let Some(followed_inbox) = followed_inbox {
             let follow_activity = follow.into_activity(&ctx.state).await?;

--- a/kitsune/src/job/deliver/follow.rs
+++ b/kitsune/src/job/deliver/follow.rs
@@ -31,7 +31,6 @@ impl Runnable for DeliverFollow {
                     .get_result::<Follow>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -54,7 +53,7 @@ impl Runnable for DeliverFollow {
                     .select(accounts::inbox_url)
                     .get_result::<Option<String>>(&mut db_conn);
 
-                try_join!(follower_info_fut, followed_inbox_fut).map_err(Self::Error::from)
+                try_join!(follower_info_fut, followed_inbox_fut)
             })
             .await?;
 

--- a/kitsune/src/job/deliver/reject.rs
+++ b/kitsune/src/job/deliver/reject.rs
@@ -39,7 +39,6 @@ impl Runnable for DeliverReject {
                     .get_result::<Follow>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -68,7 +67,6 @@ impl Runnable for DeliverReject {
                     let delete_fut = diesel::delete(&follow).execute(&mut db_conn);
 
                     try_join!(follower_inbox_url_fut, followed_info_fut, delete_fut)
-                        .map_err(Self::Error::from)
                 }
             })
             .await?;

--- a/kitsune/src/job/deliver/reject.rs
+++ b/kitsune/src/job/deliver/reject.rs
@@ -30,31 +30,44 @@ impl Runnable for DeliverReject {
 
     #[instrument(skip_all, fields(follow_id = %self.follow_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_pool.get().await?;
-        let Some(follow) = accounts_follows::table
-            .find(self.follow_id)
-            .get_result::<Follow>(&mut db_conn)
-            .await
-            .optional()?
-        else {
+        let follow = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                accounts_follows::table
+                    .find(self.follow_id)
+                    .get_result::<Follow>(&mut db_conn)
+                    .await
+                    .optional()
+                    .map_err(Self::Error::from)
+            })
+            .await?;
+
+        let Some(follow) = follow else {
             return Ok(());
         };
 
-        let follower_inbox_url_fut = accounts::table
-            .find(follow.follower_id)
-            .select(accounts::inbox_url.assume_not_null())
-            .get_result::<String>(&mut db_conn);
+        let (follower_inbox_url, (followed_account, followed_user), _delete_result) = ctx
+            .state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                let follower_inbox_url_fut = accounts::table
+                    .find(follow.follower_id)
+                    .select(accounts::inbox_url.assume_not_null())
+                    .get_result::<String>(&mut db_conn);
 
-        let followed_info_fut = accounts::table
-            .find(follow.account_id)
-            .inner_join(users::table.on(accounts::id.eq(users::account_id)))
-            .select(<(Account, User)>::as_select())
-            .get_result::<(Account, User)>(&mut db_conn);
+                let followed_info_fut = accounts::table
+                    .find(follow.account_id)
+                    .inner_join(users::table.on(accounts::id.eq(users::account_id)))
+                    .select(<(Account, User)>::as_select())
+                    .get_result::<(Account, User)>(&mut db_conn);
 
-        let delete_fut = diesel::delete(&follow).execute(&mut db_conn);
+                let delete_fut = diesel::delete(&follow).execute(&mut db_conn);
 
-        let (follower_inbox_url, (followed_account, followed_user), _delete_result) =
-            try_join!(follower_inbox_url_fut, followed_info_fut, delete_fut)?;
+                try_join!(follower_inbox_url_fut, followed_info_fut, delete_fut)
+                    .map_err(Self::Error::from)
+            })
+            .await?;
 
         let followed_account_url = ctx.state.service.url.user_url(followed_account.id);
 

--- a/kitsune/src/job/deliver/reject.rs
+++ b/kitsune/src/job/deliver/reject.rs
@@ -30,7 +30,7 @@ impl Runnable for DeliverReject {
 
     #[instrument(skip_all, fields(follow_id = %self.follow_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(follow) = accounts_follows::table
             .find(self.follow_id)
             .get_result::<Follow>(&mut db_conn)

--- a/kitsune/src/job/deliver/unfavourite.rs
+++ b/kitsune/src/job/deliver/unfavourite.rs
@@ -31,7 +31,6 @@ impl Runnable for DeliverUnfavourite {
                     .get_result::<Favourite>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -55,7 +54,7 @@ impl Runnable for DeliverUnfavourite {
                     .select(accounts::inbox_url)
                     .get_result::<Option<String>>(&mut db_conn);
 
-                try_join!(account_user_fut, inbox_url_fut).map_err(Self::Error::from)
+                try_join!(account_user_fut, inbox_url_fut)
             })
             .await?;
 
@@ -69,11 +68,8 @@ impl Runnable for DeliverUnfavourite {
 
         ctx.state
             .db_pool
-            .with_connection(|mut db_conn| async move {
-                diesel::delete(posts_favourites::table.find(favourite_id))
-                    .execute(&mut db_conn)
-                    .await
-                    .map_err(Self::Error::from)
+            .with_connection(|mut db_conn| {
+                diesel::delete(posts_favourites::table.find(favourite_id)).execute(&mut db_conn)
             })
             .await?;
 

--- a/kitsune/src/job/deliver/unfavourite.rs
+++ b/kitsune/src/job/deliver/unfavourite.rs
@@ -22,7 +22,7 @@ impl Runnable for DeliverUnfavourite {
 
     #[instrument(skip_all, fields(favourite_id = %self.favourite_id))]
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(favourite) = posts_favourites::table
             .find(self.favourite_id)
             .get_result::<Favourite>(&mut db_conn)

--- a/kitsune/src/job/deliver/unfollow.rs
+++ b/kitsune/src/job/deliver/unfollow.rs
@@ -30,7 +30,6 @@ impl Runnable for DeliverUnfollow {
                     .get_result::<Follow>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -63,7 +62,6 @@ impl Runnable for DeliverUnfollow {
                         followed_account_inbox_url_fut,
                         delete_fut
                     )
-                    .map_err(Self::Error::from)
                 }
             })
             .await?;

--- a/kitsune/src/job/deliver/unfollow.rs
+++ b/kitsune/src/job/deliver/unfollow.rs
@@ -21,7 +21,7 @@ impl Runnable for DeliverUnfollow {
     type Error = eyre::Report;
 
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let Some(follow) = accounts_follows::table
             .find(self.follow_id)
             .get_result::<Follow>(&mut db_conn)

--- a/kitsune/src/job/deliver/update.rs
+++ b/kitsune/src/job/deliver/update.rs
@@ -48,7 +48,6 @@ impl Runnable for DeliverUpdate {
                             .get_result(&mut db_conn)
                             .await
                             .optional()
-                            .map_err(Self::Error::from)
                     })
                     .await?;
 
@@ -77,7 +76,6 @@ impl Runnable for DeliverUpdate {
                             .get_result(&mut db_conn)
                             .await
                             .optional()
-                            .map_err(Self::Error::from)
                     })
                     .await?;
 

--- a/kitsune/src/job/deliver/update.rs
+++ b/kitsune/src/job/deliver/update.rs
@@ -34,8 +34,8 @@ impl Runnable for DeliverUpdate {
     type Error = eyre::Report;
 
     async fn run(&self, ctx: &Self::Context) -> Result<(), Self::Error> {
-        let inbox_resolver = InboxResolver::new(ctx.state.db_conn.clone());
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let inbox_resolver = InboxResolver::new(ctx.state.db_pool.clone());
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let (activity, account, user, inbox_stream) = match self.entity {
             UpdateEntity::Account => {
                 let Some((account, user)) = accounts::table

--- a/kitsune/src/job/mailing/confirmation.rs
+++ b/kitsune/src/job/mailing/confirmation.rs
@@ -28,13 +28,11 @@ impl Runnable for SendConfirmationMail {
         let user = ctx
             .state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 users::table
                     .find(self.user_id)
                     .select(User::as_select())
                     .get_result(&mut db_conn)
-                    .await
-                    .map_err(Self::Error::from)
             })
             .await?;
 

--- a/kitsune/src/job/mailing/confirmation.rs
+++ b/kitsune/src/job/mailing/confirmation.rs
@@ -25,7 +25,7 @@ impl Runnable for SendConfirmationMail {
             user_service.mark_as_confirmed(self.user_id).await?;
         }
 
-        let mut db_conn = ctx.state.db_conn.get().await?;
+        let mut db_conn = ctx.state.db_pool.get().await?;
         let user = users::table
             .find(self.user_id)
             .select(User::as_select())

--- a/kitsune/src/job/mod.rs
+++ b/kitsune/src/job/mod.rs
@@ -158,7 +158,7 @@ impl JobContextRepository for KitsuneContextRepo {
         context: Self::JobContext,
     ) -> Result<(), Self::Error> {
         self.db_pool
-            .with_connection(|conn| async move {
+            .with_connection(|mut conn| async move {
                 diesel::insert_into(job_context::table)
                     .values(NewJobContext {
                         id: job_id,

--- a/kitsune/src/job/mod.rs
+++ b/kitsune/src/job/mod.rs
@@ -124,12 +124,10 @@ impl JobContextRepository for KitsuneContextRepo {
     {
         let stream = self
             .db_pool
-            .with_connection(|mut conn| async move {
+            .with_connection(|mut conn| {
                 job_context::table
                     .filter(job_context::id.eq_any(job_ids))
                     .load_stream::<JobContext<Job>>(&mut conn)
-                    .await
-                    .map_err(Self::Error::from)
             })
             .await?;
 
@@ -141,11 +139,8 @@ impl JobContextRepository for KitsuneContextRepo {
 
     async fn remove_context(&self, job_id: Uuid) -> Result<(), Self::Error> {
         self.db_pool
-            .with_connection(|mut conn| async move {
-                diesel::delete(job_context::table.find(job_id))
-                    .execute(&mut conn)
-                    .await
-                    .map_err(Self::Error::from)
+            .with_connection(|mut conn| {
+                diesel::delete(job_context::table.find(job_id)).execute(&mut conn)
             })
             .await?;
 
@@ -158,15 +153,13 @@ impl JobContextRepository for KitsuneContextRepo {
         context: Self::JobContext,
     ) -> Result<(), Self::Error> {
         self.db_pool
-            .with_connection(|mut conn| async move {
+            .with_connection(|mut conn| {
                 diesel::insert_into(job_context::table)
                     .values(NewJobContext {
                         id: job_id,
                         context: Json(context),
                     })
                     .execute(&mut conn)
-                    .await
-                    .map_err(Self::Error::from)
             })
             .await?;
 

--- a/kitsune/src/job/mod.rs
+++ b/kitsune/src/job/mod.rs
@@ -122,10 +122,15 @@ impl JobContextRepository for KitsuneContextRepo {
     where
         I: Iterator<Item = Uuid> + Send + 'static,
     {
-        let mut conn = self.db_pool.get().await?;
-        let stream = job_context::table
-            .filter(job_context::id.eq_any(job_ids))
-            .load_stream::<JobContext<Job>>(&mut conn)
+        let stream = self
+            .db_pool
+            .with_connection(|mut conn| async move {
+                job_context::table
+                    .filter(job_context::id.eq_any(job_ids))
+                    .load_stream::<JobContext<Job>>(&mut conn)
+                    .await
+                    .map_err(Self::Error::from)
+            })
             .await?;
 
         Ok(stream
@@ -135,9 +140,13 @@ impl JobContextRepository for KitsuneContextRepo {
     }
 
     async fn remove_context(&self, job_id: Uuid) -> Result<(), Self::Error> {
-        let mut conn = self.db_pool.get().await?;
-        diesel::delete(job_context::table.find(job_id))
-            .execute(&mut conn)
+        self.db_pool
+            .with_connection(|mut conn| async move {
+                diesel::delete(job_context::table.find(job_id))
+                    .execute(&mut conn)
+                    .await
+                    .map_err(Self::Error::from)
+            })
             .await?;
 
         Ok(())
@@ -148,13 +157,17 @@ impl JobContextRepository for KitsuneContextRepo {
         job_id: Uuid,
         context: Self::JobContext,
     ) -> Result<(), Self::Error> {
-        let mut conn = self.db_pool.get().await?;
-        diesel::insert_into(job_context::table)
-            .values(NewJobContext {
-                id: job_id,
-                context: Json(context),
+        self.db_pool
+            .with_connection(|conn| async move {
+                diesel::insert_into(job_context::table)
+                    .values(NewJobContext {
+                        id: job_id,
+                        context: Json(context),
+                    })
+                    .execute(&mut conn)
+                    .await
+                    .map_err(Self::Error::from)
             })
-            .execute(&mut conn)
             .await?;
 
         Ok(())

--- a/kitsune/src/lib.rs
+++ b/kitsune/src/lib.rs
@@ -312,7 +312,7 @@ pub async fn initialise_state(
             .context("Couldn't build the federation filter (check your glob syntax)")?;
 
     let fetcher = Fetcher::builder()
-        .db_conn(conn.clone())
+        .db_pool(conn.clone())
         .embed_client(embed_client.clone())
         .federation_filter(federation_filter_service.clone())
         .post_cache(prepare_cache(config, "ACTIVITYPUB-POST"))
@@ -385,7 +385,7 @@ pub async fn initialise_state(
         .build();
 
     let post_service = PostService::builder()
-        .db_conn(conn.clone())
+        .db_pool(conn.clone())
         .embed_client(embed_client.clone())
         .instance_service(instance_service.clone())
         .job_service(job_service.clone())
@@ -395,7 +395,7 @@ pub async fn initialise_state(
         .url_service(url_service.clone())
         .build();
 
-    let timeline_service = TimelineService::builder().db_conn(conn.clone()).build();
+    let timeline_service = TimelineService::builder().db_pool(conn.clone()).build();
 
     let user_service = UserService::builder()
         .captcha_service(captcha_service.clone())

--- a/kitsune/src/mapping/activitypub/activity.rs
+++ b/kitsune/src/mapping/activitypub/activity.rs
@@ -48,7 +48,7 @@ impl IntoActivity for Favourite {
     type NegateOutput = Activity;
 
     async fn into_activity(self, state: &Zustand) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
+        let mut db_conn = state.db_pool.get().await?;
         let account_url_fut = accounts::table
             .find(self.account_id)
             .select(accounts::url)
@@ -72,7 +72,7 @@ impl IntoActivity for Favourite {
     }
 
     async fn into_negate_activity(self, state: &Zustand) -> Result<Self::NegateOutput> {
-        let mut db_conn = state.db_conn.get().await?;
+        let mut db_conn = state.db_pool.get().await?;
         let account_url = accounts::table
             .find(self.account_id)
             .select(accounts::url)
@@ -96,7 +96,7 @@ impl IntoActivity for Follow {
     type NegateOutput = Activity;
 
     async fn into_activity(self, state: &Zustand) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
+        let mut db_conn = state.db_pool.get().await?;
         let attributed_to_fut = accounts::table
             .find(self.follower_id)
             .select(accounts::url)
@@ -120,7 +120,7 @@ impl IntoActivity for Follow {
     }
 
     async fn into_negate_activity(self, state: &Zustand) -> Result<Self::NegateOutput> {
-        let mut db_conn = state.db_conn.get().await?;
+        let mut db_conn = state.db_pool.get().await?;
         let attributed_to = accounts::table
             .find(self.follower_id)
             .select(accounts::url)
@@ -147,7 +147,7 @@ impl IntoActivity for Post {
         let account_url = state.service.url.user_url(self.account_id);
 
         if let Some(reposted_post_id) = self.reposted_post_id {
-            let mut db_conn = state.db_conn.get().await?;
+            let mut db_conn = state.db_pool.get().await?;
             let reposted_post_url = posts::table
                 .find(reposted_post_id)
                 .select(posts::url)

--- a/kitsune/src/mapping/activitypub/activity.rs
+++ b/kitsune/src/mapping/activitypub/activity.rs
@@ -1,9 +1,5 @@
 use super::IntoObject;
-use crate::{
-    error::{Error, Result},
-    state::Zustand,
-    try_join,
-};
+use crate::{error::Result, state::Zustand, try_join};
 use async_trait::async_trait;
 use diesel::QueryDsl;
 use diesel_async::RunQueryDsl;
@@ -65,7 +61,7 @@ impl IntoActivity for Favourite {
                     .select(posts::url)
                     .get_result(&mut db_conn);
 
-                try_join!(account_url_fut, post_url_fut).map_err(Error::from)
+                try_join!(account_url_fut, post_url_fut)
             })
             .await?;
 
@@ -82,13 +78,11 @@ impl IntoActivity for Favourite {
     async fn into_negate_activity(self, state: &Zustand) -> Result<Self::NegateOutput> {
         let account_url = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 accounts::table
                     .find(self.account_id)
                     .select(accounts::url)
                     .get_result::<String>(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 
@@ -122,7 +116,7 @@ impl IntoActivity for Follow {
                     .select(accounts::url)
                     .get_result::<String>(&mut db_conn);
 
-                try_join!(attributed_to_fut, object_fut).map_err(Error::from)
+                try_join!(attributed_to_fut, object_fut)
             })
             .await?;
 
@@ -139,13 +133,11 @@ impl IntoActivity for Follow {
     async fn into_negate_activity(self, state: &Zustand) -> Result<Self::NegateOutput> {
         let attributed_to = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 accounts::table
                     .find(self.follower_id)
                     .select(accounts::url)
                     .get_result::<String>(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 
@@ -171,13 +163,11 @@ impl IntoActivity for Post {
         if let Some(reposted_post_id) = self.reposted_post_id {
             let reposted_post_url = state
                 .db_pool
-                .with_connection(|mut db_conn| async move {
+                .with_connection(|mut db_conn| {
                     posts::table
                         .find(reposted_post_id)
                         .select(posts::url)
                         .get_result(&mut db_conn)
-                        .await
-                        .map_err(Error::from)
                 })
                 .await?;
 

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -106,7 +106,6 @@ impl IntoObject for Post {
                         mentions_fut,
                         attachment_stream_fut
                     )
-                    .map_err(Error::from)
                 }
             })
             .await?;
@@ -187,7 +186,7 @@ impl IntoObject for Account {
                 }))
                 .map(Option::transpose);
 
-                try_join!(icon_fut, image_fut).map_err(Error::from)
+                try_join!(icon_fut, image_fut)
             })
             .await?;
 

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -72,38 +72,42 @@ impl IntoObject for Post {
 
         let (account, in_reply_to, mentions, attachment_stream) = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
-                let account_fut = accounts::table
-                    .find(self.account_id)
-                    .select(Account::as_select())
-                    .get_result(&mut db_conn);
+            .with_connection(|mut db_conn| {
+                let self = &self;
 
-                let in_reply_to_fut =
-                    OptionFuture::from(self.in_reply_to_id.map(|in_reply_to_id| {
-                        posts::table
-                            .find(in_reply_to_id)
-                            .select(posts::url)
-                            .get_result(&mut db_conn)
-                    }))
-                    .map(Option::transpose);
+                async move {
+                    let account_fut = accounts::table
+                        .find(self.account_id)
+                        .select(Account::as_select())
+                        .get_result(&mut db_conn);
 
-                let mentions_fut = Mention::belonging_to(&self)
-                    .inner_join(accounts::table)
-                    .select((Mention::as_select(), Account::as_select()))
-                    .load::<(Mention, Account)>(&mut db_conn);
+                    let in_reply_to_fut =
+                        OptionFuture::from(self.in_reply_to_id.map(|in_reply_to_id| {
+                            posts::table
+                                .find(in_reply_to_id)
+                                .select(posts::url)
+                                .get_result(&mut db_conn)
+                        }))
+                        .map(Option::transpose);
 
-                let attachment_stream_fut = PostMediaAttachment::belonging_to(&self)
-                    .inner_join(media_attachments::table)
-                    .select(DbMediaAttachment::as_select())
-                    .load_stream::<DbMediaAttachment>(&mut db_conn);
+                    let mentions_fut = Mention::belonging_to(&self)
+                        .inner_join(accounts::table)
+                        .select((Mention::as_select(), Account::as_select()))
+                        .load::<(Mention, Account)>(&mut db_conn);
 
-                try_join!(
-                    account_fut,
-                    in_reply_to_fut,
-                    mentions_fut,
-                    attachment_stream_fut
-                )
-                .map_err(Error::from)
+                    let attachment_stream_fut = PostMediaAttachment::belonging_to(&self)
+                        .inner_join(media_attachments::table)
+                        .select(DbMediaAttachment::as_select())
+                        .load_stream::<DbMediaAttachment>(&mut db_conn);
+
+                    try_join!(
+                        account_fut,
+                        in_reply_to_fut,
+                        mentions_fut,
+                        attachment_stream_fut
+                    )
+                    .map_err(Error::from)
+                }
             })
             .await?;
 

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -70,7 +70,7 @@ impl IntoObject for Post {
             return Err(ApiError::NotFound.into());
         }
 
-        let mut db_conn = state.db_conn.get().await?;
+        let mut db_conn = state.db_pool.get().await?;
         let account_fut = accounts::table
             .find(self.account_id)
             .select(Account::as_select())
@@ -155,7 +155,7 @@ impl IntoObject for Account {
     type Output = Actor;
 
     async fn into_object(self, state: &Zustand) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
+        let mut db_conn = state.db_pool.get().await?;
 
         let icon_fut = OptionFuture::from(self.avatar_id.map(|avatar_id| {
             media_attachments::table

--- a/kitsune/src/mapping/mastodon/mod.rs
+++ b/kitsune/src/mapping/mastodon/mod.rs
@@ -98,7 +98,7 @@ impl MastodonMapper {
     fn mapper_state(&self) -> MapperState<'_> {
         MapperState {
             attachment_service: &self.attachment_service,
-            db_conn: &self.db_pool,
+            db_pool: &self.db_pool,
             embed_client: self.embed_client.as_ref(),
             url_service: &self.url_service,
         }

--- a/kitsune/src/mapping/mastodon/mod.rs
+++ b/kitsune/src/mapping/mastodon/mod.rs
@@ -80,7 +80,7 @@ pub struct MastodonMapper {
     )]
     _cache_invalidator: (),
     attachment_service: AttachmentService,
-    db_conn: PgPool,
+    db_pool: PgPool,
     embed_client: Option<EmbedClient>,
     mastodon_cache: ArcCache<Uuid, OwnedValue>,
     url_service: UrlService,
@@ -98,7 +98,7 @@ impl MastodonMapper {
     fn mapper_state(&self) -> MapperState<'_> {
         MapperState {
             attachment_service: &self.attachment_service,
-            db_conn: &self.db_conn,
+            db_conn: &self.db_pool,
             embed_client: self.embed_client.as_ref(),
             url_service: &self.url_service,
         }

--- a/kitsune/src/mapping/mastodon/sealed.rs
+++ b/kitsune/src/mapping/mastodon/sealed.rs
@@ -40,7 +40,7 @@ use std::str::FromStr;
 #[derive(Clone, Copy)]
 pub struct MapperState<'a> {
     pub attachment_service: &'a AttachmentService,
-    pub db_conn: &'a PgPool,
+    pub db_pool: &'a PgPool,
     pub embed_client: Option<&'a EmbedClient>,
     pub url_service: &'a UrlService,
 }
@@ -69,7 +69,7 @@ impl IntoMastodon for DbAccount {
 
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
         let (statuses_count, followers_count, following_count) = state
-            .db_conn
+            .db_pool
             .with_connection(|mut db_conn| async move {
                 let statuses_count_fut = posts::table
                     .filter(posts::account_id.eq(self.id))
@@ -151,35 +151,38 @@ impl IntoMastodon for (&DbAccount, &DbAccount) {
     }
 
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
-
         let (requestor, target) = self;
-        let following_requested_fut = accounts_follows::table
-            .filter(
-                accounts_follows::account_id
-                    .eq(target.id)
-                    .and(accounts_follows::follower_id.eq(requestor.id)),
-            )
-            .get_result::<Follow>(&mut db_conn)
-            .map(OptionalExtension::optional)
-            .map_ok(|optional_follow| {
-                optional_follow.map_or((false, false), |follow| {
-                    (follow.approved_at.is_some(), follow.approved_at.is_none())
-                })
-            });
 
-        let followed_by_fut = accounts_follows::table
-            .filter(
-                accounts_follows::account_id
-                    .eq(requestor.id)
-                    .and(accounts_follows::follower_id.eq(target.id)),
-            )
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_ok(|count| count != 0);
+        let ((following, requested), followed_by) = state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                let following_requested_fut = accounts_follows::table
+                    .filter(
+                        accounts_follows::account_id
+                            .eq(target.id)
+                            .and(accounts_follows::follower_id.eq(requestor.id)),
+                    )
+                    .get_result::<Follow>(&mut db_conn)
+                    .map(OptionalExtension::optional)
+                    .map_ok(|optional_follow| {
+                        optional_follow.map_or((false, false), |follow| {
+                            (follow.approved_at.is_some(), follow.approved_at.is_none())
+                        })
+                    });
 
-        let ((following, requested), followed_by) =
-            try_join!(following_requested_fut, followed_by_fut)?;
+                let followed_by_fut = accounts_follows::table
+                    .filter(
+                        accounts_follows::account_id
+                            .eq(requestor.id)
+                            .and(accounts_follows::follower_id.eq(target.id)),
+                    )
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .map_ok(|count| count != 0);
+
+                try_join!(following_requested_fut, followed_by_fut).map_err(Error::from)
+            })
+            .await?;
 
         Ok(Relationship {
             id: target.id,
@@ -208,12 +211,16 @@ impl IntoMastodon for DbMention {
     }
 
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
-
-        let account: DbAccount = accounts::table
-            .find(self.account_id)
-            .select(DbAccount::as_select())
-            .get_result(&mut db_conn)
+        let account: DbAccount = state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                accounts::table
+                    .find(self.account_id)
+                    .select(DbAccount::as_select())
+                    .get_result(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await?;
 
         let mut acct = account.username.clone();
@@ -271,25 +278,28 @@ impl IntoMastodon for (&DbAccount, DbPost) {
     }
 
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
-
         let (account, post) = self;
 
-        let favourited_fut = posts_favourites::table
-            .filter(posts_favourites::account_id.eq(account.id))
-            .filter(posts_favourites::post_id.eq(post.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_ok(|count| count != 0);
+        let (favourited, reblogged) = state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                let favourited_fut = posts_favourites::table
+                    .filter(posts_favourites::account_id.eq(account.id))
+                    .filter(posts_favourites::post_id.eq(post.id))
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .map_ok(|count| count != 0);
 
-        let reblogged_fut = posts::table
-            .filter(posts::account_id.eq(account.id))
-            .filter(posts::reposted_post_id.eq(post.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_ok(|count| count != 0);
+                let reblogged_fut = posts::table
+                    .filter(posts::account_id.eq(account.id))
+                    .filter(posts::reposted_post_id.eq(post.id))
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .map_ok(|count| count != 0);
 
-        let (favourited, reblogged) = try_join!(favourited_fut, reblogged_fut)?;
+                try_join!(favourited_fut, reblogged_fut).map_err(Error::from)
+            })
+            .await?;
 
         let mut status = post.into_mastodon(state).await?;
         status.favourited = favourited;
@@ -308,49 +318,53 @@ impl IntoMastodon for DbPost {
     }
 
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
-        let mut db_conn = state.db_conn.get().await?;
-
-        let account_fut = accounts::table
-            .find(self.account_id)
-            .select(DbAccount::as_select())
-            .get_result::<DbAccount>(&mut db_conn)
-            .map_err(Error::from)
-            .and_then(|db_account| db_account.into_mastodon(state));
-
-        let reblog_count_fut = posts::table
-            .filter(posts::reposted_post_id.eq(self.id))
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_err(Error::from);
-
-        let favourites_count_fut = DbFavourite::belonging_to(&self)
-            .count()
-            .get_result::<i64>(&mut db_conn)
-            .map_err(Error::from);
-
-        let media_attachments_fut = DbPostMediaAttachment::belonging_to(&self)
-            .inner_join(media_attachments::table)
-            .select(DbMediaAttachment::as_select())
-            .load_stream::<DbMediaAttachment>(&mut db_conn)
-            .map_err(Error::from)
-            .and_then(|attachment_stream| {
-                attachment_stream
+        let (account, reblog_count, favourites_count, media_attachments, mentions_stream) = state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                let account_fut = accounts::table
+                    .find(self.account_id)
+                    .select(DbAccount::as_select())
+                    .get_result::<DbAccount>(&mut db_conn)
                     .map_err(Error::from)
-                    .and_then(|attachment| attachment.into_mastodon(state))
-                    .try_collect()
-            });
+                    .and_then(|db_account| db_account.into_mastodon(state));
 
-        let mentions_stream_fut = DbMention::belonging_to(&self)
-            .load_stream::<DbMention>(&mut db_conn)
-            .map_err(Error::from);
+                let reblog_count_fut = posts::table
+                    .filter(posts::reposted_post_id.eq(self.id))
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .map_err(Error::from);
 
-        let (account, reblog_count, favourites_count, media_attachments, mentions_stream) = try_join!(
-            account_fut,
-            reblog_count_fut,
-            favourites_count_fut,
-            media_attachments_fut,
-            mentions_stream_fut,
-        )?;
+                let favourites_count_fut = DbFavourite::belonging_to(&self)
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .map_err(Error::from);
+
+                let media_attachments_fut = DbPostMediaAttachment::belonging_to(&self)
+                    .inner_join(media_attachments::table)
+                    .select(DbMediaAttachment::as_select())
+                    .load_stream::<DbMediaAttachment>(&mut db_conn)
+                    .map_err(Error::from)
+                    .and_then(|attachment_stream| {
+                        attachment_stream
+                            .map_err(Error::from)
+                            .and_then(|attachment| attachment.into_mastodon(state))
+                            .try_collect()
+                    });
+
+                let mentions_stream_fut = DbMention::belonging_to(&self)
+                    .load_stream::<DbMention>(&mut db_conn)
+                    .map_err(Error::from);
+
+                try_join!(
+                    account_fut,
+                    reblog_count_fut,
+                    favourites_count_fut,
+                    media_attachments_fut,
+                    mentions_stream_fut,
+                )
+                .map_err(Error::from)
+            })
+            .await?;
 
         let link_preview = OptionFuture::from(
             self.link_preview_url
@@ -371,22 +385,27 @@ impl IntoMastodon for DbPost {
             .try_collect()
             .await?;
 
-        let reblog = OptionFuture::from(
-            OptionFuture::from(self.reposted_post_id.map(|id| {
-                posts::table
-                    .find(id)
-                    .select(DbPost::as_select())
-                    .get_result::<DbPost>(&mut db_conn)
-                    .map(OptionalExtension::optional)
-            }))
-            .await
-            .transpose()?
-            .flatten()
-            .map(|post| post.into_mastodon(state)),
-        )
-        .await
-        .transpose()?
-        .map(Box::new);
+        let reblog = state
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                OptionFuture::from(
+                    OptionFuture::from(self.reposted_post_id.map(|id| {
+                        posts::table
+                            .find(id)
+                            .select(DbPost::as_select())
+                            .get_result::<DbPost>(&mut db_conn)
+                            .map(OptionalExtension::optional)
+                    }))
+                    .await
+                    .transpose()?
+                    .flatten()
+                    .map(|post| post.into_mastodon(state)), // This will allocate two database connections. Fuck.
+                )
+                .await
+                .transpose()
+            })
+            .await?
+            .map(Box::new);
 
         Ok(Status {
             id: self.id,

--- a/kitsune/src/mapping/mastodon/sealed.rs
+++ b/kitsune/src/mapping/mastodon/sealed.rs
@@ -87,7 +87,6 @@ impl IntoMastodon for DbAccount {
                     .get_result::<i64>(&mut db_conn);
 
                 try_join!(statuses_count_fut, followers_count_fut, following_count_fut)
-                    .map_err(Error::from)
             })
             .await?;
 
@@ -180,7 +179,7 @@ impl IntoMastodon for (&DbAccount, &DbAccount) {
                     .get_result::<i64>(&mut db_conn)
                     .map_ok(|count| count != 0);
 
-                try_join!(following_requested_fut, followed_by_fut).map_err(Error::from)
+                try_join!(following_requested_fut, followed_by_fut)
             })
             .await?;
 
@@ -213,13 +212,11 @@ impl IntoMastodon for DbMention {
     async fn into_mastodon(self, state: MapperState<'_>) -> Result<Self::Output> {
         let account: DbAccount = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 accounts::table
                     .find(self.account_id)
                     .select(DbAccount::as_select())
                     .get_result(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 
@@ -297,7 +294,7 @@ impl IntoMastodon for (&DbAccount, DbPost) {
                     .get_result::<i64>(&mut db_conn)
                     .map_ok(|count| count != 0);
 
-                try_join!(favourited_fut, reblogged_fut).map_err(Error::from)
+                try_join!(favourited_fut, reblogged_fut)
             })
             .await?;
 
@@ -366,7 +363,6 @@ impl IntoMastodon for DbPost {
                         media_attachments_fut,
                         mentions_stream_fut,
                     )
-                    .map_err(Error::from)
                 }
             })
             .await?;

--- a/kitsune/src/resolve/post.rs
+++ b/kitsune/src/resolve/post.rs
@@ -87,7 +87,6 @@ mod test {
     use crate::{
         activitypub::Fetcher,
         config::FederationFilterConfiguration,
-        error::Error,
         job::KitsuneContextRepo,
         service::{
             account::AccountService, attachment::AttachmentService,
@@ -191,14 +190,13 @@ mod test {
 
                 let (account_id, _mention_text) = &mentioned_account_ids[0];
                 let mentioned_account = db_pool
-                    .with_connection(|mut db_conn| async move {
+                    .with_connection(|mut db_conn| {
                         accounts::table
                             .find(account_id)
                             .select(Account::as_select())
                             .get_result::<Account>(&mut db_conn)
-                            .await
-                            .map_err(Error::from)
-                    }).await
+                    })
+                    .await
                     .expect("Failed to fetch account");
 
                 assert_eq!(mentioned_account.username, "0x0");

--- a/kitsune/src/service/attachment.rs
+++ b/kitsune/src/service/attachment.rs
@@ -67,14 +67,11 @@ pub struct AttachmentService {
 impl AttachmentService {
     pub async fn get_by_id(&self, id: Uuid) -> Result<MediaAttachment> {
         self.db_pool
-            .with_connection(|mut db_conn| async move {
-                media_attachments::table
-                    .find(id)
-                    .get_result(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
+            .with_connection(|mut db_conn| {
+                media_attachments::table.find(id).get_result(&mut db_conn)
             })
             .await
+            .map_err(Error::from)
     }
 
     /// Get the URL to an attachment
@@ -132,7 +129,7 @@ impl AttachmentService {
         }
 
         self.db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 diesel::update(
                     media_attachments::table.filter(
                         media_attachments::id
@@ -142,10 +139,9 @@ impl AttachmentService {
                 )
                 .set(changeset)
                 .get_result(&mut db_conn)
-                .await
-                .map_err(Error::from)
             })
             .await
+            .map_err(Error::from)
     }
 
     pub async fn upload<S>(&self, upload: Upload<S>) -> Result<MediaAttachment>
@@ -164,7 +160,7 @@ impl AttachmentService {
 
         let media_attachment = self
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 diesel::insert_into(media_attachments::table)
                     .values(NewMediaAttachment {
                         id: Uuid::now_v7(),
@@ -176,8 +172,6 @@ impl AttachmentService {
                         remote_url: None,
                     })
                     .get_result(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 

--- a/kitsune/src/service/instance.rs
+++ b/kitsune/src/service/instance.rs
@@ -10,7 +10,7 @@ use typed_builder::TypedBuilder;
 
 #[derive(Clone, TypedBuilder)]
 pub struct InstanceService {
-    db_conn: PgPool,
+    db_pool: PgPool,
     #[builder(setter(into))]
     name: SmolStr,
     #[builder(setter(into))]
@@ -36,7 +36,7 @@ impl InstanceService {
     }
 
     pub async fn known_instances(&self) -> Result<u64> {
-        self.db_conn
+        self.db_pool
             .with_connection(|mut db_conn| async move {
                 accounts::table
                     .filter(accounts::local.eq(false))
@@ -52,7 +52,7 @@ impl InstanceService {
     }
 
     pub async fn local_post_count(&self) -> Result<u64> {
-        self.db_conn
+        self.db_pool
             .with_connection(|mut db_conn| async move {
                 posts::table
                     .filter(posts::is_local.eq(true))
@@ -71,7 +71,7 @@ impl InstanceService {
     }
 
     pub async fn user_count(&self) -> Result<u64> {
-        self.db_conn
+        self.db_pool
             .with_connection(|mut db_conn| async move {
                 users::table
                     .count()

--- a/kitsune/src/service/instance.rs
+++ b/kitsune/src/service/instance.rs
@@ -36,27 +36,33 @@ impl InstanceService {
     }
 
     pub async fn known_instances(&self) -> Result<u64> {
-        let mut db_conn = self.db_conn.get().await?;
-        accounts::table
-            .filter(accounts::local.eq(false))
-            .select(accounts::domain)
-            .distinct()
-            .count()
-            .get_result::<i64>(&mut db_conn)
+        self.db_conn
+            .with_connection(|mut db_conn| async move {
+                accounts::table
+                    .filter(accounts::local.eq(false))
+                    .select(accounts::domain)
+                    .distinct()
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .await
+                    .map(|count| count as u64)
+                    .map_err(Error::from)
+            })
             .await
-            .map(|count| count as u64)
-            .map_err(Error::from)
     }
 
     pub async fn local_post_count(&self) -> Result<u64> {
-        let mut db_conn = self.db_conn.get().await?;
-        posts::table
-            .filter(posts::is_local.eq(true))
-            .count()
-            .get_result::<i64>(&mut db_conn)
+        self.db_conn
+            .with_connection(|mut db_conn| async move {
+                posts::table
+                    .filter(posts::is_local.eq(true))
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .await
+                    .map(|count| count as u64)
+                    .map_err(Error::from)
+            })
             .await
-            .map(|count| count as u64)
-            .map_err(Error::from)
     }
 
     #[must_use]
@@ -65,12 +71,15 @@ impl InstanceService {
     }
 
     pub async fn user_count(&self) -> Result<u64> {
-        let mut db_conn = self.db_conn.get().await?;
-        users::table
-            .count()
-            .get_result::<i64>(&mut db_conn)
+        self.db_conn
+            .with_connection(|mut db_conn| async move {
+                users::table
+                    .count()
+                    .get_result::<i64>(&mut db_conn)
+                    .await
+                    .map(|count| count as u64)
+                    .map_err(Error::from)
+            })
             .await
-            .map(|count| count as u64)
-            .map_err(Error::from)
     }
 }

--- a/kitsune/src/service/instance.rs
+++ b/kitsune/src/service/instance.rs
@@ -46,9 +46,9 @@ impl InstanceService {
                     .get_result::<i64>(&mut db_conn)
                     .await
                     .map(|count| count as u64)
-                    .map_err(Error::from)
             })
             .await
+            .map_err(Error::from)
     }
 
     pub async fn local_post_count(&self) -> Result<u64> {
@@ -60,9 +60,9 @@ impl InstanceService {
                     .get_result::<i64>(&mut db_conn)
                     .await
                     .map(|count| count as u64)
-                    .map_err(Error::from)
             })
             .await
+            .map_err(Error::from)
     }
 
     #[must_use]
@@ -78,8 +78,8 @@ impl InstanceService {
                     .get_result::<i64>(&mut db_conn)
                     .await
                     .map(|count| count as u64)
-                    .map_err(Error::from)
             })
             .await
+            .map_err(Error::from)
     }
 }

--- a/kitsune/src/service/oauth2/issuer.rs
+++ b/kitsune/src/service/oauth2/issuer.rs
@@ -72,14 +72,12 @@ impl Issuer for OAuthIssuer {
     async fn refresh(&mut self, refresh_token: &str, grant: Grant) -> Result<RefreshedToken, ()> {
         let (refresh_token, access_token) = self
             .db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 oauth2_refresh_tokens::table
                     .find(refresh_token)
                     .inner_join(oauth2_access_tokens::table)
                     .select(<(oauth2::RefreshToken, oauth2::AccessToken)>::as_select())
                     .get_result::<(oauth2::RefreshToken, oauth2::AccessToken)>(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await
             .map_err(|_| ())?;
@@ -134,7 +132,6 @@ impl Issuer for OAuthIssuer {
                     .get_result::<(oauth2::AccessToken, oauth2::Application)>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Error::from)
             })
             .await
             .map_err(|_| ())?;
@@ -173,7 +170,6 @@ impl Issuer for OAuthIssuer {
                     .get_result::<(oauth2::AccessToken, oauth2::Application)>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Error::from)
             })
             .await
             .map_err(|_| ())?;

--- a/kitsune/src/service/oauth2/mod.rs
+++ b/kitsune/src/service/oauth2/mod.rs
@@ -90,13 +90,13 @@ struct ShowTokenPage {
 
 #[derive(Clone, TypedBuilder)]
 pub struct OAuth2Service {
-    db_conn: PgPool,
+    db_pool: PgPool,
     url_service: UrlService,
 }
 
 impl OAuth2Service {
     pub async fn create_app(&self, create_app: CreateApp) -> Result<oauth2::Application> {
-        let mut db_conn = self.db_conn.get().await?;
+        let mut db_conn = self.db_pool.get().await?;
 
         diesel::insert_into(oauth2_applications::table)
             .values(oauth2::NewApplication {
@@ -121,7 +121,7 @@ impl OAuth2Service {
             user_id,
         }: AuthorisationCode,
     ) -> Result<Response> {
-        let mut db_conn = self.db_conn.get().await?;
+        let mut db_conn = self.db_pool.get().await?;
         let authorization_code: oauth2::AuthorizationCode =
             diesel::insert_into(oauth2_authorization_codes::table)
                 .values(oauth2::NewAuthorizationCode {

--- a/kitsune/src/service/oauth2/registrar.rs
+++ b/kitsune/src/service/oauth2/registrar.rs
@@ -1,4 +1,3 @@
-use crate::error::Error;
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl};
 use diesel_async::RunQueryDsl;
@@ -56,7 +55,6 @@ impl Registrar for OAuthRegistrar {
                     .get_result::<oauth2::Application>(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Error::from)
             })
             .await
             .map_err(|_| RegistrarError::PrimitiveError)?
@@ -112,7 +110,6 @@ impl Registrar for OAuthRegistrar {
                     .execute(&mut db_conn)
                     .await
                     .optional()
-                    .map_err(Error::from)
             })
             .await
             .map_err(|_| RegistrarError::PrimitiveError)?

--- a/kitsune/src/service/oauth2/solicitor.rs
+++ b/kitsune/src/service/oauth2/solicitor.rs
@@ -1,5 +1,4 @@
 use super::OAuthScope;
-use crate::error::Error;
 use askama::Template;
 use async_trait::async_trait;
 use diesel::{OptionalExtension, QueryDsl};
@@ -74,7 +73,6 @@ impl OAuthOwnerSolicitor {
                             .get_result::<String>(&mut db_conn)
                             .await
                             .optional()
-                            .map_err(Error::from)
                     })
                     .await
                     .map_err(|_| WebError::InternalError(None))?

--- a/kitsune/src/service/post.rs
+++ b/kitsune/src/service/post.rs
@@ -19,9 +19,7 @@ use diesel::{
     BelongingToDsl, BoolExpressionMethods, ExpressionMethods, OptionalExtension, QueryDsl,
     SelectableHelper,
 };
-use diesel_async::{
-    scoped_futures::ScopedFutureExt, AsyncConnection, AsyncPgConnection, RunQueryDsl,
-};
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncPgConnection, RunQueryDsl};
 use futures_util::{stream::BoxStream, Stream, StreamExt};
 use kitsune_db::{
     model::{
@@ -123,7 +121,7 @@ impl DeletePost {
 
 #[derive(Clone, TypedBuilder)]
 pub struct PostService {
-    db_conn: PgPool,
+    db_pool: PgPool,
     embed_client: Option<EmbedClient>,
     instance_service: InstanceService,
     job_service: JobService,
@@ -233,9 +231,9 @@ impl PostService {
         let id = Uuid::now_v7();
         let url = self.url_service.post_url(id);
 
-        let mut db_conn = self.db_conn.get().await?;
-        let post = db_conn
-            .transaction(move |tx| {
+        let post = self
+            .db_pool
+            .with_transaction(move |tx| {
                 async move {
                     let in_reply_to_id = if let Some(in_reply_to_id) = create_post.in_reply_to_id {
                         (posts::table
@@ -309,23 +307,34 @@ impl PostService {
     ///
     /// This should never ever panic. If it does, open a bug report.
     pub async fn delete(&self, delete_post: DeletePost) -> Result<()> {
-        let mut db_conn = self.db_conn.get().await?;
-        let post: Post = posts::table
-            .find(delete_post.post_id)
-            .select(Post::as_select())
-            .first(&mut db_conn)
+        let post: Post = self
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                posts::table
+                    .find(delete_post.post_id)
+                    .select(Post::as_select())
+                    .first(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await?;
 
         if post.account_id != delete_post.account_id {
             if let Some(user_id) = delete_post.user_id {
-                let admin_role_count = users_roles::table
-                    .filter(
-                        users_roles::user_id
-                            .eq(user_id)
-                            .and(users_roles::role.eq(Role::Administrator)),
-                    )
-                    .count()
-                    .get_result::<i64>(&mut db_conn)
+                let admin_role_count = self
+                    .db_pool
+                    .with_connection(|mut db_conn| async move {
+                        users_roles::table
+                            .filter(
+                                users_roles::user_id
+                                    .eq(user_id)
+                                    .and(users_roles::role.eq(Role::Administrator)),
+                            )
+                            .count()
+                            .get_result::<i64>(&mut db_conn)
+                            .await
+                            .map_err(Error::from)
+                    })
                     .await?;
 
                 if admin_role_count == 0 {
@@ -368,26 +377,37 @@ impl PostService {
             .build()
             .unwrap();
 
-        let mut db_conn = self.db_conn.get().await?;
-        let post: Post = posts::table
-            .find(post_id)
-            .add_post_permission_check(permission_check)
-            .select(Post::as_select())
-            .get_result(&mut db_conn)
+        let post: Post = self
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                posts::table
+                    .find(post_id)
+                    .add_post_permission_check(permission_check)
+                    .select(Post::as_select())
+                    .get_result(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await?;
 
         let id = Uuid::now_v7();
         let url = self.url_service.favourite_url(id);
-        let favourite_id = diesel::insert_into(posts_favourites::table)
-            .values(NewFavourite {
-                id,
-                account_id: favouriting_account_id,
-                post_id: post.id,
-                url,
-                created_at: None,
+        let favourite_id = self
+            .db_pool
+            .with_connection(|mut db_conn| async move {
+                diesel::insert_into(posts_favourites::table)
+                    .values(NewFavourite {
+                        id,
+                        account_id: favouriting_account_id,
+                        post_id: post.id,
+                        url,
+                        created_at: None,
+                    })
+                    .returning(posts_favourites::id)
+                    .get_result(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
             })
-            .returning(posts_favourites::id)
-            .get_result(&mut db_conn)
             .await?;
 
         self.job_service
@@ -411,13 +431,23 @@ impl PostService {
             .get_by_id(post_id, Some(favouriting_account_id))
             .await?;
 
-        let mut db_conn = self.db_conn.get().await?;
-        if let Some(favourite) = Favourite::belonging_to(&post)
-            .filter(posts_favourites::account_id.eq(favouriting_account_id))
-            .get_result::<Favourite>(&mut db_conn)
-            .await
-            .optional()?
-        {
+        let favourite = self
+            .db_pool
+            .with_connection(|mut db_conn| {
+                let post = &post;
+
+                async move {
+                    Favourite::belonging_to(&post)
+                        .filter(posts_favourites::account_id.eq(favouriting_account_id))
+                        .get_result::<Favourite>(&mut db_conn)
+                        .await
+                        .optional()
+                        .map_err(Error::from)
+                }
+            })
+            .await?;
+
+        if let Some(favourite) = favourite {
             self.job_service
                 .enqueue(
                     Enqueue::builder()
@@ -440,19 +470,22 @@ impl PostService {
     ///
     /// This should never panic. If it does, please open an issue.
     pub async fn get_by_id(&self, id: Uuid, fetching_account_id: Option<Uuid>) -> Result<Post> {
-        let mut db_conn = self.db_conn.get().await?;
         let permission_check = PermissionCheck::builder()
             .fetching_account_id(fetching_account_id)
             .build()
             .unwrap();
 
-        posts::table
-            .find(id)
-            .add_post_permission_check(permission_check)
-            .select(Post::as_select())
-            .get_result(&mut db_conn)
+        self.db_pool
+            .with_connection(|mut db_conn| async move {
+                posts::table
+                    .find(id)
+                    .add_post_permission_check(permission_check)
+                    .select(Post::as_select())
+                    .get_result(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await
-            .map_err(Error::from)
     }
 
     /// Get the ancestors of the post
@@ -473,12 +506,16 @@ impl PostService {
                 .unwrap();
 
             while let Some(in_reply_to_id) = last_post.in_reply_to_id {
-                let mut db_conn = self.db_conn.get().await?;
-                let post = posts::table
-                    .find(in_reply_to_id)
-                    .add_post_permission_check(permission_check)
-                    .select(Post::as_select())
-                    .get_result::<Post>(&mut db_conn)
+                let post = self.db_pool
+                    .with_connection(|mut db_conn| async move {
+                        posts::table
+                            .find(in_reply_to_id)
+                            .add_post_permission_check(permission_check)
+                            .select(Post::as_select())
+                            .get_result::<Post>(&mut db_conn)
+                            .await
+                            .map_err(Error::from)
+                    })
                     .await?;
 
                 yield post.clone();
@@ -505,12 +542,16 @@ impl PostService {
                 .build()
                 .unwrap();
 
-            let mut db_conn = self.db_conn.get().await?;
-            let descendant_stream = posts::table
-                .filter(posts::in_reply_to_id.eq(id))
-                .add_post_permission_check(permission_check)
-                .select(Post::as_select())
-                .load_stream::<Post>(&mut db_conn)
+            let descendant_stream = self.db_pool
+                .with_connection(|mut db_conn| async move {
+                    posts::table
+                        .filter(posts::in_reply_to_id.eq(id))
+                        .add_post_permission_check(permission_check)
+                        .select(Post::as_select())
+                        .load_stream::<Post>(&mut db_conn)
+                        .await
+                        .map_err(Error::from)
+                })
                 .await?;
 
             for await descendant in descendant_stream {

--- a/kitsune/src/service/timeline.rs
+++ b/kitsune/src/service/timeline.rs
@@ -111,9 +111,10 @@ impl TimelineService {
 
         self.db_pool
             .with_connection(|mut db_conn| async move {
-                Ok(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+                Ok::<_, Error>(query.load_stream(&mut db_conn).await?.map_err(Error::from))
             })
             .await
+            .map_err(Error::from)
     }
 
     /// Get a stream of public posts
@@ -156,8 +157,9 @@ impl TimelineService {
 
         self.db_pool
             .with_connection(|mut db_conn| async move {
-                Ok(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+                Ok::<_, Error>(query.load_stream(&mut db_conn).await?.map_err(Error::from))
             })
             .await
+            .map_err(Error::from)
     }
 }

--- a/kitsune/src/service/timeline.rs
+++ b/kitsune/src/service/timeline.rs
@@ -55,7 +55,7 @@ pub struct GetPublic {
 
 #[derive(Clone, TypedBuilder)]
 pub struct TimelineService {
-    db_conn: PgPool,
+    db_pool: PgPool,
 }
 
 impl TimelineService {
@@ -64,7 +64,6 @@ impl TimelineService {
         &self,
         get_home: GetHome,
     ) -> Result<impl Stream<Item = Result<Post>> + '_> {
-        let mut db_conn = self.db_conn.get().await?;
         let mut query = posts::table
             .filter(
                 // Post is owned by the user
@@ -110,7 +109,11 @@ impl TimelineService {
             query = query.filter(posts::id.gt(min_id)).order(posts::id.asc());
         }
 
-        Ok(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+        self.db_pool
+            .with_connection(|mut db_conn| async move {
+                Ok(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+            })
+            .await
     }
 
     /// Get a stream of public posts
@@ -123,7 +126,6 @@ impl TimelineService {
         &self,
         get_public: GetPublic,
     ) -> Result<impl Stream<Item = Result<Post>> + '_> {
-        let mut db_conn = self.db_conn.get().await?;
         let permission_check = PermissionCheck::builder()
             .include_unlisted(false)
             .build()
@@ -152,6 +154,10 @@ impl TimelineService {
             query = query.filter(posts::is_local.eq(false));
         }
 
-        Ok(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+        self.db_pool
+            .with_connection(|mut db_conn| async move {
+                Ok(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+            })
+            .await
     }
 }

--- a/kitsune/src/service/user.rs
+++ b/kitsune/src/service/user.rs
@@ -63,7 +63,7 @@ pub struct UserService {
 impl UserService {
     pub async fn mark_as_confirmed_by_token(&self, confirmation_token: &str) -> Result<()> {
         self.db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 diesel::update(
                     users::table
                         .filter(users::confirmation_token.eq(confirmation_token))
@@ -71,8 +71,6 @@ impl UserService {
                 )
                 .set(users::confirmed_at.eq(Timestamp::now_utc()))
                 .execute(&mut db_conn)
-                .await
-                .map_err(Error::from)
             })
             .await?;
 
@@ -81,12 +79,10 @@ impl UserService {
 
     pub async fn mark_as_confirmed(&self, user_id: Uuid) -> Result<()> {
         self.db_pool
-            .with_connection(|mut db_conn| async move {
+            .with_connection(|mut db_conn| {
                 diesel::update(users::table.find(user_id))
                     .set(users::confirmed_at.eq(Timestamp::now_utc()))
                     .execute(&mut db_conn)
-                    .await
-                    .map_err(Error::from)
             })
             .await?;
 

--- a/kitsune/src/service/user.rs
+++ b/kitsune/src/service/user.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use argon2::{password_hash::SaltString, Argon2, PasswordHasher};
 use diesel::{ExpressionMethods, QueryDsl};
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
+use diesel_async::{scoped_futures::ScopedFutureExt, RunQueryDsl};
 use futures_util::future::OptionFuture;
 use iso8601_timestamp::Timestamp;
 use kitsune_captcha::ChallengeStatus;
@@ -62,24 +62,32 @@ pub struct UserService {
 
 impl UserService {
     pub async fn mark_as_confirmed_by_token(&self, confirmation_token: &str) -> Result<()> {
-        let mut db_conn = self.db_conn.get().await?;
-        diesel::update(
-            users::table
-                .filter(users::confirmation_token.eq(confirmation_token))
-                .filter(users::confirmed_at.is_null()),
-        )
-        .set(users::confirmed_at.eq(Timestamp::now_utc()))
-        .execute(&mut db_conn)
-        .await?;
+        self.db_conn
+            .with_connection(|mut db_conn| async move {
+                diesel::update(
+                    users::table
+                        .filter(users::confirmation_token.eq(confirmation_token))
+                        .filter(users::confirmed_at.is_null()),
+                )
+                .set(users::confirmed_at.eq(Timestamp::now_utc()))
+                .execute(&mut db_conn)
+                .await
+                .map_err(Error::from)
+            })
+            .await?;
 
         Ok(())
     }
 
     pub async fn mark_as_confirmed(&self, user_id: Uuid) -> Result<()> {
-        let mut db_conn = self.db_conn.get().await?;
-        diesel::update(users::table.find(user_id))
-            .set(users::confirmed_at.eq(Timestamp::now_utc()))
-            .execute(&mut db_conn)
+        self.db_conn
+            .with_connection(|mut db_conn| async move {
+                diesel::update(users::table.find(user_id))
+                    .set(users::confirmed_at.eq(Timestamp::now_utc()))
+                    .execute(&mut db_conn)
+                    .await
+                    .map_err(Error::from)
+            })
             .await?;
 
         Ok(())
@@ -123,9 +131,9 @@ impl UserService {
         let url = self.url_service.user_url(account_id);
         let public_key_id = self.url_service.public_key_id(account_id);
 
-        let mut db_conn = self.db_conn.get().await?;
-        let new_user = db_conn
-            .transaction(|tx| {
+        let new_user = self
+            .db_conn
+            .with_transaction(|tx| {
                 async move {
                     let account_fut = diesel::insert_into(accounts::table)
                         .values(NewAccount {

--- a/kitsune/src/service/user.rs
+++ b/kitsune/src/service/user.rs
@@ -53,7 +53,7 @@ pub struct Register {
 
 #[derive(Clone, TypedBuilder)]
 pub struct UserService {
-    db_conn: PgPool,
+    db_pool: PgPool,
     job_service: JobService,
     registrations_open: bool,
     url_service: UrlService,
@@ -62,7 +62,7 @@ pub struct UserService {
 
 impl UserService {
     pub async fn mark_as_confirmed_by_token(&self, confirmation_token: &str) -> Result<()> {
-        self.db_conn
+        self.db_pool
             .with_connection(|mut db_conn| async move {
                 diesel::update(
                     users::table
@@ -80,7 +80,7 @@ impl UserService {
     }
 
     pub async fn mark_as_confirmed(&self, user_id: Uuid) -> Result<()> {
-        self.db_conn
+        self.db_pool
             .with_connection(|mut db_conn| async move {
                 diesel::update(users::table.find(user_id))
                     .set(users::confirmed_at.eq(Timestamp::now_utc()))
@@ -132,7 +132,7 @@ impl UserService {
         let public_key_id = self.url_service.public_key_id(account_id);
 
         let new_user = self
-            .db_conn
+            .db_pool
             .with_transaction(|tx| {
                 async move {
                     let account_fut = diesel::insert_into(accounts::table)

--- a/kitsune/src/state.rs
+++ b/kitsune/src/state.rs
@@ -143,7 +143,7 @@ pub struct Service {
 /// "Zustand" is just the german word for state.
 #[derive(Clone, FromRef)]
 pub struct Zustand {
-    pub db_conn: PgPool,
+    pub db_pool: PgPool,
     pub embed_client: Option<EmbedClient>,
     pub event_emitter: EventEmitter,
     pub fetcher: Fetcher,


### PR DESCRIPTION
Right now we use the `deadpool` connection pool directly. This works fine but has some downsides.

One of them is that, since it is guard-based, it's harder to keep track where a connection is going to be returned to the pool.

This PR adds a wrapper with the two functions `with_connection` and `with_transaction`. These two functions accept a closure that takes a connection as a parameter that returns a future.

That way we can easier track scopes in which database connections are borrowed from the pool, and lets us define tighter scopes easier (and implicitly discourages long-term ownage of connections by forcing another level of indentation).