### PR TITLE
Fix transaction state panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,6 +3716,7 @@ dependencies = [
  "rayon",
  "redis",
  "rsa",
+ "scoped-futures",
  "serde",
  "serde_urlencoded",
  "serial_test",

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -89,6 +89,7 @@ rand = "0.8.5"
 rayon = "1.7.0"
 redis = "0.23.2"
 rsa = "0.9.2"
+scoped-futures = "0.1.3"
 serde = { version = "1.0.186", features = ["derive"] }
 serde_urlencoded = "0.7.1"
 sha2 = "0.10.7"

--- a/kitsune/src/activitypub/mod.rs
+++ b/kitsune/src/activitypub/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     util::timestamp_to_uuid,
 };
 use diesel::SelectableHelper;
-use diesel_async::{scoped_futures::ScopedFutureExt, AsyncPgConnection, RunQueryDsl};
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
 use kitsune_db::{
     model::{
         account::Account,
@@ -20,6 +20,7 @@ use kitsune_language::DetectionBackend;
 use kitsune_search::{SearchBackend, SearchService};
 use kitsune_type::ap::{object::MediaAttachment, Object, Tag, TagType};
 use pulldown_cmark::{html, Options, Parser};
+use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 use typed_builder::TypedBuilder;
 

--- a/kitsune/src/http/graphql/types/account.rs
+++ b/kitsune/src/http/graphql/types/account.rs
@@ -13,6 +13,7 @@ use kitsune_db::{
     },
     schema::media_attachments,
 };
+use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 use time::OffsetDateTime;
 
@@ -40,13 +41,16 @@ impl Account {
 
         if let Some(avatar_id) = self.avatar_id {
             db_pool
-                .with_connection(|mut db_conn| async move {
-                    media_attachments::table
-                        .find(avatar_id)
-                        .get_result::<DbMediaAttachment>(&mut db_conn)
-                        .await
-                        .optional()
-                        .map(|attachment| attachment.map(Into::into))
+                .with_connection(|db_conn| {
+                    async move {
+                        media_attachments::table
+                            .find(avatar_id)
+                            .get_result::<DbMediaAttachment>(db_conn)
+                            .await
+                            .optional()
+                            .map(|attachment| attachment.map(Into::into))
+                    }
+                    .scoped()
                 })
                 .await
                 .map_err(Into::into)
@@ -60,13 +64,16 @@ impl Account {
 
         if let Some(header_id) = self.header_id {
             db_pool
-                .with_connection(|mut db_conn| async move {
-                    media_attachments::table
-                        .find(header_id)
-                        .get_result::<DbMediaAttachment>(&mut db_conn)
-                        .await
-                        .optional()
-                        .map(|attachment| attachment.map(Into::into))
+                .with_connection(|db_conn| {
+                    async move {
+                        media_attachments::table
+                            .find(header_id)
+                            .get_result::<DbMediaAttachment>(db_conn)
+                            .await
+                            .optional()
+                            .map(|attachment| attachment.map(Into::into))
+                    }
+                    .scoped()
                 })
                 .await
                 .map_err(Into::into)

--- a/kitsune/src/http/handler/oidc/callback.rs
+++ b/kitsune/src/http/handler/oidc/callback.rs
@@ -16,6 +16,7 @@ use kitsune_db::{
     schema::{oauth2_applications, users},
     PgPool,
 };
+use scoped_futures::ScopedFutureExt;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
@@ -37,16 +38,15 @@ pub async fn get(
 
     let user_info = oidc_service.get_user_info(query.state, query.code).await?;
     let user = db_pool
-        .with_connection(|mut db_conn| {
-            let user_info = &user_info;
-
-            async move {
+        .with_connection(|db_conn| {
+            async {
                 users::table
                     .filter(users::oidc_id.eq(&user_info.subject))
-                    .get_result(&mut db_conn)
+                    .get_result(db_conn)
                     .await
                     .optional()
             }
+            .scoped()
         })
         .await?;
 
@@ -63,10 +63,10 @@ pub async fn get(
     };
 
     let application = db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             oauth2_applications::table
                 .find(user_info.oauth2.application_id)
-                .get_result(&mut db_conn)
+                .get_result(db_conn)
         })
         .await?;
 

--- a/kitsune/src/http/handler/oidc/callback.rs
+++ b/kitsune/src/http/handler/oidc/callback.rs
@@ -67,6 +67,7 @@ pub async fn get(
             oauth2_applications::table
                 .find(user_info.oauth2.application_id)
                 .get_result(db_conn)
+                .scoped()
         })
         .await?;
 

--- a/kitsune/src/http/handler/users/followers.rs
+++ b/kitsune/src/http/handler/users/followers.rs
@@ -9,6 +9,7 @@ use kitsune_type::ap::{
     ap_context,
     collection::{Collection, CollectionType},
 };
+use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 
 pub async fn get(
@@ -19,7 +20,7 @@ pub async fn get(
 ) -> Result<ActivityPubJson<Collection>> {
     let follower_count = state
         .db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             accounts_follows::table
                 .inner_join(
                     accounts::table.on(accounts_follows::account_id
@@ -29,7 +30,8 @@ pub async fn get(
                         .and(accounts::local.eq(true))),
                 )
                 .count()
-                .get_result::<i64>(&mut db_conn)
+                .get_result::<i64>(db_conn)
+                .scoped()
         })
         .await?;
 

--- a/kitsune/src/http/handler/users/following.rs
+++ b/kitsune/src/http/handler/users/following.rs
@@ -9,6 +9,7 @@ use kitsune_type::ap::{
     ap_context,
     collection::{Collection, CollectionType},
 };
+use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 
 pub async fn get(
@@ -19,7 +20,7 @@ pub async fn get(
 ) -> Result<ActivityPubJson<Collection>> {
     let following_count = state
         .db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             accounts_follows::table
                 .inner_join(
                     accounts::table.on(accounts_follows::follower_id
@@ -29,7 +30,8 @@ pub async fn get(
                         .and(accounts::local.eq(true))),
                 )
                 .count()
-                .get_result::<i64>(&mut db_conn)
+                .get_result::<i64>(db_conn)
+                .scoped()
         })
         .await?;
 

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -23,18 +23,20 @@ use kitsune_db::{
     schema::{accounts_follows, posts, posts_favourites},
 };
 use kitsune_type::ap::{Activity, ActivityType};
+use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 use std::ops::Not;
 
 async fn accept_activity(state: &Zustand, activity: Activity) -> Result<()> {
     state
         .db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             diesel::update(
                 accounts_follows::table.filter(accounts_follows::url.eq(activity.object())),
             )
             .set(accounts_follows::approved_at.eq(Timestamp::now_utc()))
-            .execute(&mut db_conn)
+            .execute(db_conn)
+            .scoped()
         })
         .await?;
 
@@ -46,7 +48,7 @@ async fn announce_activity(state: &Zustand, author: Account, activity: Activity)
 
     state
         .db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             diesel::insert_into(posts::table)
                 .values(NewPost {
                     id: Uuid::now_v7(),
@@ -64,7 +66,8 @@ async fn announce_activity(state: &Zustand, author: Account, activity: Activity)
                     url: activity.id.as_str(),
                     created_at: None,
                 })
-                .execute(&mut db_conn)
+                .execute(db_conn)
+                .scoped()
         })
         .await?;
 
@@ -100,19 +103,22 @@ async fn create_activity(state: &Zustand, author: Account, activity: Activity) -
 async fn delete_activity(state: &Zustand, author: Account, activity: Activity) -> Result<()> {
     let post_id = state
         .db_pool
-        .with_connection(|mut db_conn| async move {
-            let post_id = posts::table
-                .filter(posts::account_id.eq(author.id))
-                .filter(posts::url.eq(activity.object()))
-                .select(posts::id)
-                .get_result(&mut db_conn)
-                .await?;
+        .with_connection(|db_conn| {
+            async move {
+                let post_id = posts::table
+                    .filter(posts::account_id.eq(author.id))
+                    .filter(posts::url.eq(activity.object()))
+                    .select(posts::id)
+                    .get_result(db_conn)
+                    .await?;
 
-            diesel::delete(posts::table.find(post_id))
-                .execute(&mut db_conn)
-                .await?;
+                diesel::delete(posts::table.find(post_id))
+                    .execute(db_conn)
+                    .await?;
 
-            Ok::<_, Error>(post_id)
+                Ok::<_, Error>(post_id)
+            }
+            .scoped()
         })
         .await?;
 
@@ -135,7 +141,7 @@ async fn follow_activity(state: &Zustand, author: Account, activity: Activity) -
 
     let follow_id = state
         .db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             diesel::insert_into(accounts_follows::table)
                 .values(NewFollow {
                     id: Uuid::now_v7(),
@@ -146,7 +152,8 @@ async fn follow_activity(state: &Zustand, author: Account, activity: Activity) -
                     created_at: Some(activity.published),
                 })
                 .returning(accounts_follows::id)
-                .get_result(&mut db_conn)
+                .get_result(db_conn)
+                .scoped()
         })
         .await?;
 
@@ -169,26 +176,29 @@ async fn like_activity(state: &Zustand, author: Account, activity: Activity) -> 
 
     state
         .db_pool
-        .with_connection(|mut db_conn| async move {
-            let post = posts::table
-                .filter(posts::url.eq(activity.object()))
-                .add_post_permission_check(permission_check)
-                .select(Post::as_select())
-                .get_result::<Post>(&mut db_conn)
-                .await?;
+        .with_connection(|db_conn| {
+            async move {
+                let post = posts::table
+                    .filter(posts::url.eq(activity.object()))
+                    .add_post_permission_check(permission_check)
+                    .select(Post::as_select())
+                    .get_result::<Post>(db_conn)
+                    .await?;
 
-            diesel::insert_into(posts_favourites::table)
-                .values(NewFavourite {
-                    id: Uuid::now_v7(),
-                    account_id: author.id,
-                    post_id: post.id,
-                    url: activity.id,
-                    created_at: Some(Timestamp::now_utc()),
-                })
-                .execute(&mut db_conn)
-                .await?;
+                diesel::insert_into(posts_favourites::table)
+                    .values(NewFavourite {
+                        id: Uuid::now_v7(),
+                        account_id: author.id,
+                        post_id: post.id,
+                        url: activity.id,
+                        created_at: Some(Timestamp::now_utc()),
+                    })
+                    .execute(db_conn)
+                    .await?;
 
-            Ok::<_, Error>(())
+                Ok::<_, Error>(())
+            }
+            .scoped()
         })
         .await?;
 
@@ -198,7 +208,7 @@ async fn like_activity(state: &Zustand, author: Account, activity: Activity) -> 
 async fn reject_activity(state: &Zustand, author: Account, activity: Activity) -> Result<()> {
     state
         .db_pool
-        .with_connection(|mut db_conn| {
+        .with_connection(|db_conn| {
             diesel::delete(
                 accounts_follows::table.filter(
                     accounts_follows::account_id
@@ -206,7 +216,8 @@ async fn reject_activity(state: &Zustand, author: Account, activity: Activity) -
                         .and(accounts_follows::url.eq(activity.object())),
                 ),
             )
-            .execute(&mut db_conn)
+            .execute(db_conn)
+            .scoped()
         })
         .await?;
 
@@ -216,36 +227,39 @@ async fn reject_activity(state: &Zustand, author: Account, activity: Activity) -
 async fn undo_activity(state: &Zustand, author: Account, activity: Activity) -> Result<()> {
     state
         .db_pool
-        .with_connection(|mut db_conn| async move {
-            // An undo activity can apply for likes and follows and announces
-            let favourite_delete_fut = diesel::delete(
-                posts_favourites::table.filter(
-                    posts_favourites::account_id
-                        .eq(author.id)
-                        .and(posts_favourites::url.eq(activity.object())),
-                ),
-            )
-            .execute(&mut db_conn);
+        .with_connection(|db_conn| {
+            async move {
+                // An undo activity can apply for likes and follows and announces
+                let favourite_delete_fut = diesel::delete(
+                    posts_favourites::table.filter(
+                        posts_favourites::account_id
+                            .eq(author.id)
+                            .and(posts_favourites::url.eq(activity.object())),
+                    ),
+                )
+                .execute(db_conn);
 
-            let follow_delete_fut = diesel::delete(
-                accounts_follows::table.filter(
-                    accounts_follows::follower_id
-                        .eq(author.id)
-                        .and(accounts_follows::url.eq(activity.object())),
-                ),
-            )
-            .execute(&mut db_conn);
+                let follow_delete_fut = diesel::delete(
+                    accounts_follows::table.filter(
+                        accounts_follows::follower_id
+                            .eq(author.id)
+                            .and(accounts_follows::url.eq(activity.object())),
+                    ),
+                )
+                .execute(db_conn);
 
-            let repost_delete_fut = diesel::delete(
-                posts::table.filter(
-                    posts::url
-                        .eq(activity.object())
-                        .and(posts::account_id.eq(author.id)),
-                ),
-            )
-            .execute(&mut db_conn);
+                let repost_delete_fut = diesel::delete(
+                    posts::table.filter(
+                        posts::url
+                            .eq(activity.object())
+                            .and(posts::account_id.eq(author.id)),
+                    ),
+                )
+                .execute(db_conn);
 
-            try_join!(favourite_delete_fut, follow_delete_fut, repost_delete_fut)
+                try_join!(favourite_delete_fut, follow_delete_fut, repost_delete_fut)
+            }
+            .scoped()
         })
         .await?;
 

--- a/kitsune/src/job/mailing/confirmation.rs
+++ b/kitsune/src/job/mailing/confirmation.rs
@@ -4,6 +4,7 @@ use athena::Runnable;
 use diesel::{QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use kitsune_db::{model::user::User, schema::users};
+use scoped_futures::ScopedFutureExt;
 use serde::{Deserialize, Serialize};
 use speedy_uuid::Uuid;
 
@@ -28,11 +29,12 @@ impl Runnable for SendConfirmationMail {
         let user = ctx
             .state
             .db_pool
-            .with_connection(|mut db_conn| {
+            .with_connection(|db_conn| {
                 users::table
                     .find(self.user_id)
                     .select(User::as_select())
-                    .get_result(&mut db_conn)
+                    .get_result(db_conn)
+                    .scoped()
             })
             .await?;
 

--- a/kitsune/src/mapping/activitypub/object.rs
+++ b/kitsune/src/mapping/activitypub/object.rs
@@ -24,6 +24,7 @@ use kitsune_type::ap::{
     AttributedToField, Object, ObjectType, Tag, TagType,
 };
 use mime::Mime;
+use scoped_futures::ScopedFutureExt;
 use std::str::FromStr;
 
 #[async_trait]
@@ -72,33 +73,31 @@ impl IntoObject for Post {
 
         let (account, in_reply_to, mentions, attachment_stream) = state
             .db_pool
-            .with_connection(|mut db_conn| {
-                let self = &self;
-
-                async move {
+            .with_connection(|db_conn| {
+                async {
                     let account_fut = accounts::table
                         .find(self.account_id)
                         .select(Account::as_select())
-                        .get_result(&mut db_conn);
+                        .get_result(db_conn);
 
                     let in_reply_to_fut =
                         OptionFuture::from(self.in_reply_to_id.map(|in_reply_to_id| {
                             posts::table
                                 .find(in_reply_to_id)
                                 .select(posts::url)
-                                .get_result(&mut db_conn)
+                                .get_result(db_conn)
                         }))
                         .map(Option::transpose);
 
                     let mentions_fut = Mention::belonging_to(&self)
                         .inner_join(accounts::table)
                         .select((Mention::as_select(), Account::as_select()))
-                        .load::<(Mention, Account)>(&mut db_conn);
+                        .load::<(Mention, Account)>(db_conn);
 
                     let attachment_stream_fut = PostMediaAttachment::belonging_to(&self)
                         .inner_join(media_attachments::table)
                         .select(DbMediaAttachment::as_select())
-                        .load_stream::<DbMediaAttachment>(&mut db_conn);
+                        .load_stream::<DbMediaAttachment>(db_conn);
 
                     try_join!(
                         account_fut,
@@ -107,6 +106,7 @@ impl IntoObject for Post {
                         attachment_stream_fut
                     )
                 }
+                .scoped()
             })
             .await?;
 
@@ -166,27 +166,30 @@ impl IntoObject for Account {
     async fn into_object(self, state: &Zustand) -> Result<Self::Output> {
         let (icon, image) = state
             .db_pool
-            .with_connection(|mut db_conn| async move {
-                // These calls also probably allocate two cocnnections. ugh.
-                let icon_fut = OptionFuture::from(self.avatar_id.map(|avatar_id| {
-                    media_attachments::table
-                        .find(avatar_id)
-                        .get_result::<DbMediaAttachment>(&mut db_conn)
-                        .map_err(Error::from)
-                        .and_then(|media_attachment| media_attachment.into_object(state))
-                }))
-                .map(Option::transpose);
+            .with_connection(|db_conn| {
+                async move {
+                    // These calls also probably allocate two cocnnections. ugh.
+                    let icon_fut = OptionFuture::from(self.avatar_id.map(|avatar_id| {
+                        media_attachments::table
+                            .find(avatar_id)
+                            .get_result::<DbMediaAttachment>(db_conn)
+                            .map_err(Error::from)
+                            .and_then(|media_attachment| media_attachment.into_object(state))
+                    }))
+                    .map(Option::transpose);
 
-                let image_fut = OptionFuture::from(self.header_id.map(|header_id| {
-                    media_attachments::table
-                        .find(header_id)
-                        .get_result::<DbMediaAttachment>(&mut db_conn)
-                        .map_err(Error::from)
-                        .and_then(|media_attachment| media_attachment.into_object(state))
-                }))
-                .map(Option::transpose);
+                    let image_fut = OptionFuture::from(self.header_id.map(|header_id| {
+                        media_attachments::table
+                            .find(header_id)
+                            .get_result::<DbMediaAttachment>(db_conn)
+                            .map_err(Error::from)
+                            .and_then(|media_attachment| media_attachment.into_object(state))
+                    }))
+                    .map(Option::transpose);
 
-                try_join!(icon_fut, image_fut)
+                    try_join!(icon_fut, image_fut)
+                }
+                .scoped()
             })
             .await?;
 

--- a/kitsune/src/resolve/post.rs
+++ b/kitsune/src/resolve/post.rs
@@ -106,6 +106,7 @@ mod test {
     use kitsune_search::NoopSearchService;
     use kitsune_storage::fs::Storage as FsStorage;
     use pretty_assertions::assert_eq;
+    use scoped_futures::ScopedFutureExt;
     use std::sync::Arc;
     use tower::service_fn;
 
@@ -190,11 +191,12 @@ mod test {
 
                 let (account_id, _mention_text) = &mentioned_account_ids[0];
                 let mentioned_account = db_pool
-                    .with_connection(|mut db_conn| {
+                    .with_connection(|db_conn| {
                         accounts::table
                             .find(account_id)
                             .select(Account::as_select())
-                            .get_result::<Account>(&mut db_conn)
+                            .get_result::<Account>(db_conn)
+                            .scoped()
                     })
                     .await
                     .expect("Failed to fetch account");

--- a/kitsune/src/service/timeline.rs
+++ b/kitsune/src/service/timeline.rs
@@ -11,6 +11,7 @@ use kitsune_db::{
     schema::{accounts_follows, posts, posts_mentions},
     PgPool,
 };
+use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 use std::cmp::min;
 use typed_builder::TypedBuilder;
@@ -110,8 +111,11 @@ impl TimelineService {
         }
 
         self.db_pool
-            .with_connection(|mut db_conn| async move {
-                Ok::<_, Error>(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+            .with_connection(|db_conn| {
+                async move {
+                    Ok::<_, Error>(query.load_stream(db_conn).await?.map_err(Error::from))
+                }
+                .scoped()
             })
             .await
             .map_err(Error::from)
@@ -156,8 +160,11 @@ impl TimelineService {
         }
 
         self.db_pool
-            .with_connection(|mut db_conn| async move {
-                Ok::<_, Error>(query.load_stream(&mut db_conn).await?.map_err(Error::from))
+            .with_connection(|db_conn| {
+                async move {
+                    Ok::<_, Error>(query.load_stream(db_conn).await?.map_err(Error::from))
+                }
+                .scoped()
             })
             .await
             .map_err(Error::from)


### PR DESCRIPTION
The issue here was that the connection was returned to the pool before the futures querying the database were polled to completion or dropped.

This PR changes the pool API to only supply a mutable reference to the connection which ensures that the ownership of the connection is kept until the future is either polled to completion or dropped.

Closes #308 