### PR TITLE
More swagger fixes

### DIFF
--- a/crates/kitsune-type/src/mastodon/status.rs
+++ b/crates/kitsune-type/src/mastodon/status.rs
@@ -7,6 +7,7 @@ use utoipa::ToSchema;
 
 #[derive(Deserialize, Serialize, ToSchema)]
 pub struct Context {
+    #[schema(value_type = Vec<Status>)]
     pub ancestors: VecDeque<Status>,
     pub descendants: Vec<Status>,
 }

--- a/kitsune/src/http/openapi.rs
+++ b/kitsune/src/http/openapi.rs
@@ -29,12 +29,17 @@ impl Modify for SecurityAddon {
 }
 
 #[derive(ToSchema)]
+#[schema(as = SmolStr)]
+struct SmolStrPolyfill(String);
+
+#[derive(ToSchema)]
 #[schema(as = Timestamp)]
 struct TimestampPolyfill(String);
 
 #[derive(OpenApi)]
 #[openapi(
     components(schemas(
+        SmolStrPolyfill,
         TimestampPolyfill,
         mastodon_type::App,
         mastodon_type::account::Account,
@@ -45,6 +50,8 @@ struct TimestampPolyfill(String);
         mastodon_type::instance::Instance,
         mastodon_type::media_attachment::MediaType,
         mastodon_type::media_attachment::MediaAttachment,
+        mastodon_type::preview_card::PreviewCard,
+        mastodon_type::preview_card::PreviewType,
         mastodon_type::relationship::Relationship,
         mastodon_type::search::SearchResult,
         mastodon_type::status::Context,


### PR DESCRIPTION
Relates to https://github.com/kitsune-soc/kitsune/issues/360

I validated the entire schema this time and it turns out that there were still errors with `SmolStr` and `VecDeque` definitions missing + PreviewCard and PreviewType not added to the list.