### PR TITLE
Dedicated job runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
  "axum-prometheus",
  "bytes",
  "chrono",
+ "clap",
  "color-eyre",
  "const-oid",
  "deadpool-redis",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,6 +3108,7 @@ dependencies = [
  "kitsune-embed",
  "kitsune-http-client",
  "kitsune-http-signatures",
+ "kitsune-job-runner",
  "kitsune-language",
  "kitsune-messaging",
  "kitsune-search",
@@ -3215,6 +3216,8 @@ dependencies = [
  "async-trait",
  "athena",
  "autometrics",
+ "aws-credential-types",
+ "aws-sdk-s3",
  "base64-simd",
  "bytes",
  "const_format",
@@ -3361,6 +3364,22 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+]
+
+[[package]]
+name = "kitsune-job-runner"
+version = "0.0.1-pre.3"
+dependencies = [
+ "athena",
+ "clap",
+ "color-eyre",
+ "deadpool-redis",
+ "just-retry",
+ "kitsune-core",
+ "kitsune-db",
+ "tokio",
+ "toml 0.8.0",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/kitsune-type",
     "kitsune",
     "kitsune-cli",
+    "kitsune-job-runner",
     "kitsune-search-server",
     "kitsune-search-server/proto",
     "lib/athena",

--- a/crates/kitsune-core/Cargo.toml
+++ b/crates/kitsune-core/Cargo.toml
@@ -11,6 +11,10 @@ async-stream = "0.3.5"
 async-trait = "0.1.73"
 athena = { path = "../../lib/athena" }
 autometrics = { version = "0.6.0", default-features = false }
+aws-credential-types = { version = "0.56.1", features = [
+    "hardcoded-credentials",
+] }
+aws-sdk-s3 = "0.30.0"
 base64-simd = "0.8.0"
 bytes = "1.5.0"
 const_format = "0.2.31"
@@ -73,7 +77,9 @@ zxcvbn = { version = "2.2.2", default-features = false }
 
 [features]
 default = []
+kitsune-search = ["kitsune-search/kitsune-search"]
 mastodon-api = []
+meilisearch = ["kitsune-search/meilisearch"]
 
 [build-dependencies]
 vergen = { version = "8.2.5", features = ["build", "git", "gitcl"] }

--- a/crates/kitsune-core/build.rs
+++ b/crates/kitsune-core/build.rs
@@ -1,8 +1,6 @@
 use vergen::EmitBuilder;
 
 fn main() {
-    println!("cargo:rerun-if-changed=templates");
-
     EmitBuilder::builder()
         .all_git()
         .git_sha(true)

--- a/crates/kitsune-core/src/lib.rs
+++ b/crates/kitsune-core/src/lib.rs
@@ -4,6 +4,7 @@
     clippy::cast_possible_wrap,
     clippy::cast_sign_loss,
     clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
     clippy::module_name_repetitions,
     forbidden_lint_groups
 )]
@@ -25,3 +26,343 @@ pub mod service;
 pub mod state;
 pub mod util;
 pub mod webfinger;
+
+use self::{
+    activitypub::Fetcher,
+    config::{
+        CacheConfiguration, CaptchaConfiguration, Configuration, EmailConfiguration,
+        MessagingConfiguration, SearchConfiguration, StorageConfiguration,
+    },
+    job::KitsuneContextRepo,
+    resolve::PostResolver,
+    service::{
+        account::AccountService, attachment::AttachmentService, captcha::CaptchaService,
+        federation_filter::FederationFilterService, instance::InstanceService, job::JobService,
+        mailing::MailingService, notification::NotificationService, post::PostService,
+        timeline::TimelineService, url::UrlService, user::UserService,
+    },
+    state::{EventEmitter, Service, State},
+    webfinger::Webfinger,
+};
+use athena::JobQueue;
+use aws_credential_types::Credentials;
+use aws_sdk_s3::config::Region;
+use eyre::Context;
+use kitsune_cache::{ArcCache, InMemoryCache, NoopCache, RedisCache};
+use kitsune_captcha::{hcaptcha::Captcha as HCaptcha, mcaptcha::Captcha as MCaptcha, Captcha};
+use kitsune_db::PgPool;
+use kitsune_email::{
+    lettre::{message::Mailbox, AsyncSmtpTransport, Tokio1Executor},
+    MailSender,
+};
+use kitsune_embed::Client as EmbedClient;
+use kitsune_messaging::{
+    redis::RedisMessagingBackend, tokio_broadcast::TokioBroadcastMessagingBackend, MessagingHub,
+};
+use kitsune_search::{NoopSearchService, SearchService, SqlSearchService};
+use kitsune_storage::{fs::Storage as FsStorage, s3::Storage as S3Storage, Storage};
+use serde::{de::DeserializeOwned, Serialize};
+use std::{
+    fmt::Display,
+    str::FromStr,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+#[cfg(feature = "kitsune-search")]
+use kitsune_search::GrpcSearchService;
+
+#[cfg(feature = "meilisearch")]
+use kitsune_search::MeiliSearchService;
+
+pub fn prepare_cache<K, V>(config: &Configuration, cache_name: &str) -> ArcCache<K, V>
+where
+    K: Display + Send + Sync + ?Sized + 'static,
+    V: Clone + DeserializeOwned + Serialize + Send + Sync + 'static,
+{
+    let cache = match config.cache {
+        CacheConfiguration::InMemory => InMemoryCache::new(100, Duration::from_secs(60)).into(), // TODO: Parameterise this
+        CacheConfiguration::None => NoopCache.into(),
+        CacheConfiguration::Redis(ref redis_config) => {
+            static REDIS_POOL: OnceLock<deadpool_redis::Pool> = OnceLock::new();
+
+            let pool = REDIS_POOL.get_or_init(|| {
+                let config = deadpool_redis::Config::from_url(redis_config.url.clone());
+                config
+                    .create_pool(Some(deadpool_redis::Runtime::Tokio1))
+                    .unwrap()
+            });
+
+            RedisCache::builder()
+                .prefix(cache_name)
+                .redis_conn(pool.clone())
+                .ttl(Duration::from_secs(60)) // TODO: Parameterise this
+                .build()
+                .expect("[Bug] Failed to build the Redis cache")
+                .into()
+        }
+    };
+
+    Arc::new(cache)
+}
+
+fn prepare_captcha(config: &CaptchaConfiguration) -> Captcha {
+    match config {
+        CaptchaConfiguration::HCaptcha(config) => HCaptcha::builder()
+            .verify_url(config.verify_url.to_string())
+            .site_key(config.site_key.to_string())
+            .secret_key(config.secret_key.to_string())
+            .build()
+            .into(),
+        CaptchaConfiguration::MCaptcha(config) => MCaptcha::builder()
+            .widget_link(config.widget_link.to_string())
+            .verify_url(config.verify_url.to_string())
+            .site_key(config.site_key.to_string())
+            .secret_key(config.secret_key.to_string())
+            .build()
+            .into(),
+    }
+}
+
+fn prepare_storage(config: &Configuration) -> Storage {
+    match config.storage {
+        StorageConfiguration::Fs(ref fs_config) => {
+            FsStorage::new(fs_config.upload_dir.as_str().into()).into()
+        }
+        StorageConfiguration::S3(ref s3_config) => {
+            let s3_client_config = aws_sdk_s3::Config::builder()
+                .region(Region::new(s3_config.region.to_string()))
+                .endpoint_url(s3_config.endpoint_url.as_str())
+                .force_path_style(s3_config.force_path_style)
+                .credentials_provider(Credentials::from_keys(
+                    s3_config.access_key.as_str(),
+                    s3_config.secret_access_key.as_str(),
+                    None,
+                ))
+                .build();
+
+            S3Storage::new(s3_config.bucket_name.to_string(), s3_client_config).into()
+        }
+    }
+}
+
+fn prepare_mail_sender(
+    config: &EmailConfiguration,
+) -> eyre::Result<MailSender<AsyncSmtpTransport<Tokio1Executor>>> {
+    let transport_builder = if config.starttls {
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(config.host.as_str())?
+    } else {
+        AsyncSmtpTransport::<Tokio1Executor>::relay(config.host.as_str())?
+    };
+
+    let transport = transport_builder
+        .credentials((config.username.as_str(), config.password.as_str()).into())
+        .build();
+
+    Ok(MailSender::builder()
+        .backend(transport)
+        .from_mailbox(Mailbox::from_str(config.from_address.as_str())?)
+        .build())
+}
+
+async fn prepare_messaging(config: &Configuration) -> eyre::Result<MessagingHub> {
+    let backend = match config.messaging {
+        MessagingConfiguration::InProcess => {
+            MessagingHub::new(TokioBroadcastMessagingBackend::default())
+        }
+        MessagingConfiguration::Redis(ref redis_config) => {
+            let redis_messaging_backend = RedisMessagingBackend::new(&redis_config.url)
+                .await
+                .context("Failed to initialise Redis messaging backend")?;
+
+            MessagingHub::new(redis_messaging_backend)
+        }
+    };
+
+    Ok(backend)
+}
+
+#[allow(clippy::unused_async)] // "async" is only unused when none of the more advanced searches are compiled in
+async fn prepare_search(
+    search_config: &SearchConfiguration,
+    db_pool: &PgPool,
+) -> eyre::Result<SearchService> {
+    let service = match search_config {
+        SearchConfiguration::Kitsune(_config) => {
+            #[cfg(not(feature = "kitsune-search"))]
+            panic!("Server compiled without Kitsune Search compatibility");
+
+            #[cfg(feature = "kitsune-search")]
+            #[allow(clippy::used_underscore_binding)]
+            GrpcSearchService::connect(
+                &_config.index_server,
+                _config.search_servers.iter().map(ToString::to_string),
+            )
+            .await
+            .context("Failed to connect to the search servers")?
+            .into()
+        }
+        SearchConfiguration::Meilisearch(_config) => {
+            #[cfg(not(feature = "meilisearch"))]
+            panic!("Server compiled without Meilisearch compatibility");
+
+            #[cfg(feature = "meilisearch")]
+            #[allow(clippy::used_underscore_binding)]
+            MeiliSearchService::new(&_config.instance_url, &_config.api_key)
+                .await
+                .context("Failed to connect to Meilisearch")?
+                .into()
+        }
+        SearchConfiguration::Sql => SqlSearchService::new(db_pool.clone()).into(),
+        SearchConfiguration::None => NoopSearchService.into(),
+    };
+
+    Ok(service)
+}
+
+#[allow(clippy::too_many_lines)] // TODO: Refactor to get under 100 lines
+pub async fn prepare_state(
+    config: &Configuration,
+    db_pool: PgPool,
+    job_queue: JobQueue<KitsuneContextRepo>,
+) -> eyre::Result<State> {
+    let messaging_hub = prepare_messaging(config).await?;
+    let status_event_emitter = messaging_hub.emitter("event.status".into());
+
+    let search_service = prepare_search(&config.search, &db_pool).await?;
+
+    let embed_client = config.embed.as_ref().map(|embed_config| {
+        EmbedClient::builder()
+            .db_pool(db_pool.clone())
+            .embed_service(embed_config.service_url.clone())
+            .build()
+    });
+
+    let federation_filter_service =
+        FederationFilterService::new(&config.instance.federation_filter)
+            .context("Couldn't build the federation filter (check your glob syntax)")?;
+
+    let fetcher = Fetcher::builder()
+        .db_pool(db_pool.clone())
+        .embed_client(embed_client.clone())
+        .federation_filter(federation_filter_service.clone())
+        .post_cache(prepare_cache(config, "ACTIVITYPUB-POST"))
+        .search_service(search_service.clone())
+        .user_cache(prepare_cache(config, "ACTIVITYPUB-USER"))
+        .build();
+
+    let webfinger = Webfinger::new(prepare_cache(config, "WEBFINGER"));
+
+    let job_service = JobService::builder().job_queue(job_queue).build();
+
+    let url_service = UrlService::builder()
+        .scheme(config.url.scheme.as_str())
+        .domain(config.url.domain.as_str())
+        .webfinger_domain(config.instance.webfinger_domain.clone())
+        .build();
+
+    let attachment_service = AttachmentService::builder()
+        .db_pool(db_pool.clone())
+        .media_proxy_enabled(config.server.media_proxy_enabled)
+        .storage_backend(prepare_storage(config))
+        .url_service(url_service.clone())
+        .build();
+
+    let account_service = AccountService::builder()
+        .attachment_service(attachment_service.clone())
+        .db_pool(db_pool.clone())
+        .fetcher(fetcher.clone())
+        .job_service(job_service.clone())
+        .url_service(url_service.clone())
+        .webfinger(webfinger.clone())
+        .build();
+
+    let captcha_backend = config.captcha.as_ref().map(prepare_captcha);
+    let captcha_service = CaptchaService::builder().backend(captcha_backend).build();
+
+    let instance_service = InstanceService::builder()
+        .db_pool(db_pool.clone())
+        .name(config.instance.name.as_str())
+        .description(config.instance.description.as_str())
+        .character_limit(config.instance.character_limit)
+        .registrations_open(config.instance.registrations_open)
+        .build();
+
+    let mail_sender = config.email.as_ref().map(prepare_mail_sender).transpose()?;
+    let mailing_service = MailingService::builder()
+        .sender(mail_sender)
+        .url_service(url_service.clone())
+        .build();
+
+    let notification_service = NotificationService::builder()
+        .db_pool(db_pool.clone())
+        .build();
+
+    let post_resolver = PostResolver::builder()
+        .account(account_service.clone())
+        .build();
+
+    let post_service = PostService::builder()
+        .db_pool(db_pool.clone())
+        .embed_client(embed_client.clone())
+        .instance_service(instance_service.clone())
+        .job_service(job_service.clone())
+        .post_resolver(post_resolver)
+        .search_service(search_service.clone())
+        .status_event_emitter(status_event_emitter.clone())
+        .url_service(url_service.clone())
+        .build();
+
+    let timeline_service = TimelineService::builder().db_pool(db_pool.clone()).build();
+
+    let user_service = UserService::builder()
+        .captcha_service(captcha_service.clone())
+        .db_pool(db_pool.clone())
+        .job_service(job_service.clone())
+        .registrations_open(config.instance.registrations_open)
+        .url_service(url_service.clone())
+        .build();
+
+    #[cfg(feature = "mastodon-api")]
+    let mastodon_mapper = self::mapping::MastodonMapper::builder()
+        .attachment_service(attachment_service.clone())
+        .cache_invalidator(
+            status_event_emitter
+                .consumer()
+                .await
+                .expect("Failed to register status event consumer"),
+        )
+        .db_pool(db_pool.clone())
+        .embed_client(embed_client.clone())
+        .mastodon_cache(prepare_cache(config, "MASTODON-ENTITY"))
+        .url_service(url_service.clone())
+        .build()
+        .expect("[Bug] Failed to initialise Mastodon mapper");
+
+    Ok(State {
+        db_pool: db_pool.clone(),
+        embed_client,
+        event_emitter: EventEmitter {
+            post: status_event_emitter.clone(),
+        },
+        fetcher,
+        #[cfg(feature = "mastodon-api")]
+        mastodon_mapper,
+        service: Service {
+            account: account_service,
+            captcha: captcha_service,
+            federation_filter: federation_filter_service,
+            instance: instance_service,
+            job: job_service,
+            mailing: mailing_service,
+            notification: notification_service,
+            search: search_service,
+            post: post_service,
+            timeline: timeline_service,
+            attachment: attachment_service,
+            url: url_service,
+            user: user_service,
+        },
+        webfinger,
+    })
+}

--- a/crates/kitsune-search/Cargo.toml
+++ b/crates/kitsune-search/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 speedy-uuid = { path = "../../lib/speedy-uuid" }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.48"
+tracing = "0.1.37"
 
 # "kitsune-search" feature
 bytes = { version = "1.5.0", optional = true }
@@ -24,7 +25,6 @@ tonic = { version = "0.10.0", optional = true }
 
 # "meilisearch" feature
 meilisearch-sdk = { version = "0.24.2", optional = true }
-tracing = "0.1.37"
 
 [features]
 default = []

--- a/kitsune-job-runner/Cargo.toml
+++ b/kitsune-job-runner/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "kitsune-job-runner"
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+athena = { path = "../lib/athena" }
+clap = { version = "4.4.3", features = ["derive"] }
+color-eyre = "0.6.2"
+deadpool-redis = "0.12.0"
+just-retry = { path = "../lib/just-retry" }
+kitsune-core = { path = "../crates/kitsune-core" }
+kitsune-db = { path = "../crates/kitsune-db" }
+tokio = { version = "1.32.0", features = ["full"] }
+toml = "0.8.0"
+tracing = "0.1.37"
+
+[features]

--- a/kitsune-job-runner/src/lib.rs
+++ b/kitsune-job-runner/src/lib.rs
@@ -1,0 +1,62 @@
+#[macro_use]
+extern crate tracing;
+
+use athena::JobQueue;
+use kitsune_core::{
+    activitypub::Deliverer,
+    config::JobQueueConfiguration,
+    job::{JobRunnerContext, KitsuneContextRepo},
+    state::State as CoreState,
+};
+use kitsune_db::PgPool;
+use std::{sync::Arc, time::Duration};
+use tokio::task::JoinSet;
+
+const EXECUTION_TIMEOUT_DURATION: Duration = Duration::from_secs(30);
+
+pub fn prepare_job_queue(
+    db_pool: PgPool,
+    config: &JobQueueConfiguration,
+) -> Result<JobQueue<KitsuneContextRepo>, deadpool_redis::CreatePoolError> {
+    let context_repo = KitsuneContextRepo::builder().db_pool(db_pool).build();
+    let redis_pool = deadpool_redis::Config::from_url(config.redis_url.as_str())
+        .create_pool(Some(deadpool_redis::Runtime::Tokio1))?;
+
+    let queue = JobQueue::builder()
+        .context_repository(context_repo)
+        .queue_name("kitsune-jobs")
+        .redis_pool(redis_pool)
+        .build();
+
+    Ok(queue)
+}
+
+#[instrument(skip(job_queue, state))]
+pub async fn run_dispatcher(
+    job_queue: JobQueue<KitsuneContextRepo>,
+    state: CoreState,
+    num_job_workers: usize,
+) {
+    let deliverer = Deliverer::builder()
+        .federation_filter(state.service.federation_filter.clone())
+        .build();
+    let ctx = Arc::new(JobRunnerContext { deliverer, state });
+
+    let mut job_joinset = JoinSet::new();
+    loop {
+        while let Err(error) = job_queue
+            .spawn_jobs(
+                num_job_workers - job_joinset.len(),
+                Arc::clone(&ctx),
+                &mut job_joinset,
+            )
+            .await
+        {
+            error!(?error, "failed to spawn more jobs");
+            just_retry::sleep_a_bit().await;
+        }
+
+        let join_all = async { while job_joinset.join_next().await.is_some() {} };
+        let _ = tokio::time::timeout(EXECUTION_TIMEOUT_DURATION, join_all).await;
+    }
+}

--- a/kitsune-job-runner/src/main.rs
+++ b/kitsune-job-runner/src/main.rs
@@ -1,0 +1,36 @@
+use clap::Parser;
+use color_eyre::eyre;
+use kitsune_core::config::Configuration;
+use std::path::PathBuf;
+use tokio::fs;
+
+/// Dedicated Kitsune job runner
+#[derive(Parser)]
+#[command(about, author, version)]
+struct Args {
+    /// Path to the configuration
+    #[arg(long, short)]
+    config: PathBuf,
+}
+
+#[tokio::main]
+async fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+
+    let args = Args::parse();
+
+    let raw_config = fs::read_to_string(args.config).await?;
+    let config: Configuration = toml::from_str(&raw_config)?;
+
+    let db_pool = kitsune_db::connect(
+        &config.database.url,
+        config.database.max_connections as usize,
+    )
+    .await?;
+    let job_queue = kitsune_job_runner::prepare_job_queue(db_pool.clone(), &config.job_queue)?;
+    let state = kitsune_core::prepare_state(&config, db_pool, job_queue.clone()).await?;
+
+    kitsune_job_runner::run_dispatcher(job_queue, state, config.job_queue.num_workers.into()).await;
+
+    Ok(())
+}

--- a/kitsune-job-runner/src/main.rs
+++ b/kitsune-job-runner/src/main.rs
@@ -1,12 +1,12 @@
 use clap::Parser;
 use color_eyre::eyre;
-use kitsune_core::config::Configuration;
+use kitsune_core::{config::Configuration, consts::VERSION};
 use std::path::PathBuf;
 use tokio::fs;
 
 /// Dedicated Kitsune job runner
 #[derive(Parser)]
-#[command(about, author, version)]
+#[command(about, author, version = VERSION)]
 struct Args {
     /// Path to the configuration
     #[arg(long, short)]

--- a/kitsune-job-runner/src/main.rs
+++ b/kitsune-job-runner/src/main.rs
@@ -18,7 +18,6 @@ async fn main() -> eyre::Result<()> {
     color_eyre::install()?;
 
     let args = Args::parse();
-
     let raw_config = fs::read_to_string(args.config).await?;
     let config: Configuration = toml::from_str(&raw_config)?;
 

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -28,6 +28,7 @@ axum-extra = { version = "0.7.7", features = [
 axum-flash = "0.7.0"
 bytes = "1.5.0"
 chrono = { version = "0.4.31", default-features = false }
+clap = { version = "4.4.3", features = ["derive"] }
 color-eyre = "0.6.2"
 const-oid = { version = "0.9.5", features = ["db"] }
 deadpool-redis = "0.12.0"

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 repository = "https://github.com/kitsune-soc/kitsune"
 homepage = "https://joinkitsune.org"
+build = "build.rs"
 
 [dependencies]
 athena = { version = "0.0.1-pre.3", path = "../lib/athena" }
@@ -54,6 +55,7 @@ kitsune-email = { path = "../crates/kitsune-email" }
 kitsune-embed = { path = "../crates/kitsune-embed" }
 kitsune-http-client = { path = "../crates/kitsune-http-client" }
 kitsune-http-signatures = { path = "../crates/kitsune-http-signatures" }
+kitsune-job-runner = { path = "../kitsune-job-runner" }
 kitsune-language = { path = "../crates/kitsune-language", default-features = false }
 kitsune-messaging = { path = "../crates/kitsune-messaging" }
 kitsune-search = { path = "../crates/kitsune-search" }
@@ -125,9 +127,9 @@ graphql-api = [
     "dep:async-graphql-axum",
     "speedy-uuid/async-graphql",
 ]
-kitsune-search = ["kitsune-search/kitsune-search"]
+kitsune-search = ["kitsune-core/kitsune-search"]
 mastodon-api = ["kitsune-core/mastodon-api"]
-meilisearch = ["kitsune-search/meilisearch"]
+meilisearch = ["kitsune-core/meilisearch"]
 metrics = [
     "autometrics/metrics",
     "dep:axum-prometheus",

--- a/kitsune/build.rs
+++ b/kitsune/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=templates");
+}

--- a/kitsune/src/http/handler/mastodon/api/v1/notifications/clear.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/notifications/clear.rs
@@ -1,13 +1,12 @@
 use crate::{
     error::Result,
     http::extractor::{AuthExtractor, MastodonAuthExtractor},
-    state::Zustand,
 };
 use axum::{debug_handler, extract::State};
 use http::StatusCode;
 use kitsune_core::service::notification::NotificationService;
 
-#[debug_handler(state = Zustand)]
+#[debug_handler(state = crate::state::Zustand)]
 #[utoipa::path(
     post,
     path = "/api/v1/notifications/clear",

--- a/kitsune/src/http/handler/mastodon/api/v1/notifications/dismiss.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/notifications/dismiss.rs
@@ -1,7 +1,6 @@
 use crate::{
     error::Result,
     http::extractor::{AuthExtractor, MastodonAuthExtractor},
-    state::Zustand,
 };
 use axum::{
     debug_handler,
@@ -11,7 +10,7 @@ use http::StatusCode;
 use kitsune_core::service::notification::NotificationService;
 use speedy_uuid::Uuid;
 
-#[debug_handler(state = Zustand)]
+#[debug_handler(state = crate::state::Zustand)]
 #[utoipa::path(
     post,
     path = "/api/v1/notifications/{id}/dismiss",

--- a/kitsune/src/http/handler/mastodon/api/v1/statuses/unreblog.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/statuses/unreblog.rs
@@ -1,7 +1,6 @@
 use crate::{
     error::Result,
     http::extractor::{AuthExtractor, MastodonAuthExtractor},
-    state::Zustand,
 };
 use axum::{
     debug_handler,
@@ -15,7 +14,7 @@ use kitsune_core::{
 use kitsune_type::mastodon::Status;
 use speedy_uuid::Uuid;
 
-#[debug_handler(state = Zustand)]
+#[debug_handler(state = crate::state::Zustand)]
 #[utoipa::path(
     delete,
     path = "/api/v1/statuses/{id}/unreblog",

--- a/kitsune/src/lib.rs
+++ b/kitsune/src/lib.rs
@@ -27,7 +27,6 @@ use self::{
     state::{SessionConfig, Zustand},
 };
 use athena::JobQueue;
-use eyre::Context;
 use kitsune_core::{config::Configuration, job::KitsuneContextRepo};
 use kitsune_db::PgPool;
 use oauth2::OAuthEndpoint;
@@ -48,6 +47,8 @@ async fn prepare_oidc_client(
     oidc_config: &OidcConfiguration,
     url_service: &UrlService,
 ) -> eyre::Result<CoreClient> {
+    use eyre::Context;
+
     let provider_metadata = CoreProviderMetadata::discover_async(
         IssuerUrl::new(oidc_config.server_url.to_string()).context("Invalid OIDC issuer URL")?,
         async_client,

--- a/kitsune/src/lib.rs
+++ b/kitsune/src/lib.rs
@@ -27,171 +27,21 @@ use self::{
     state::{SessionConfig, Zustand},
 };
 use athena::JobQueue;
-use aws_credential_types::Credentials;
-use aws_sdk_s3::config::Region;
 use eyre::Context;
-use kitsune_cache::{ArcCache, InMemoryCache, NoopCache, RedisCache};
-use kitsune_captcha::{hcaptcha::Captcha as HCaptcha, mcaptcha::Captcha as MCaptcha, Captcha};
-use kitsune_core::{
-    activitypub::Fetcher,
-    config::{
-        CacheConfiguration, CaptchaConfiguration, Configuration, EmailConfiguration,
-        JobQueueConfiguration, MessagingConfiguration, SearchConfiguration, StorageConfiguration,
-    },
-    job::KitsuneContextRepo,
-    resolve::PostResolver,
-    service::{
-        account::AccountService, attachment::AttachmentService, captcha::CaptchaService,
-        federation_filter::FederationFilterService, instance::InstanceService, job::JobService,
-        mailing::MailingService, notification::NotificationService, post::PostService,
-        timeline::TimelineService, url::UrlService, user::UserService,
-    },
-    state::{EventEmitter, Service, State as CoreState},
-    webfinger::Webfinger,
-};
+use kitsune_core::{config::Configuration, job::KitsuneContextRepo};
 use kitsune_db::PgPool;
-use kitsune_email::{
-    lettre::{message::Mailbox, AsyncSmtpTransport, Tokio1Executor},
-    MailSender,
-};
-use kitsune_embed::Client as EmbedClient;
-use kitsune_messaging::{
-    redis::RedisMessagingBackend, tokio_broadcast::TokioBroadcastMessagingBackend, MessagingHub,
-};
-use kitsune_search::{NoopSearchService, SearchService, SqlSearchService};
-use kitsune_storage::{fs::Storage as FsStorage, s3::Storage as S3Storage, Storage};
 use oauth2::OAuthEndpoint;
-use serde::{de::DeserializeOwned, Serialize};
-use std::{
-    fmt::Display,
-    str::FromStr,
-    sync::{Arc, OnceLock},
-    time::Duration,
-};
-
-#[cfg(feature = "kitsune-search")]
-use kitsune_search::GrpcSearchService;
-
-#[cfg(feature = "meilisearch")]
-use kitsune_search::MeiliSearchService;
 
 #[cfg(feature = "oidc")]
 use {
     self::oidc::{async_client, OidcService},
     futures_util::future::OptionFuture,
-    kitsune_core::config::OidcConfiguration,
+    kitsune_core::{config::OidcConfiguration, service::url::UrlService},
     openidconnect::{
         core::{CoreClient, CoreProviderMetadata},
         ClientId, ClientSecret, IssuerUrl, RedirectUrl,
     },
 };
-
-fn prepare_cache<K, V>(config: &Configuration, cache_name: &str) -> ArcCache<K, V>
-where
-    K: Display + Send + Sync + ?Sized + 'static,
-    V: Clone + DeserializeOwned + Serialize + Send + Sync + 'static,
-{
-    let cache = match config.cache {
-        CacheConfiguration::InMemory => InMemoryCache::new(100, Duration::from_secs(60)).into(), // TODO: Parameterise this
-        CacheConfiguration::None => NoopCache.into(),
-        CacheConfiguration::Redis(ref redis_config) => {
-            static REDIS_POOL: OnceLock<deadpool_redis::Pool> = OnceLock::new();
-
-            let pool = REDIS_POOL.get_or_init(|| {
-                let config = deadpool_redis::Config::from_url(redis_config.url.clone());
-                config
-                    .create_pool(Some(deadpool_redis::Runtime::Tokio1))
-                    .unwrap()
-            });
-
-            RedisCache::builder()
-                .prefix(cache_name)
-                .redis_conn(pool.clone())
-                .ttl(Duration::from_secs(60)) // TODO: Parameterise this
-                .build()
-                .expect("[Bug] Failed to build the Redis cache")
-                .into()
-        }
-    };
-
-    Arc::new(cache)
-}
-
-fn prepare_captcha(config: &CaptchaConfiguration) -> Captcha {
-    match config {
-        CaptchaConfiguration::HCaptcha(config) => HCaptcha::builder()
-            .verify_url(config.verify_url.to_string())
-            .site_key(config.site_key.to_string())
-            .secret_key(config.secret_key.to_string())
-            .build()
-            .into(),
-        CaptchaConfiguration::MCaptcha(config) => MCaptcha::builder()
-            .widget_link(config.widget_link.to_string())
-            .verify_url(config.verify_url.to_string())
-            .site_key(config.site_key.to_string())
-            .secret_key(config.secret_key.to_string())
-            .build()
-            .into(),
-    }
-}
-
-fn prepare_storage(config: &Configuration) -> Storage {
-    match config.storage {
-        StorageConfiguration::Fs(ref fs_config) => {
-            FsStorage::new(fs_config.upload_dir.as_str().into()).into()
-        }
-        StorageConfiguration::S3(ref s3_config) => {
-            let s3_client_config = aws_sdk_s3::Config::builder()
-                .region(Region::new(s3_config.region.to_string()))
-                .endpoint_url(s3_config.endpoint_url.as_str())
-                .force_path_style(s3_config.force_path_style)
-                .credentials_provider(Credentials::from_keys(
-                    s3_config.access_key.as_str(),
-                    s3_config.secret_access_key.as_str(),
-                    None,
-                ))
-                .build();
-
-            S3Storage::new(s3_config.bucket_name.to_string(), s3_client_config).into()
-        }
-    }
-}
-
-fn prepare_mail_sender(
-    config: &EmailConfiguration,
-) -> eyre::Result<MailSender<AsyncSmtpTransport<Tokio1Executor>>> {
-    let transport_builder = if config.starttls {
-        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(config.host.as_str())?
-    } else {
-        AsyncSmtpTransport::<Tokio1Executor>::relay(config.host.as_str())?
-    };
-
-    let transport = transport_builder
-        .credentials((config.username.as_str(), config.password.as_str()).into())
-        .build();
-
-    Ok(MailSender::builder()
-        .backend(transport)
-        .from_mailbox(Mailbox::from_str(config.from_address.as_str())?)
-        .build())
-}
-
-async fn prepare_messaging(config: &Configuration) -> eyre::Result<MessagingHub> {
-    let backend = match config.messaging {
-        MessagingConfiguration::InProcess => {
-            MessagingHub::new(TokioBroadcastMessagingBackend::default())
-        }
-        MessagingConfiguration::Redis(ref redis_config) => {
-            let redis_messaging_backend = RedisMessagingBackend::new(&redis_config.url)
-                .await
-                .context("Failed to initialise Redis messaging backend")?;
-
-            MessagingHub::new(redis_messaging_backend)
-        }
-    };
-
-    Ok(backend)
-}
 
 #[cfg(feature = "oidc")]
 async fn prepare_oidc_client(
@@ -215,142 +65,18 @@ async fn prepare_oidc_client(
     Ok(client)
 }
 
-#[allow(clippy::unused_async)] // "async" is only unused when none of the more advanced searches are compiled in
-async fn prepare_search(
-    search_config: &SearchConfiguration,
-    db_pool: &PgPool,
-) -> eyre::Result<SearchService> {
-    let service = match search_config {
-        SearchConfiguration::Kitsune(_config) => {
-            #[cfg(not(feature = "kitsune-search"))]
-            panic!("Server compiled without Kitsune Search compatibility");
-
-            #[cfg(feature = "kitsune-search")]
-            #[allow(clippy::used_underscore_binding)]
-            GrpcSearchService::connect(
-                &_config.index_server,
-                _config.search_servers.iter().map(ToString::to_string),
-            )
-            .await
-            .context("Failed to connect to the search servers")?
-            .into()
-        }
-        SearchConfiguration::Meilisearch(_config) => {
-            #[cfg(not(feature = "meilisearch"))]
-            panic!("Server compiled without Meilisearch compatibility");
-
-            #[cfg(feature = "meilisearch")]
-            #[allow(clippy::used_underscore_binding)]
-            MeiliSearchService::new(&_config.instance_url, &_config.api_key)
-                .await
-                .context("Failed to connect to Meilisearch")?
-                .into()
-        }
-        SearchConfiguration::Sql => SqlSearchService::new(db_pool.clone()).into(),
-        SearchConfiguration::None => NoopSearchService.into(),
-    };
-
-    Ok(service)
-}
-
-pub fn prepare_job_queue(
-    db_pool: PgPool,
-    config: &JobQueueConfiguration,
-) -> eyre::Result<JobQueue<KitsuneContextRepo>> {
-    let context_repo = KitsuneContextRepo::builder().db_pool(db_pool).build();
-    let redis_pool = deadpool_redis::Config::from_url(config.redis_url.as_str())
-        .create_pool(Some(deadpool_redis::Runtime::Tokio1))?;
-
-    let queue = JobQueue::builder()
-        .context_repository(context_repo)
-        .queue_name("kitsune-jobs")
-        .redis_pool(redis_pool)
-        .build();
-
-    Ok(queue)
-}
-
-#[allow(clippy::missing_panics_doc, clippy::too_many_lines)] // TODO: Refactor this method to get under the 100 lines
 pub async fn initialise_state(
     config: &Configuration,
     conn: PgPool,
     job_queue: JobQueue<KitsuneContextRepo>,
 ) -> eyre::Result<Zustand> {
-    let messaging_hub = prepare_messaging(config).await?;
-    let status_event_emitter = messaging_hub.emitter("event.status".into());
-
-    let search_service = prepare_search(&config.search, &conn).await?;
-
-    let embed_client = config.embed.as_ref().map(|embed_config| {
-        EmbedClient::builder()
-            .db_pool(conn.clone())
-            .embed_service(embed_config.service_url.clone())
-            .build()
-    });
-
-    let federation_filter_service =
-        FederationFilterService::new(&config.instance.federation_filter)
-            .context("Couldn't build the federation filter (check your glob syntax)")?;
-
-    let fetcher = Fetcher::builder()
-        .db_pool(conn.clone())
-        .embed_client(embed_client.clone())
-        .federation_filter(federation_filter_service.clone())
-        .post_cache(prepare_cache(config, "ACTIVITYPUB-POST"))
-        .search_service(search_service.clone())
-        .user_cache(prepare_cache(config, "ACTIVITYPUB-USER"))
-        .build();
-
-    let webfinger = Webfinger::new(prepare_cache(config, "WEBFINGER"));
-
-    let job_service = JobService::builder().job_queue(job_queue).build();
-
-    let url_service = UrlService::builder()
-        .scheme(config.url.scheme.as_str())
-        .domain(config.url.domain.as_str())
-        .webfinger_domain(config.instance.webfinger_domain.clone())
-        .build();
-
-    let attachment_service = AttachmentService::builder()
-        .db_pool(conn.clone())
-        .media_proxy_enabled(config.server.media_proxy_enabled)
-        .storage_backend(prepare_storage(config))
-        .url_service(url_service.clone())
-        .build();
-
-    let account_service = AccountService::builder()
-        .attachment_service(attachment_service.clone())
-        .db_pool(conn.clone())
-        .fetcher(fetcher.clone())
-        .job_service(job_service.clone())
-        .url_service(url_service.clone())
-        .webfinger(webfinger.clone())
-        .build();
-
-    let captcha_backend = config.captcha.as_ref().map(prepare_captcha);
-    let captcha_service = CaptchaService::builder().backend(captcha_backend).build();
-
-    let instance_service = InstanceService::builder()
-        .db_pool(conn.clone())
-        .name(config.instance.name.as_str())
-        .description(config.instance.description.as_str())
-        .character_limit(config.instance.character_limit)
-        .registrations_open(config.instance.registrations_open)
-        .build();
-
-    let mail_sender = config.email.as_ref().map(prepare_mail_sender).transpose()?;
-    let mailing_service = MailingService::builder()
-        .sender(mail_sender)
-        .url_service(url_service.clone())
-        .build();
-
-    let notification_service = NotificationService::builder().db_pool(conn.clone()).build();
+    let core_state = kitsune_core::prepare_state(config, conn.clone(), job_queue).await?;
 
     #[cfg(feature = "oidc")]
     let oidc_service = OptionFuture::from(config.server.oidc.as_ref().map(|oidc_config| async {
         let service = OidcService::builder()
-            .client(prepare_oidc_client(oidc_config, &url_service).await?)
-            .login_state(prepare_cache(config, "OIDC-LOGIN-STATE"))
+            .client(prepare_oidc_client(oidc_config, &core_state.service.url).await?)
+            .login_state(kitsune_core::prepare_cache(config, "OIDC-LOGIN-STATE")) // TODO: REPLACE THIS WITH A BETTER ALTERNATIVE TO JUST ABUSING A CACHE
             .build();
 
         Ok::<_, eyre::Report>(service)
@@ -360,77 +86,11 @@ pub async fn initialise_state(
 
     let oauth2_service = OAuth2Service::builder()
         .db_pool(conn.clone())
-        .url_service(url_service.clone())
+        .url_service(core_state.service.url.clone())
         .build();
-
-    let post_resolver = PostResolver::builder()
-        .account(account_service.clone())
-        .build();
-
-    let post_service = PostService::builder()
-        .db_pool(conn.clone())
-        .embed_client(embed_client.clone())
-        .instance_service(instance_service.clone())
-        .job_service(job_service.clone())
-        .post_resolver(post_resolver)
-        .search_service(search_service.clone())
-        .status_event_emitter(status_event_emitter.clone())
-        .url_service(url_service.clone())
-        .build();
-
-    let timeline_service = TimelineService::builder().db_pool(conn.clone()).build();
-
-    let user_service = UserService::builder()
-        .captcha_service(captcha_service.clone())
-        .db_pool(conn.clone())
-        .job_service(job_service.clone())
-        .registrations_open(config.instance.registrations_open)
-        .url_service(url_service.clone())
-        .build();
-
-    #[cfg(feature = "mastodon-api")]
-    let mastodon_mapper = kitsune_core::mapping::MastodonMapper::builder()
-        .attachment_service(attachment_service.clone())
-        .cache_invalidator(
-            status_event_emitter
-                .consumer()
-                .await
-                .expect("Failed to register status event consumer"),
-        )
-        .db_pool(conn.clone())
-        .embed_client(embed_client.clone())
-        .mastodon_cache(prepare_cache(config, "MASTODON-ENTITY"))
-        .url_service(url_service.clone())
-        .build()
-        .expect("[Bug] Failed to initialise Mastodon mapper");
 
     Ok(Zustand {
-        core: CoreState {
-            db_pool: conn.clone(),
-            embed_client,
-            event_emitter: EventEmitter {
-                post: status_event_emitter.clone(),
-            },
-            fetcher,
-            #[cfg(feature = "mastodon-api")]
-            mastodon_mapper,
-            service: Service {
-                account: account_service,
-                captcha: captcha_service,
-                federation_filter: federation_filter_service,
-                instance: instance_service,
-                job: job_service,
-                mailing: mailing_service,
-                notification: notification_service,
-                search: search_service,
-                post: post_service,
-                timeline: timeline_service,
-                attachment: attachment_service,
-                url: url_service,
-                user: user_service,
-            },
-            webfinger,
-        },
+        core: core_state,
         oauth2: oauth2_service,
         oauth_endpoint: OAuthEndpoint::from(conn),
         #[cfg(feature = "oidc")]


### PR DESCRIPTION
This PR adds a new binary that runs jobs dispatched by the main Kitsune binary.  

The idea behind this is that the running of jobs is something that can be highly parallelised, therefore someone could spin up a single server to handle all the HTTP requests, and ten job runners to handle all the outgoing federation, email delivery, etc.