### PR TITLE
Upgrade dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,12 +3,7 @@ xtask = "run --manifest-path ./xtask/Cargo.toml --"
 
 [build]
 rustdocflags = ["--document-private-items"]
-rustflags = [
-    "--cfg",
-    "uuid_unstable",
-    "-C",
-    "target-cpu=native", # This probably isn't good, could lead to some weird issues but better than end-users having to struggle with arcane `simd-json` errors
-]
+rustflags = ["--cfg", "uuid_unstable"]
 
 [registries.crates-io]
 protocol = "sparse"

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: "-C debuginfo=0 -C target-cpu=x86-64-v3 --cfg uuid_unstable"
+  RUSTFLAGS: "-C debuginfo=0 --cfg uuid_unstable"
 
 jobs:
   clippy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.5"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -235,7 +235,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -338,7 +338,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.35",
+ "syn 2.0.37",
  "thiserror",
 ]
 
@@ -383,7 +383,7 @@ checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -405,7 +405,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -422,7 +422,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -553,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a531d010f9f556bf65eb3bcd8d24f1937600ab6940fede4d454cd9b1f031fb34"
+checksum = "45030d64c20774ea450ee605e731b4a00fafb28730a56441c674ba156f213e72"
 dependencies = [
  "aws-credential-types",
  "aws-http",
@@ -867,6 +867,28 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "serde",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab90e7b70bea63a153137162affb6a0bce26b584c24a4c7885509783e2cf30b"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "pin-project-lite",
+ "serde",
  "serde_html_form",
  "tokio",
  "tower",
@@ -882,7 +904,7 @@ checksum = "919d104c8fdd083e19a9ba8b579b1c10ecea38c131a65acdea052a6af561d397"
 dependencies = [
  "async-trait",
  "axum-core",
- "axum-extra",
+ "axum-extra 0.7.7",
  "base64 0.21.4",
  "cookie",
  "http",
@@ -901,7 +923,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1063,7 +1085,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -1273,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.3"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
+checksum = "b1d7b8d5ec32af0fadc644bf1fd509a688c2103b185644bb1e29d164e0703136"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1283,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.2"
+version = "4.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+checksum = "5179bb514e4d7c2051749d8fcefa2ed6d06a9f4e6d69faf3805f5d80b8cf8d56"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1302,7 +1324,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1592,7 +1614,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740fe28e594155f10cfc383984cbefd529d7396050557148f79cb0f621204124"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "rand_core",
  "subtle",
  "zeroize",
@@ -1604,7 +1626,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.7",
  "typenum",
 ]
 
@@ -1628,7 +1650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1648,9 +1670,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.65+curl-8.2.1"
+version = "0.4.66+curl-8.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "961ba061c9ef2fe34bbd12b807152d96f0badd2bebe7b90ce6c8c8b7572a0986"
+checksum = "70c44a72e830f0e40ad90dda8a6ab6ed6314d39776599a58a2e5e37fbc6db5b9"
 dependencies = [
  "cc",
  "libc",
@@ -1659,7 +1681,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "vcpkg",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1707,7 +1729,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1729,7 +1751,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1883,7 +1905,7 @@ dependencies = [
  "diesel_table_macro_syntax",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1914,7 +1936,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc5557efc453706fed5e4fa85006fe9817c224c3f480a34c7e5959fd700921c5"
 dependencies = [
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1984,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfc4744c1b8f2a09adc0e55242f60b1af195d88596bd8700be74418c056c555"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
 
 [[package]]
 name = "ecdsa"
@@ -2027,7 +2049,7 @@ dependencies = [
  "crypto-bigint",
  "digest",
  "ff",
- "generic-array",
+ "generic-array 0.14.7",
  "group",
  "hkdf",
  "pem-rfc7468",
@@ -2098,7 +2120,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2374,7 +2396,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2440,7 +2462,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -2465,6 +2487,15 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "generic-array"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe739944a5406424e080edccb6add95685130b9f160d5407c639c7df0c5836b0"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -2611,9 +2642,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -2894,9 +2925,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.31.0"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0770b0a3d4c70567f0d58331f3088b0e4c4f56c9b8d764efe654b4a5d46de3a"
+checksum = "a3e02c584f4595792d09509a94cdb92a3cef7592b1eb2d9877ee6f527062d0ea"
 dependencies = [
  "console",
  "globset",
@@ -2984,12 +3015,12 @@ dependencies = [
 
 [[package]]
 name = "iso8601-timestamp"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd7663ae5b511b3d13c7d374dbe73b03da3da8e66b83950390173bc7c7325cc"
+checksum = "8fccbbbf8b1bfbdc1f58c64ea2efe80a0e2669a0873605ea7fb91a623355942c"
 dependencies = [
  "diesel",
- "generic-array",
+ "generic-array 1.0.0",
  "serde",
  "time",
 ]
@@ -3082,7 +3113,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "axum",
- "axum-extra",
+ "axum-extra 0.8.0",
  "axum-flash",
  "axum-prometheus",
  "bytes",
@@ -3697,7 +3728,7 @@ checksum = "bc28438cad73dcc90ff3466fc329a9252b1b8ba668eb0d5668ba97088cf4eef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3748,7 +3779,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3964,7 +3995,7 @@ checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4074,9 +4105,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6e72583bf6830c956235bff0d5afec8cf2952f579ebad18ae7821a917d950f"
+checksum = "8dc65d4615c08c8a13d91fd404b5a2a4485ba35b4091e3315cf8798d280c2f29"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -4085,7 +4116,6 @@ dependencies = [
  "parking_lot",
  "quanta",
  "rustc_version",
- "scheduled-thread-pool",
  "skeptic",
  "smallvec",
  "tagptr",
@@ -4219,7 +4249,7 @@ checksum = "9e6a0fd4f737c707bd9086cc16c925f294943eb62eb71499e9fd4cf71f8b9f4e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4668,7 +4698,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4706,7 +4736,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4839,7 +4869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -4927,7 +4957,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.35",
+ "syn 2.0.37",
  "tempfile",
  "which",
 ]
@@ -4942,7 +4972,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5103,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
 dependencies = [
  "either",
  "rayon-core",
@@ -5113,14 +5143,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -5332,7 +5360,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn 2.0.35",
+ "syn 2.0.37",
  "walkdir",
 ]
 
@@ -5379,9 +5407,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -5474,15 +5502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scheduled-thread-pool"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
 name = "scoped-futures"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5538,7 +5557,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array",
+ "generic-array 0.14.7",
  "pkcs8",
  "subtle",
  "zeroize",
@@ -5622,7 +5641,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5726,7 +5745,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5751,7 +5770,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -5830,9 +5849,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.10.7"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ea1dfc2c400965867fc4ddd6f502572be2de2074b39f90984ed15fbdbdd8eb"
+checksum = "5292d9aeaa0fcfd2732c6254761ef6394a4c1a9f255426c0c95b77069184816f"
 dependencies = [
  "getrandom",
  "halfbrown",
@@ -5907,9 +5926,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "smol_str"
@@ -5961,7 +5980,7 @@ checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6070,7 +6089,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6092,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.35"
+version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bf04c28bee9043ed9ea1e41afc0552288d3aba9c6efdd78903b802926f4879"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6303,7 +6322,7 @@ checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6408,7 +6427,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6484,9 +6503,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6593,7 +6612,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6690,7 +6709,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6787,22 +6806,22 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6605aaa56cce0947127ffa0675a8a1b181f87773364390174de60a86ab9085f1"
+checksum = "76f727af476880274a8a198e1276d56fe61fbb07832b19884d2ecee72715f593"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6a6884f6a890a012adcc20ce498f30ebdc70fb1ea242c333cc5f435b0b3871"
+checksum = "d8edc122087639fa8f8dff897ca93c9b8eec999e1c0a94d72c40ed429edac2f2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -6917,7 +6936,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.35",
+ "syn 2.0.37",
  "uuid",
 ]
 
@@ -7059,7 +7078,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -7093,7 +7112,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.35",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7179,9 +7198,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
 dependencies = [
  "winapi",
 ]

--- a/crates/kitsune-cache/Cargo.toml
+++ b/crates/kitsune-cache/Cargo.toml
@@ -8,10 +8,10 @@ async-trait = "0.1.73"
 deadpool-redis = "0.12.0"
 derive_builder = "0.12.0"
 enum_dispatch = "0.3.12"
-moka = "0.11.3"
+moka = { version = "0.12.0", features = ["sync"] }
 redis = "0.23.3"
 serde = "1.0.188"
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 thiserror = "1.0.48"
 tracing = "0.1.37"
 

--- a/crates/kitsune-cache/src/in_memory.rs
+++ b/crates/kitsune-cache/src/in_memory.rs
@@ -54,7 +54,6 @@ where
 #[cfg(test)]
 mod test {
     use crate::{CacheBackend, InMemoryCache};
-    use moka::sync::ConcurrentCacheExt;
     use std::time::Duration;
 
     #[tokio::test]
@@ -72,7 +71,7 @@ mod test {
         cache.set(&"hello", &"world").await.unwrap();
         cache.set(&"another", &"pair").await.unwrap();
 
-        cache.inner.sync();
+        cache.inner.run_pending_tasks();
 
         assert_eq!(cache.inner.entry_count(), 1);
     }

--- a/crates/kitsune-captcha/Cargo.toml
+++ b/crates/kitsune-captcha/Cargo.toml
@@ -10,8 +10,8 @@ http = "0.2.9"
 kitsune-http-client = { path = "../kitsune-http-client" }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 strum = { version = "0.25.0", features = ["derive"] }
 strum_macros = "0.25.2"
 thiserror = "1.0.48"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"

--- a/crates/kitsune-core/Cargo.toml
+++ b/crates/kitsune-core/Cargo.toml
@@ -14,7 +14,7 @@ autometrics = { version = "0.6.0", default-features = false }
 aws-credential-types = { version = "0.56.1", features = [
     "hardcoded-credentials",
 ] }
-aws-sdk-s3 = "0.30.0"
+aws-sdk-s3 = "0.31.1"
 base64-simd = "0.8.0"
 bytes = "1.5.0"
 const_format = "0.2.31"
@@ -34,7 +34,7 @@ garde = { version = "0.15.0", default-features = false, features = [
 globset = "0.4.13"
 hex-simd = "0.8.0"
 http = "0.2.9"
-iso8601-timestamp = "0.2.11"
+iso8601-timestamp = "0.2.12"
 just-retry = { path = "../../lib/just-retry" }
 kitsune-cache = { path = "../kitsune-cache" }
 kitsune-captcha = { path = "../kitsune-captcha" }
@@ -57,12 +57,12 @@ pulldown-cmark = { version = "0.9.3", default-features = false, features = [
     "simd",
 ] }
 rand = "0.8.5"
-rayon = "1.7.0"
+rayon = "1.8.0"
 rsa = "0.9.2"
 scoped-futures = "0.1.3"
 serde = { version = "1.0.188", features = ["derive"] }
 sha2 = "0.10.7"
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 smol_str = "0.2.0"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["diesel"] }
 strum = { version = "0.25.0", features = ["derive", "phf"] }
@@ -71,7 +71,7 @@ time = "0.3.28"
 tokio = { version = "1.32.0", features = ["macros", "rt"] }
 toml = { version = "0.8.0", default-features = false, features = ["parse"] }
 tracing = "0.1.37"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"
 url = "2.4.1"
 zxcvbn = { version = "2.2.2", default-features = false }
 

--- a/crates/kitsune-db/Cargo.toml
+++ b/crates/kitsune-db/Cargo.toml
@@ -11,14 +11,14 @@ diesel_full_text_search = { version = "2.1.0", default-features = false }
 diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "8e7085e7c93baca31b817b1814e14c4ac2beb2c4", features = [
     "postgres",
 ] }
-iso8601-timestamp = { version = "0.2.11", features = ["diesel-pg"] }
+iso8601-timestamp = { version = "0.2.12", features = ["diesel-pg"] }
 kitsune-language = { path = "../kitsune-language" }
 kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.4.0"
 num-traits = "0.2.16"
 serde = { version = "1.0.188", features = ["derive"] }
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["diesel"] }
 thiserror = "1.0.48"
 tracing-log = "0.1.3"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"

--- a/crates/kitsune-email/Cargo.toml
+++ b/crates/kitsune-email/Cargo.toml
@@ -21,4 +21,4 @@ mrml = { version = "2.0.0-rc4", default-features = false, features = [
     "render",
 ] }
 thiserror = "1.0.48"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"

--- a/crates/kitsune-embed/Cargo.toml
+++ b/crates/kitsune-embed/Cargo.toml
@@ -8,11 +8,11 @@ diesel = "2.1.1"
 diesel-async = "0.4.1"
 embed-sdk = { git = "https://github.com/Lantern-chat/embed-service.git", rev = "6f664877dc173153ca36810cc4f510df35c6b67d" }
 http = "0.2.9"
-iso8601-timestamp = "0.2.11"
+iso8601-timestamp = "0.2.12"
 kitsune-db = { path = "../kitsune-db" }
 kitsune-http-client = { path = "../kitsune-http-client" }
 once_cell = "1.18.0"
 scraper = { version = "0.17.1", default-features = false }
 smol_str = "0.2.0"
 thiserror = "1.0.48"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"

--- a/crates/kitsune-http-client/Cargo.toml
+++ b/crates/kitsune-http-client/Cargo.toml
@@ -21,7 +21,7 @@ kitsune-http-signatures = { path = "../kitsune-http-signatures" }
 kitsune-type = { path = "../kitsune-type" }
 pin-project-lite = "0.2.13"
 serde = "1.0.188"
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.4.4", features = [
     "decompression-full",

--- a/crates/kitsune-http-signatures/Cargo.toml
+++ b/crates/kitsune-http-signatures/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 base64-simd = "0.8.0"
 derive_builder = "0.12.0"
 http = "0.2.9"
-rayon = "1.7.0"
+rayon = "1.8.0"
 ring = { version = "0.16.20", features = ["std"] }
 time = { version = "0.3.28", features = ["formatting", "parsing"] }
 thiserror = "1.0.48"

--- a/crates/kitsune-messaging/Cargo.toml
+++ b/crates/kitsune-messaging/Cargo.toml
@@ -14,7 +14,7 @@ redis = { version = "0.23.3", features = [
     "tokio-rustls-comp",
 ] }
 serde = "1.0.188"
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 tokio = { version = "1.32.0", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.37"

--- a/crates/kitsune-storage/Cargo.toml
+++ b/crates/kitsune-storage/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1.73"
-aws-sdk-s3 = "0.30.0"
+aws-sdk-s3 = "0.31.1"
 aws-smithy-http = "0.56.1"
 bytes = "1.5.0"
 enum_dispatch = "0.3.12"
@@ -15,7 +15,7 @@ http-body = "0.4.5"
 pin-project-lite = "0.2.13"
 sync_wrapper = "0.1.2"
 tokio = { version = "1.32.0", features = ["fs", "io-util"] }
-tokio-util = { version = "0.7.8", features = ["io"] }
+tokio-util = { version = "0.7.9", features = ["io"] }
 
 [dev-dependencies]
 aws-credential-types = { version = "0.56.1", features = [

--- a/crates/kitsune-type/Cargo.toml
+++ b/crates/kitsune-type/Cargo.toml
@@ -4,9 +4,9 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-iso8601-timestamp = "0.2.11"
+iso8601-timestamp = "0.2.12"
 serde = { version = "1.0.188", features = ["derive"] }
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 smol_str = { version = "0.2.0", features = ["serde"] }
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["serde"] }
 utoipa = { version = "3.5.0", features = ["chrono", "uuid"] }

--- a/flake.lock
+++ b/flake.lock
@@ -140,11 +140,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694767346,
-        "narHash": "sha256-5uH27SiVFUwsTsqC5rs3kS7pBoNhtoy9QfTP9BmknGk=",
+        "lastModified": 1694959747,
+        "narHash": "sha256-CXQ2MuledDVlVM5dLC4pB41cFlBWxRw4tCBsFrq3cRk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ace5093e36ab1e95cb9463863491bee90d5a4183",
+        "rev": "970a59bd19eff3752ce552935687100c46e820a5",
         "type": "github"
       },
       "original": {
@@ -232,11 +232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1694830162,
-        "narHash": "sha256-BOs2/e70ojvkAPaChy/mz9EuJ7Lgp7oRygwVzStvsnU=",
+        "lastModified": 1695262242,
+        "narHash": "sha256-X8o0VqTOvc301bYoFLJedCi9QiosRYhiyKZhAUmV620=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f84bb1621574473d05e6ed79ba57a371d8ad8259",
+        "rev": "23224b680af0b27b320adec2a0dae4eef29350e6",
         "type": "github"
       },
       "original": {

--- a/kitsune-cli/Cargo.toml
+++ b/kitsune-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 build = "build.rs"
 
 [dependencies]
-clap = { version = "4.4.3", features = ["derive"] }
+clap = { version = "4.4.4", features = ["derive"] }
 color-eyre = "0.6.2"
 diesel = "2.1.1"
 diesel-async = "0.4.1"

--- a/kitsune-job-runner/Cargo.toml
+++ b/kitsune-job-runner/Cargo.toml
@@ -5,7 +5,7 @@ version.workspace = true
 
 [dependencies]
 athena = { path = "../lib/athena" }
-clap = { version = "4.4.3", features = ["derive"] }
+clap = { version = "4.4.4", features = ["derive"] }
 color-eyre = "0.6.2"
 deadpool-redis = "0.12.0"
 just-retry = { path = "../lib/just-retry" }

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -18,9 +18,9 @@ async-trait = "0.1.73"
 aws-credential-types = { version = "0.56.1", features = [
     "hardcoded-credentials",
 ] }
-aws-sdk-s3 = "0.30.0"
+aws-sdk-s3 = "0.31.1"
 axum = { version = "0.6.20", features = ["headers", "macros", "multipart"] }
-axum-extra = { version = "0.7.7", features = [
+axum-extra = { version = "0.8.0", features = [
     "cookie",
     "cookie-signed",
     "query",
@@ -28,7 +28,7 @@ axum-extra = { version = "0.7.7", features = [
 axum-flash = "0.7.0"
 bytes = "1.5.0"
 chrono = { version = "0.4.31", default-features = false }
-clap = { version = "4.4.3", features = ["derive"] }
+clap = { version = "4.4.4", features = ["derive"] }
 color-eyre = "0.6.2"
 const-oid = { version = "0.9.5", features = ["db"] }
 deadpool-redis = "0.12.0"
@@ -41,7 +41,7 @@ headers = "0.3.9"
 http = "0.2.9"
 human-panic = "1.2.0"
 hyper = { version = "0.14.27", features = ["deprecated"] }
-iso8601-timestamp = "0.2.11"
+iso8601-timestamp = "0.2.12"
 mimalloc = "0.1.39"
 mime = "0.3.17"
 mime_guess = { version = "2.0.4", default-features = false }
@@ -67,14 +67,14 @@ redis = "0.23.3"
 scoped-futures = "0.1.3"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 speedy-uuid = { path = "../lib/speedy-uuid" }
 strum = { version = "0.25.0", features = ["derive", "phf"] }
 tempfile = "3.8.0"
 thiserror = "1.0.48"
 time = "0.3.28"
 tokio = { version = "1.32.0", features = ["full"] }
-tokio-util = { version = "0.7.8", features = ["compat"] }
+tokio-util = { version = "0.7.9", features = ["compat"] }
 tower-http = { version = "0.4.4", features = [
     "catch-panic",
     "cors",
@@ -85,7 +85,7 @@ tower-http = { version = "0.4.4", features = [
 tracing = "0.1.37"
 tracing-error = "0.2.0"
 tracing-subscriber = "0.3.17"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"
 url = "2.4.1"
 utoipa = { version = "3.5.0", features = ["axum_extras", "time", "uuid"] }
 utoipa-swagger-ui = { version = "3.1.5", features = ["axum"] }

--- a/lib/athena/Cargo.toml
+++ b/lib/athena/Cargo.toml
@@ -11,7 +11,7 @@ deadpool-redis = "0.12.0"
 either = { version = "1.9.0", default-features = false }
 exponential-backoff = "1.2.0"
 futures-util = { version = "0.3.28", default-features = false }
-iso8601-timestamp = { version = "0.2.11", features = ["diesel-pg"] }
+iso8601-timestamp = { version = "0.2.12", features = ["diesel-pg"] }
 just-retry = { path = "../just-retry" }
 once_cell = "1.18.0"
 rand = "0.8.5"
@@ -23,13 +23,13 @@ redis = { version = "0.23.3", default-features = false, features = [
     "tokio-rustls-comp",
 ] }
 serde = { version = "1.0.188", features = ["derive"] }
-simd-json = "0.10.7"
+simd-json = "0.11.0"
 smol_str = "0.2.0"
 speedy-uuid = { path = "../speedy-uuid", features = ["redis", "serde"] }
 thiserror = "1.0.48"
 tokio = { version = "1.32.0", features = ["macros", "rt", "sync"] }
 tracing = "0.1.37"
-typed-builder = "0.16.0"
+typed-builder = "0.16.1"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.17"

--- a/lib/post-process/Cargo.toml
+++ b/lib/post-process/Cargo.toml
@@ -13,7 +13,7 @@ criterion = { version = "0.5.1", default-features = false, features = [
     "rayon",
 ] }
 futures = "0.3.28"
-insta = { version = "1.31.0", features = ["glob"] }
+insta = { version = "1.32.0", features = ["glob"] }
 pretty_assertions = "1.4.0"
 
 [[bench]]


### PR DESCRIPTION
`simd-json` should do runtime feature detection now, meaning we can get rid of the `target-cpu=native` configuration flag