### PR TITLE
Add `xtask` project for automation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,10 +1,13 @@
+[alias]
+xtask = "run --package xtask --"
+
 [build]
 rustdocflags = ["--document-private-items"]
 rustflags = [
     "--cfg",
     "uuid_unstable",
     "-C",
-    "target-cpu=native",   # This probably isn't good, could lead to some weird issues but better than end-users having to struggle with arcane `simd-json` errors
+    "target-cpu=native", # This probably isn't good, could lead to some weird issues but better than end-users having to struggle with arcane `simd-json` errors
 ]
 
 [registries.crates-io]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -163,6 +163,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "argh"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af5ba06967ff7214ce4c7419c7d185be7ecd6cc4965a8f6e1d8ce0398aad219"
+dependencies = [
+ "argh_derive",
+ "argh_shared",
+]
+
+[[package]]
+name = "argh_derive"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56df0aeedf6b7a2fc67d06db35b09684c3e8da0c95f8f27685cb17e08413d87a"
+dependencies = [
+ "argh_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "argh_shared"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5693f39141bda5760ecc4111ab08da40565d1771038c4a0250f03457ec707531"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b74f44609f0f91493e3082d3734d98497e094777144380ea4db9f9905dd5b6"
+checksum = "d495b6dc0184693324491a5ac05f559acc97bf937ab31d7a1c33dd0016be6d2b"
 dependencies = [
  "brotli",
  "flate2",
@@ -415,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "athena"
-version = "0.1.0"
+version = "0.0.1-pre.3"
 dependencies = [
  "ahash 0.7.6",
  "async-trait",
@@ -1086,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+checksum = "8042c26c77e5bd6897a7358e0abb3ec412ed126d826988135653fc669263899d"
 dependencies = [
  "memchr",
  "regex-automata 0.3.7",
@@ -1208,22 +1239,22 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "f56b4c72906975ca04becb8a30e102dfecddd0c06181e3e95ddc444be28881f8"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits 0.2.16",
  "serde",
- "winapi",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
 name = "clap"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
+checksum = "7c8d502cbaec4595d2e7d5f61e318f05417bd2b66fdc3809498f0d3fdf0bea27"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1232,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.0"
+version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+checksum = "5891c7bc0edb3e1c2204fc5e94009affabeb1821c9e5fdc3959536c5c0bb984d"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1645,9 +1676,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",
@@ -2054,9 +2085,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -3631,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "just-retry"
-version = "0.1.0"
+version = "0.0.1-pre.3"
 dependencies = [
  "rand",
  "tokio",
@@ -4358,9 +4389,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f478948fd84d9f8e86967bf432640e46adfb5a4bd4f14ef7e864ab38220534ae"
 
 [[package]]
 name = "memmap2"
@@ -4648,6 +4679,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.16",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,6 +4734,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits 0.2.16",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
  "num-integer",
  "num-traits 0.2.16",
 ]
@@ -4816,9 +4870,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.91"
+version = "0.9.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
+checksum = "db7e971c2c2bba161b2d2fdf37080177eff520b3bc044787c7f1f5f9e78d869b"
 dependencies = [
  "cc",
  "libc",
@@ -5787,6 +5841,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsass"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e5c4ce6e9720b51f90dbd5f38c011d0e409fab722ee6b9bb15f5e5550500353"
+dependencies = [
+ "arc-swap",
+ "fastrand 2.0.0",
+ "lazy_static",
+ "nom",
+ "num-bigint",
+ "num-integer",
+ "num-rational",
+ "num-traits 0.2.16",
+ "tracing",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5866,9 +5937,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.9"
+version = "0.38.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
+checksum = "ed6248e1caa625eb708e266e06159f135e8c26f2bb7ceb72dc4b2766d0340964"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -5879,9 +5950,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
@@ -6438,7 +6509,7 @@ dependencies = [
 
 [[package]]
 name = "speedy-uuid"
-version = "0.1.0"
+version = "0.0.1-pre.3"
 dependencies = [
  "async-graphql",
  "diesel",
@@ -7337,9 +7408,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
@@ -7817,6 +7888,18 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
+
+[[package]]
+name = "xtask"
+version = "0.0.1-pre.3"
+dependencies = [
+ "anyhow",
+ "argh",
+ "glob",
+ "rsass",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,12 @@ members = [
     "lib/just-retry",
     "lib/post-process",
     "lib/speedy-uuid",
+    "xtask",
 ]
 resolver = "2"
 
 [workspace.package]
+edition = "2021"
 version = "0.0.1-pre.3"
 
 [patch.crates-io] # Patch to get client credential support for async

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ So, as long as this disclaimer is here, make sure to double check all the change
 - `lib/`: Libraries made for Kitsune but with no dependencies on Kitsune-specific code. Easily usable by other projects
 - `proto/`: Any Protobuf definitions for the Kitsune project
 - `public/`: Public web assets
+- `xtask/`: Task-runner polyfill
 
 ## State of federation
 

--- a/crates/kitsune-cache/Cargo.toml
+++ b/crates/kitsune-cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-cache"
-edition = "2021"
+edition.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/crates/kitsune-captcha/Cargo.toml
+++ b/crates/kitsune-captcha/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-captcha"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.73"

--- a/crates/kitsune-db/Cargo.toml
+++ b/crates/kitsune-db/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-db"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 build = "build.rs"
 
 [dependencies]

--- a/crates/kitsune-email/Cargo.toml
+++ b/crates/kitsune-email/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-email"
-edition = "2021"
+edition.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/crates/kitsune-embed/Cargo.toml
+++ b/crates/kitsune-embed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-embed"
-edition = "2021"
+edition.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/crates/kitsune-http-client/Cargo.toml
+++ b/crates/kitsune-http-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-http-client"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 bytes = "1.4.0"

--- a/crates/kitsune-http-signatures/Cargo.toml
+++ b/crates/kitsune-http-signatures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-http-signatures"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 base64-simd = "0.8.0"

--- a/crates/kitsune-language/Cargo.toml
+++ b/crates/kitsune-language/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-language"
-edition = "2021"
+edition.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/crates/kitsune-messaging/Cargo.toml
+++ b/crates/kitsune-messaging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-messaging"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 ahash = "0.8.3"

--- a/crates/kitsune-search/Cargo.toml
+++ b/crates/kitsune-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune-search"
-edition = "2021"
+edition.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/crates/kitsune-storage/Cargo.toml
+++ b/crates/kitsune-storage/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-storage"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.73"

--- a/crates/kitsune-type/Cargo.toml
+++ b/crates/kitsune-type/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-type"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 iso8601-timestamp = "0.2.11"

--- a/kitsune-cli/Cargo.toml
+++ b/kitsune-cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "kitsune-cli"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 build = "build.rs"
 
 [dependencies]
-clap = { version = "4.4.0", features = ["derive"] }
+clap = { version = "4.4.1", features = ["derive"] }
 color-eyre = "0.6.2"
 diesel = "2.1.1"
 diesel-async = "0.3.2"

--- a/kitsune-search-server/Cargo.toml
+++ b/kitsune-search-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-search-server"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 autometrics = { version = "0.6.0", default-features = false, features = [

--- a/kitsune-search-server/proto/Cargo.toml
+++ b/kitsune-search-server/proto/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune-search-proto"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 prost = "0.11.9"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kitsune"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 repository = "https://github.com/kitsune-soc/kitsune"
 homepage = "https://joinkitsune.org"
 build = "build.rs"
@@ -31,11 +31,11 @@ axum-extra = { version = "0.7.7", features = [
 axum-flash = "0.7.0"
 base64-simd = "0.8.0"
 bytes = "1.4.0"
-chrono = { version = "0.4.26", default-features = false } # Needed because of oxide-auth. Thinking about forking and porting to time..
+chrono = { version = "0.4.27", default-features = false } # Needed because of oxide-auth. Thinking about forking and porting to time..
 color-eyre = "0.6.2"
 const_format = "0.2.31"
 const-oid = { version = "0.9.5", features = ["db"] }
-dashmap = "5.5.1"
+dashmap = "5.5.3"
 deadpool-redis = "0.12.0"
 derive_builder = "0.12.0"
 diesel = "2.1.1"
@@ -114,7 +114,7 @@ tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.17"
 typed-builder = "0.16.0"
-url = "2.4.0"
+url = "2.4.1"
 utoipa = { version = "3.5.0", features = ["axum_extras", "time", "uuid"] }
 utoipa-swagger-ui = { version = "3.1.5", features = ["axum"] }
 zxcvbn = { version = "2.2.2", default-features = false }

--- a/lib/athena/Cargo.toml
+++ b/lib/athena/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "athena"
-edition = "2021"
-version = "0.1.0"
+edition.workspace = true
+version.workspace = true
 license = "MIT"
 
 [dependencies]

--- a/lib/just-retry/Cargo.toml
+++ b/lib/just-retry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "just-retry"
-edition = "2021"
-version = "0.1.0"
+edition.workspace = true
+version.workspace = true
 
 [dependencies]
 rand = "0.8.5"

--- a/lib/post-process/Cargo.toml
+++ b/lib/post-process/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "post-process"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
 
 [dependencies]
 futures-util = "0.3.28"

--- a/lib/speedy-uuid/Cargo.toml
+++ b/lib/speedy-uuid/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "speedy-uuid"
-edition = "2021"
-version = "0.1.0"
+edition.workspace = true
+version.workspace = true
 
 [dependencies]
 async-graphql = { version = "6.0.4", default-features = false, optional = true }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "xtask"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+anyhow = "1.0.75"
+argh = "0.1.12"
+glob = "0.3.1"
+rsass = "0.28.2"
+tracing = { version = "0.1.37", default-features = false }
+tracing-subscriber = { version = "0.3.17", default-features = false, features = [
+    "ansi",
+    "fmt",
+] }

--- a/xtask/src/build_scss.rs
+++ b/xtask/src/build_scss.rs
@@ -1,0 +1,24 @@
+use glob::glob;
+use rsass::output::{Format, Style};
+use std::{fs, path::PathBuf};
+
+pub fn build_scss(path: PathBuf) -> anyhow::Result<()> {
+    info!("Building backend SCSS..");
+
+    let scss_format = Format {
+        style: Style::Compressed,
+        ..Default::default()
+    };
+
+    let pattern = format!("{}/*.scss", path.display());
+    for file in glob(&pattern)? {
+        let mut path = file?;
+        info!("Compiling \"{}\" into CSS", path.display());
+
+        let compiled_css = rsass::compile_scss_path(&path, scss_format)?;
+        path.set_extension("css");
+        fs::write(path, compiled_css)?;
+    }
+
+    Ok(())
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,39 @@
+#[macro_use]
+extern crate tracing;
+
+use std::path::PathBuf;
+
+mod build_scss;
+
+#[derive(argh::FromArgs)]
+#[argh(subcommand, name = "build-scss")]
+/// Build a directory of SCSS files
+struct BuildScss {
+    #[argh(option, default = "\"kitsune/assets\".into()")]
+    /// path to the directory
+    path: PathBuf,
+}
+
+#[derive(argh::FromArgs)]
+#[argh(subcommand)]
+enum Subcommand {
+    BuildScss(BuildScss),
+}
+
+#[derive(argh::FromArgs)]
+/// Kitsune dev taskrunner
+struct Command {
+    #[argh(subcommand)]
+    subcommand: Subcommand,
+}
+
+fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let command: Command = argh::from_env();
+    match command.subcommand {
+        Subcommand::BuildScss(BuildScss { path }) => build_scss::build_scss(path)?,
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
In preparation of migrating the backend CSS to SCSS, I'm adding the `cargo-xtask` pattern to the project, which allows for running tasks similar to `npm run`.

It has a single command for now, `cargo xtask build-scss` which compiles SCSS files inside a directory to CSS using the `rsass` compiler.