### PR TITLE
Remove `diesel_migrations_async`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "askama_parser"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281ace75bcec9b4a608a6dbe5518d7bc97e8760476943bbf656e0a91b2a7c4d"
+checksum = "c268a96e01a4c47c8c5c2472aaa570707e006a875ea63e819f75474ceedaf7b4"
 dependencies = [
  "nom",
 ]
@@ -1913,16 +1913,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "diesel_migrations_async"
-version = "0.1.0"
-source = "git+https://github.com/aumetra/diesel_migrations_async.git?rev=8e7085e7c93baca31b817b1814e14c4ac2beb2c4#8e7085e7c93baca31b817b1814e14c4ac2beb2c4"
+name = "diesel_migrations"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6036b3f0120c5961381b570ee20a02432d7e2d27ea60de9578799cf9156914ac"
 dependencies = [
- "async-trait",
  "diesel",
- "diesel-async",
  "migrations_internals",
  "migrations_macros",
- "tokio",
 ]
 
 [[package]]
@@ -3235,7 +3233,7 @@ dependencies = [
  "diesel",
  "diesel-async",
  "diesel_full_text_search",
- "diesel_migrations_async",
+ "diesel_migrations",
  "iso8601-timestamp",
  "kitsune-language",
  "kitsune-type",
@@ -3245,6 +3243,7 @@ dependencies = [
  "simd-json",
  "speedy-uuid",
  "thiserror",
+ "tokio",
  "tracing-log",
  "typed-builder",
 ]
@@ -3857,8 +3856,9 @@ dependencies = [
 
 [[package]]
 name = "migrations_internals"
-version = "0.1.0"
-source = "git+https://github.com/aumetra/diesel_migrations_async.git?rev=8e7085e7c93baca31b817b1814e14c4ac2beb2c4#8e7085e7c93baca31b817b1814e14c4ac2beb2c4"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f23f71580015254b020e856feac3df5878c2c7a8812297edd6c0a485ac9dada"
 dependencies = [
  "serde",
  "toml 0.7.8",
@@ -3866,8 +3866,9 @@ dependencies = [
 
 [[package]]
 name = "migrations_macros"
-version = "0.1.0"
-source = "git+https://github.com/aumetra/diesel_migrations_async.git?rev=8e7085e7c93baca31b817b1814e14c4ac2beb2c4#8e7085e7c93baca31b817b1814e14c4ac2beb2c4"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce3325ac70e67bbab5bd837a31cae01f1a6db64e0e744a33cb03a543469ef08"
 dependencies = [
  "migrations_internals",
  "proc-macro2",

--- a/crates/kitsune-db/Cargo.toml
+++ b/crates/kitsune-db/Cargo.toml
@@ -6,11 +6,14 @@ build = "build.rs"
 
 [dependencies]
 diesel = { version = "2.1.2", features = ["uuid"] }
-diesel-async = { version = "0.4.1", features = ["deadpool", "postgres"] }
-diesel_full_text_search = { version = "2.1.0", default-features = false }
-diesel_migrations_async = { git = "https://github.com/aumetra/diesel_migrations_async.git", rev = "8e7085e7c93baca31b817b1814e14c4ac2beb2c4", features = [
+diesel-async = { version = "0.4.1", features = [
+    "async-connection-wrapper",
+    "deadpool",
     "postgres",
+    "tokio",
 ] }
+diesel_full_text_search = { version = "2.1.0", default-features = false }
+diesel_migrations = "2.1.0"
 iso8601-timestamp = { version = "0.2.12", features = ["diesel-pg"] }
 kitsune-language = { path = "../kitsune-language" }
 kitsune-type = { path = "../kitsune-type" }
@@ -20,5 +23,6 @@ serde = { version = "1.0.188", features = ["derive"] }
 simd-json = "0.11.1"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["diesel"] }
 thiserror = "1.0.49"
+tokio = { version = "1.32.0", features = ["rt"] }
 tracing-log = "0.1.3"
 typed-builder = "0.16.2"

--- a/crates/kitsune-db/src/error.rs
+++ b/crates/kitsune-db/src/error.rs
@@ -41,8 +41,14 @@ pub enum Error {
     Diesel(#[from] diesel::result::Error),
 
     #[error(transparent)]
+    DieselConnection(#[from] diesel::result::ConnectionError),
+
+    #[error(transparent)]
     Migration(BoxError),
 
     #[error(transparent)]
     Pool(#[from] PoolError),
+
+    #[error(transparent)]
+    TokioJoin(#[from] tokio::task::JoinError),
 }

--- a/crates/kitsune-db/src/lib.rs
+++ b/crates/kitsune-db/src/lib.rs
@@ -7,11 +7,13 @@
     forbidden_lint_groups
 )]
 
+use diesel::Connection;
 use diesel_async::{
+    async_connection_wrapper::AsyncConnectionWrapper,
     pooled_connection::{deadpool::Pool, AsyncDieselConnectionManager},
     AsyncPgConnection,
 };
-use diesel_migrations_async::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
 use tracing_log::LogTracer;
 
 pub use crate::{
@@ -43,11 +45,23 @@ pub async fn connect(conn_str: &str, max_pool_size: usize) -> Result<PgPool> {
         .build()
         .unwrap();
 
-    let mut conn = pool.get().await?;
-    conn.run_pending_migrations(MIGRATIONS)
-        .await
-        .map_err(Error::Migration)?;
+    tokio::task::spawn_blocking({
+        let conn_str = conn_str.to_string();
 
+        move || {
+            let mut migration_conn =
+                AsyncConnectionWrapper::<AsyncPgConnection>::establish(conn_str.as_str())?;
+
+            migration_conn
+                .run_pending_migrations(MIGRATIONS)
+                .map_err(Error::Migration)?;
+
+            Ok::<_, Error>(())
+        }
+    })
+    .await??;
+
+    let mut conn = pool.get().await?;
     kitsune_language::generate_postgres_enum(&mut conn, "language_iso_code").await?;
     kitsune_language::generate_regconfig_function(
         &mut conn,


### PR DESCRIPTION
This PR removes our usage of the custom `diesel_migrations_async` crate, and replaces it with the `diesel_migrations` crate using the new `async-connection-wrapper` feature.