### PR TITLE
fix: docker-compose start command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,9 @@
-version: '3.1'
+version: "3.1"
 
 services:
   backend:
     image: kitsune
-    command: 
-      - config.toml
+    command: --config config.toml
     ports:
       - "5000:5000"
     networks:


### PR DESCRIPTION
## What this PR changes/adds
Updated `docker-compose.yaml`

## Why it does that
I have adjusted the start command so that it also executes the config that is mapped.
Additionally I have adjusted the quotation marks. If we use double quotes in the port, we should use them everywhere.