### PR TITLE
Remove the /oauth/token endpoint from the OpenAPI scheme

### DIFF
--- a/kitsune/src/http/openapi.rs
+++ b/kitsune/src/http/openapi.rs
@@ -77,7 +77,6 @@ struct TimestampPolyfill(String);
     modifiers(&SecurityAddon),
     paths(
         nodeinfo::two_one::get,
-        oauth::token::post,
         well_known::nodeinfo::get,
         well_known::webfinger::get,
     ),


### PR DESCRIPTION
Right now our schema is still invalid because of that `/oauth/token` endpoint, as [every endpoint in the OpenAPI spec needs to have at least one response defined](https://swagger.io/docs/specification/describing-responses/), which we don't do right now. One way would would be to of course write all of these possible responses and their bodies etc. but there is actually no need to. OpenAPI docs state that [including this endpoint is entirely optional](https://swagger.io/docs/specification/authentication/oauth2/#faq) so I propose just removing it from the schema. This endpoint is the same for every OAuth flow after all.