### PR TITLE
Fix issue #319

### DIFF
--- a/kitsune/src/http/handler/mastodon/api/v1/statuses/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/statuses/mod.rs
@@ -133,7 +133,7 @@ async fn post(
         .visibility(form.visibility.into())
         .clone();
 
-    if let Some(subject) = form.spoiler_text {
+    if let Some(subject) = form.spoiler_text.filter(|subject| !subject.is_empty()) {
         create_post.subject(subject);
     }
     if let Some(in_reply_to_id) = form.in_reply_to_id {
@@ -171,7 +171,7 @@ async fn put(
         .content(form.status)
         .media_ids(form.media_ids)
         .sensitive(form.sensitive)
-        .subject(form.spoiler_text)
+        .subject(form.spoiler_text.filter(|subject| !subject.is_empty()))
         .build()
         .unwrap();
 


### PR DESCRIPTION
This fixes issue #319 by mapping `Some("")` to `None` in following APIs

* `POST /api/v1/status`
* `PUT /api/v1/status/{id}`