### PR TITLE
Remove unsound `lexical` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,6 +460,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits 0.2.17",
+]
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0870c84016d4b481be5c9f323c24f65e31e901ae618f0e80f4308fb00de1d2d"
+checksum = "a481586acf778f1b1455424c343f71124b048ffa5f4fc3f8f6ae9dc432dcb3c7"
 
 [[package]]
 name = "finl_unicode"
@@ -3225,15 +3234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical"
-version = "6.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7aefb36fd43fef7003334742cbf77b243fcd36418a1d1bdd480d613a67968f6"
-dependencies = [
- "lexical-core",
-]
-
-[[package]]
 name = "lexical-core"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3466,8 +3466,8 @@ dependencies = [
 name = "masto-id-convert"
 version = "0.0.1-pre.4"
 dependencies = [
+ "atoi",
  "criterion",
- "lexical",
  "nanorand",
  "time",
  "uuid",
@@ -6892,18 +6892,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1808c6e5aa42cb2b67578276190258f08679c275d92a19735aad5d359e1b154"
+checksum = "ede7d7c7970ca2215b8c1ccf4d4f354c4733201dfaaba72d44ae5b37472e4901"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea597733532c780ce3e110401fc3b359b984cc78e17ac0917d3f371ffd1c1618"
+checksum = "4b27b1bb92570f989aac0ab7e9cbfbacdd65973f7ee920d9f0e71ebac878fd0b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,8 @@
+[profile.dev.package.backtrace]
+opt-level = 3
+
+[profile.dev.package.num-bigint-dig]
+opt-level = 3
 
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-[profile.dev.package.backtrace]
-opt-level = 3
-
-[profile.dev.package.num-bigint-dig]
-opt-level = 3
 
 [profile.release]
 codegen-units = 1

--- a/lib/masto-id-convert/Cargo.toml
+++ b/lib/masto-id-convert/Cargo.toml
@@ -8,9 +8,7 @@ name = "process"
 harness = false
 
 [dependencies]
-lexical = { version = "6.1.1", default-features = false, features = [
-    "parse-integers",
-] }
+atoi = { version = "2.0.0", default-features = false }
 nanorand = { version = "0.7.0", default-features = false, features = [
     "wyrand",
 ] }

--- a/lib/masto-id-convert/src/lib.rs
+++ b/lib/masto-id-convert/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::all, clippy::pedantic)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use atoi::FromRadix10;
 use core::fmt;
 use nanorand::{Rng, WyRand};
 use uuid::Uuid;
@@ -11,13 +12,7 @@ use uuid::Uuid;
 #[derive(Debug)]
 pub enum Error {
     /// Number parsing error
-    Lexical(lexical::Error),
-}
-
-impl From<lexical::Error> for Error {
-    fn from(value: lexical::Error) -> Self {
-        Self::Lexical(value)
-    }
+    NumberParse,
 }
 
 impl fmt::Display for Error {
@@ -61,7 +56,10 @@ pub fn process<T>(masto_id: T) -> Result<Uuid, Error>
 where
     T: AsRef<[u8]>,
 {
-    lexical::parse(masto_id)
-        .map(process_u64)
-        .map_err(Error::from)
+    let (result, index) = u64::from_radix_10(masto_id.as_ref());
+    if index == 0 {
+        return Err(Error::NumberParse);
+    }
+
+    Ok(process_u64(result))
 }


### PR DESCRIPTION
This PR removes the as unsound marked `lexical` dependency