### PR TITLE
ci: Remove `needs: fmt` requirements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,6 @@ env:
 jobs:
   clippy:
     name: Clippy
-    needs: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -37,7 +36,6 @@ jobs:
   
   test:
     name: Test
-    needs: fmt
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
This allows the `fmt` job to run in parallel with the other jobs and reduces CI execution time by ~1 min.