### PR TITLE
Restructure search logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "editor.formatOnSave": true,
     "rust-analyzer.showUnlinkedFileNotification": false,
     "rust-analyzer.cargo.features": [
+        "meilisearch",
         "oidc"
     ],
     "rust-analyzer.check.extraArgs": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da74e2b81409b1b743f8f0c62cc6254afefb8b8e50bbfe3735550f7aeefa3448"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -2146,9 +2146,9 @@ dependencies = [
 
 [[package]]
 name = "garde"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16596022bab79d38f74999f49b2fa08db8e4e568b43a95a2bd78afbee13f55c"
+checksum = "93476a1d00b9a3a72c886af12323f9f2ec59b5cf5260519306f77b062f49a06c"
 dependencies = [
  "compact_str",
  "garde_derive",
@@ -2161,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "garde_derive"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ae3270e3d5914fcf8ac7b3f77d2e7d424018913e62f5f3ade51995da109412"
+checksum = "6af38284b8a9ce86826312de5123d79bff22231ef3033da3a48aa95d195c51a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2894,6 +2894,7 @@ dependencies = [
 name = "kitsune-core"
 version = "0.0.1-pre.4"
 dependencies = [
+ "ahash 0.8.6",
  "ammonia",
  "argon2",
  "async-recursion",
@@ -5488,9 +5489,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d123f285a3635e423ec2ef5b67e0168dcf86c0d62fffbcea88fcd1c926e47413"
+checksum = "e5a3720326b20bf5b95b72dbbd133caae7e0dcf71eae8f6e6656e71a7e5c9aaa"
 dependencies = [
  "getrandom",
  "halfbrown",

--- a/crates/kitsune-cache/Cargo.toml
+++ b/crates/kitsune-cache/Cargo.toml
@@ -10,7 +10,7 @@ enum_dispatch = "0.3.12"
 moka = { version = "0.12.1", features = ["sync"] }
 redis = "0.23.3"
 serde = "1.0.190"
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 thiserror = "1.0.50"
 tracing = "0.1.40"
 typed-builder = "0.18.0"

--- a/crates/kitsune-captcha/Cargo.toml
+++ b/crates/kitsune-captcha/Cargo.toml
@@ -10,7 +10,7 @@ http = "0.2.9"
 kitsune-http-client = { path = "../kitsune-http-client" }
 serde = { version = "1.0.190", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.50"
 typed-builder = "0.18.0"

--- a/crates/kitsune-core/Cargo.toml
+++ b/crates/kitsune-core/Cargo.toml
@@ -4,6 +4,7 @@ edition.workspace = true
 version.workspace = true
 
 [dependencies]
+ahash = "0.8.6"
 ammonia = "3.3.0"
 argon2 = "0.5.2"
 async-recursion = "1.0.5"
@@ -22,7 +23,7 @@ diesel = "2.1.3"
 diesel-async = { version = "0.4.1", features = ["postgres"] }
 eyre = "0.6.8"
 futures-util = "0.3.29"
-garde = { version = "0.16.1", default-features = false, features = [
+garde = { version = "0.16.2", default-features = false, features = [
     "derive",
     "email",
     "email-idna",
@@ -63,7 +64,7 @@ rusty-s3 = { version = "0.5.0", default-features = false }
 scoped-futures = "0.1.3"
 serde = { version = "1.0.190", features = ["derive"] }
 sha2 = "0.10.8"
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 smol_str = "0.2.0"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["diesel"] }
 thiserror = "1.0.50"

--- a/crates/kitsune-core/src/activitypub/fetcher.rs
+++ b/crates/kitsune-core/src/activitypub/fetcher.rs
@@ -25,7 +25,7 @@ use kitsune_db::{
 };
 use kitsune_embed::Client as EmbedClient;
 use kitsune_http_client::Client;
-use kitsune_search::{Search, SearchBackend};
+use kitsune_search::SearchBackend;
 use kitsune_type::{
     ap::{actor::Actor, Object},
     jsonld::RdfNode,
@@ -85,7 +85,7 @@ pub struct Fetcher {
     embed_client: Option<EmbedClient>,
     federation_filter: FederationFilterService,
     #[builder(setter(into))]
-    search_service: Search,
+    search_backend: kitsune_search::Search,
     webfinger: Webfinger,
 
     // Caches
@@ -292,7 +292,7 @@ impl Fetcher {
             })
             .await?;
 
-        self.search_service
+        self.search_backend
             .add_to_index(account.clone().into())
             .await?;
 
@@ -346,7 +346,7 @@ impl Fetcher {
             .embed_client(self.embed_client.as_ref())
             .fetcher(self)
             .object(Box::new(object))
-            .search_service(&self.search_service)
+            .search_backend(&self.search_backend)
             .build();
         let post = process_new_object(process_data).await?;
 
@@ -419,7 +419,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))
@@ -482,7 +482,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))
@@ -559,7 +559,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))
@@ -593,7 +593,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))
@@ -705,7 +705,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))
@@ -732,7 +732,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()));
 
@@ -798,7 +798,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))
@@ -827,7 +827,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()));
 
@@ -894,7 +894,7 @@ mod test {
                     })
                     .unwrap(),
                 )
-                .search_service(NoopSearchService)
+                .search_backend(NoopSearchService)
                 .webfinger(Webfinger::with_client(client, Arc::new(NoopCache.into())))
                 .post_cache(Arc::new(NoopCache.into()))
                 .user_cache(Arc::new(NoopCache.into()))

--- a/crates/kitsune-core/src/activitypub/fetcher.rs
+++ b/crates/kitsune-core/src/activitypub/fetcher.rs
@@ -25,7 +25,7 @@ use kitsune_db::{
 };
 use kitsune_embed::Client as EmbedClient;
 use kitsune_http_client::Client;
-use kitsune_search::{SearchBackend, SearchService};
+use kitsune_search::{Search, SearchBackend};
 use kitsune_type::{
     ap::{actor::Actor, Object},
     jsonld::RdfNode,
@@ -85,7 +85,7 @@ pub struct Fetcher {
     embed_client: Option<EmbedClient>,
     federation_filter: FederationFilterService,
     #[builder(setter(into))]
-    search_service: SearchService,
+    search_service: Search,
     webfinger: Webfinger,
 
     // Caches

--- a/crates/kitsune-core/src/activitypub/mod.rs
+++ b/crates/kitsune-core/src/activitypub/mod.rs
@@ -141,7 +141,7 @@ async fn preprocess_object(
         embed_client,
         mut object,
         fetcher,
-        search_backend: search_service,
+        search_backend,
     }: ProcessNewObject<'_>,
 ) -> Result<PreprocessedObject<'_>> {
     let attributed_to = object.attributed_to().ok_or(ApiError::BadRequest)?;
@@ -200,7 +200,7 @@ async fn preprocess_object(
         content_lang,
         db_pool,
         object,
-        search_backend: search_service,
+        search_backend,
     })
 }
 
@@ -214,7 +214,7 @@ pub async fn process_new_object(process_data: ProcessNewObject<'_>) -> Result<Po
         content_lang,
         db_pool,
         object,
-        search_backend: search_service,
+        search_backend,
     } = preprocess_object(process_data).await?;
 
     let post = db_pool
@@ -270,7 +270,7 @@ pub async fn process_new_object(process_data: ProcessNewObject<'_>) -> Result<Po
         .await?;
 
     if post.visibility == Visibility::Public || post.visibility == Visibility::Unlisted {
-        search_service.add_to_index(post.clone().into()).await?;
+        search_backend.add_to_index(post.clone().into()).await?;
     }
 
     Ok(post)
@@ -286,7 +286,7 @@ pub async fn update_object(process_data: ProcessNewObject<'_>) -> Result<Post> {
         content_lang,
         db_pool,
         object,
-        search_backend: search_service,
+        search_backend,
     } = preprocess_object(process_data).await?;
 
     let post = db_pool
@@ -336,7 +336,7 @@ pub async fn update_object(process_data: ProcessNewObject<'_>) -> Result<Post> {
         .await?;
 
     if post.visibility == Visibility::Public || post.visibility == Visibility::Unlisted {
-        search_service.update_in_index(post.clone().into()).await?;
+        search_backend.update_in_index(post.clone().into()).await?;
     }
 
     Ok(post)

--- a/crates/kitsune-core/src/activitypub/mod.rs
+++ b/crates/kitsune-core/src/activitypub/mod.rs
@@ -117,7 +117,7 @@ pub struct ProcessNewObject<'a> {
     embed_client: Option<&'a EmbedClient>,
     object: Box<Object>,
     fetcher: &'a Fetcher,
-    search_service: &'a Search,
+    search_backend: &'a Search,
 }
 
 #[derive(TypedBuilder)]
@@ -129,7 +129,7 @@ struct PreprocessedObject<'a> {
     content_lang: Language,
     db_pool: &'a PgPool,
     object: Box<Object>,
-    search_service: &'a Search,
+    search_backend: &'a Search,
 }
 
 #[allow(clippy::missing_panics_doc)]
@@ -141,7 +141,7 @@ async fn preprocess_object(
         embed_client,
         mut object,
         fetcher,
-        search_service,
+        search_backend: search_service,
     }: ProcessNewObject<'_>,
 ) -> Result<PreprocessedObject<'_>> {
     let attributed_to = object.attributed_to().ok_or(ApiError::BadRequest)?;
@@ -200,7 +200,7 @@ async fn preprocess_object(
         content_lang,
         db_pool,
         object,
-        search_service,
+        search_backend: search_service,
     })
 }
 
@@ -214,7 +214,7 @@ pub async fn process_new_object(process_data: ProcessNewObject<'_>) -> Result<Po
         content_lang,
         db_pool,
         object,
-        search_service,
+        search_backend: search_service,
     } = preprocess_object(process_data).await?;
 
     let post = db_pool
@@ -286,7 +286,7 @@ pub async fn update_object(process_data: ProcessNewObject<'_>) -> Result<Post> {
         content_lang,
         db_pool,
         object,
-        search_service,
+        search_backend: search_service,
     } = preprocess_object(process_data).await?;
 
     let post = db_pool

--- a/crates/kitsune-core/src/activitypub/mod.rs
+++ b/crates/kitsune-core/src/activitypub/mod.rs
@@ -19,7 +19,7 @@ use kitsune_db::{
 };
 use kitsune_embed::Client as EmbedClient;
 use kitsune_language::{DetectionBackend, Language};
-use kitsune_search::{SearchBackend, SearchService};
+use kitsune_search::{Search, SearchBackend};
 use kitsune_type::ap::{object::MediaAttachment, Object, Tag, TagType};
 use pulldown_cmark::{html, Options, Parser};
 use scoped_futures::ScopedFutureExt;
@@ -117,7 +117,7 @@ pub struct ProcessNewObject<'a> {
     embed_client: Option<&'a EmbedClient>,
     object: Box<Object>,
     fetcher: &'a Fetcher,
-    search_service: &'a SearchService,
+    search_service: &'a Search,
 }
 
 #[derive(TypedBuilder)]
@@ -129,7 +129,7 @@ struct PreprocessedObject<'a> {
     content_lang: Language,
     db_pool: &'a PgPool,
     object: Box<Object>,
-    search_service: &'a SearchService,
+    search_service: &'a Search,
 }
 
 #[allow(clippy::missing_panics_doc)]

--- a/crates/kitsune-core/src/lib.rs
+++ b/crates/kitsune-core/src/lib.rs
@@ -55,7 +55,7 @@ use kitsune_embed::Client as EmbedClient;
 use kitsune_messaging::{
     redis::RedisMessagingBackend, tokio_broadcast::TokioBroadcastMessagingBackend, MessagingHub,
 };
-use kitsune_search::{NoopSearchService, SearchService, SqlSearchService};
+use kitsune_search::{NoopSearchService, Search, SqlSearchService};
 use kitsune_storage::{fs::Storage as FsStorage, s3::Storage as S3Storage, Storage};
 use rusty_s3::{Bucket as S3Bucket, Credentials as S3Credentials};
 use serde::{de::DeserializeOwned, Serialize};
@@ -187,7 +187,7 @@ async fn prepare_messaging(config: &Configuration) -> eyre::Result<MessagingHub>
 async fn prepare_search(
     search_config: &SearchConfiguration,
     db_pool: &PgPool,
-) -> eyre::Result<SearchService> {
+) -> eyre::Result<Search> {
     let service = match search_config {
         SearchConfiguration::Meilisearch(_config) => {
             #[cfg(not(feature = "meilisearch"))]

--- a/crates/kitsune-core/src/lib.rs
+++ b/crates/kitsune-core/src/lib.rs
@@ -243,6 +243,7 @@ pub async fn prepare_state(
         .build();
 
     let search_service = SearchService::builder()
+        .db_pool(db_pool.clone())
         .fetcher(fetcher.clone())
         .search_backend(search_backend.clone())
         .build();

--- a/crates/kitsune-core/src/resolve/post.rs
+++ b/crates/kitsune-core/src/resolve/post.rs
@@ -136,7 +136,7 @@ mod test {
                         })
                         .unwrap(),
                     )
-                    .search_service(NoopSearchService)
+                    .search_backend(NoopSearchService)
                     .webfinger(webfinger.clone())
                     .post_cache(Arc::new(NoopCache.into()))
                     .user_cache(Arc::new(NoopCache.into()))

--- a/crates/kitsune-core/src/service/mod.rs
+++ b/crates/kitsune-core/src/service/mod.rs
@@ -9,6 +9,7 @@ pub mod job;
 pub mod mailing;
 pub mod notification;
 pub mod post;
+pub mod search;
 pub mod timeline;
 pub mod url;
 pub mod user;

--- a/crates/kitsune-core/src/service/post.rs
+++ b/crates/kitsune-core/src/service/post.rs
@@ -47,7 +47,7 @@ use kitsune_db::{
 };
 use kitsune_embed::Client as EmbedClient;
 use kitsune_language::{DetectionBackend, Language};
-use kitsune_search::{Search, SearchBackend};
+use kitsune_search::SearchBackend;
 use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 use typed_builder::TypedBuilder;
@@ -300,7 +300,7 @@ pub struct PostService {
     instance_service: InstanceService,
     job_service: JobService,
     post_resolver: PostResolver,
-    search_service: Search,
+    search_backend: kitsune_search::Search,
     status_event_emitter: PostEventEmitter,
     url_service: UrlService,
 }
@@ -502,7 +502,7 @@ impl PostService {
             .await?;
 
         if post.visibility == Visibility::Public || post.visibility == Visibility::Unlisted {
-            self.search_service
+            self.search_backend
                 .add_to_index(post.clone().into())
                 .await?;
         }
@@ -548,7 +548,7 @@ impl PostService {
             .await
             .map_err(Error::Event)?;
 
-        self.search_service.remove_from_index(&post.into()).await?;
+        self.search_backend.remove_from_index(&post.into()).await?;
 
         Ok(())
     }
@@ -653,7 +653,7 @@ impl PostService {
             .await?;
 
         if post.visibility == Visibility::Public || post.visibility == Visibility::Unlisted {
-            self.search_service
+            self.search_backend
                 .update_in_index(post.clone().into())
                 .await?;
         }

--- a/crates/kitsune-core/src/service/post.rs
+++ b/crates/kitsune-core/src/service/post.rs
@@ -47,7 +47,7 @@ use kitsune_db::{
 };
 use kitsune_embed::Client as EmbedClient;
 use kitsune_language::{DetectionBackend, Language};
-use kitsune_search::{SearchBackend, SearchService};
+use kitsune_search::{Search, SearchBackend};
 use scoped_futures::ScopedFutureExt;
 use speedy_uuid::Uuid;
 use typed_builder::TypedBuilder;
@@ -300,7 +300,7 @@ pub struct PostService {
     instance_service: InstanceService,
     job_service: JobService,
     post_resolver: PostResolver,
-    search_service: SearchService,
+    search_service: Search,
     status_event_emitter: PostEventEmitter,
     url_service: UrlService,
 }

--- a/crates/kitsune-core/src/service/search.rs
+++ b/crates/kitsune-core/src/service/search.rs
@@ -28,6 +28,11 @@ pub struct SearchService {
 }
 
 impl SearchService {
+    #[must_use]
+    pub fn backend(&self) -> &kitsune_search::Search {
+        &self.search_backend
+    }
+
     pub async fn search(&self, search: Search<'_>) -> Result<Vec<SearchResult>> {
         search.validate(&())?;
 

--- a/crates/kitsune-core/src/service/search.rs
+++ b/crates/kitsune-core/src/service/search.rs
@@ -1,0 +1,73 @@
+use crate::{activitypub::Fetcher, consts::API_MAX_LIMIT, error::Result};
+use garde::Validate;
+use kitsune_search::{SearchBackend, SearchIndex, SearchResult};
+use speedy_uuid::Uuid;
+use typed_builder::TypedBuilder;
+use url::Url;
+
+#[derive(TypedBuilder, Validate)]
+pub struct Search<'a> {
+    #[garde(skip)]
+    indices: &'a [SearchIndex],
+    #[garde(skip)]
+    query: &'a str,
+    #[garde(range(max = API_MAX_LIMIT as u64))]
+    max_results: u64,
+    #[garde(skip)]
+    offset: u64,
+    #[garde(skip)]
+    min_id: Option<Uuid>,
+    #[garde(skip)]
+    max_id: Option<Uuid>,
+}
+
+#[derive(Clone, TypedBuilder)]
+pub struct SearchService {
+    fetcher: Fetcher,
+    search_backend: kitsune_search::Search,
+}
+
+impl SearchService {
+    pub async fn search(&self, search: Search<'_>) -> Result<Vec<SearchResult>> {
+        search.validate(&())?;
+
+        let mut results = Vec::new();
+
+        // TODO: Add Webfinger-based handle resolver
+
+        if let Ok(searched_url) = Url::parse(search.query) {
+            match self.fetcher.fetch_actor(searched_url.as_str().into()).await {
+                Ok(account) => results.push(SearchResult {
+                    index: SearchIndex::Account,
+                    id: account.id,
+                }),
+                Err(error) => debug!(?error, "couldn't fetch actor via url"),
+            }
+
+            match self.fetcher.fetch_object(searched_url.as_str()).await {
+                Ok(post) => results.push(SearchResult {
+                    index: SearchIndex::Post,
+                    id: post.id,
+                }),
+                Err(error) => debug!(?error, "couldn't fetch object via url"),
+            }
+        }
+
+        for index in search.indices {
+            results.extend(
+                self.search_backend
+                    .search(
+                        *index,
+                        search.query,
+                        search.max_results,
+                        search.offset,
+                        search.min_id,
+                        search.max_id,
+                    )
+                    .await?,
+            );
+        }
+
+        Ok(results)
+    }
+}

--- a/crates/kitsune-core/src/state.rs
+++ b/crates/kitsune-core/src/state.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use kitsune_db::PgPool;
 use kitsune_embed::Client as EmbedClient;
-use kitsune_search::SearchService;
+use kitsune_search::Search;
 
 /// Emitter collection
 ///
@@ -37,7 +37,7 @@ pub struct Service {
     pub notification: NotificationService,
     pub post: PostService,
     pub instance: InstanceService,
-    pub search: SearchService,
+    pub search: Search,
     pub timeline: TimelineService,
     pub url: UrlService,
     pub user: UserService,

--- a/crates/kitsune-core/src/state.rs
+++ b/crates/kitsune-core/src/state.rs
@@ -5,13 +5,12 @@ use crate::{
         account::AccountService, attachment::AttachmentService, captcha::CaptchaService,
         federation_filter::FederationFilterService, instance::InstanceService, job::JobService,
         mailing::MailingService, notification::NotificationService, post::PostService,
-        timeline::TimelineService, url::UrlService, user::UserService,
+        search::SearchService, timeline::TimelineService, url::UrlService, user::UserService,
     },
     webfinger::Webfinger,
 };
 use kitsune_db::PgPool;
 use kitsune_embed::Client as EmbedClient;
-use kitsune_search::Search;
 
 /// Emitter collection
 ///
@@ -37,7 +36,7 @@ pub struct Service {
     pub notification: NotificationService,
     pub post: PostService,
     pub instance: InstanceService,
-    pub search: Search,
+    pub search: SearchService,
     pub timeline: TimelineService,
     pub url: UrlService,
     pub user: UserService,

--- a/crates/kitsune-db/Cargo.toml
+++ b/crates/kitsune-db/Cargo.toml
@@ -21,7 +21,7 @@ kitsune-type = { path = "../kitsune-type" }
 num-derive = "0.4.1"
 num-traits = "0.2.17"
 serde = { version = "1.0.190", features = ["derive"] }
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["diesel"] }
 thiserror = "1.0.50"
 tracing-log = "0.2.0"

--- a/crates/kitsune-http-client/Cargo.toml
+++ b/crates/kitsune-http-client/Cargo.toml
@@ -20,7 +20,7 @@ kitsune-http-signatures = { path = "../kitsune-http-signatures" }
 kitsune-type = { path = "../kitsune-type" }
 pin-project-lite = "0.2.13"
 serde = "1.0.190"
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.4.4", features = [
     # Explicitly exclude `zstd`

--- a/crates/kitsune-messaging/Cargo.toml
+++ b/crates/kitsune-messaging/Cargo.toml
@@ -15,7 +15,7 @@ redis = { version = "0.23.3", features = [
     "tokio-rustls-comp",
 ] }
 serde = "1.0.190"
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 tokio = { version = "1.33.0", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.40"

--- a/crates/kitsune-search/src/lib.rs
+++ b/crates/kitsune-search/src/lib.rs
@@ -106,14 +106,14 @@ impl From<DbPost> for SearchItem {
     }
 }
 
-#[derive(Clone, Copy, Debug, EnumIter)]
+#[derive(Clone, Copy, Debug, EnumIter, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum SearchIndex {
     Account,
     Post,
 }
 
 #[derive(Clone, Copy)]
-pub struct SearchResult {
+pub struct SearchResultReference {
     pub index: SearchIndex,
     pub id: Uuid,
 }
@@ -141,7 +141,7 @@ pub trait SearchBackend: Send + Sync {
         offset: u64,
         min_id: Option<Uuid>,
         max_id: Option<Uuid>,
-    ) -> Result<Vec<SearchResult>>;
+    ) -> Result<Vec<SearchResultReference>>;
 
     async fn update_in_index(&self, item: SearchItem) -> Result<()>;
 }
@@ -174,7 +174,7 @@ impl SearchBackend for NoopSearchService {
         _offset: u64,
         _min_id: Option<Uuid>,
         _max_id: Option<Uuid>,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<Vec<SearchResultReference>> {
         Ok(Vec::new())
     }
 

--- a/crates/kitsune-search/src/lib.rs
+++ b/crates/kitsune-search/src/lib.rs
@@ -26,7 +26,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Clone)]
 #[enum_dispatch(SearchBackend)]
-pub enum SearchService {
+pub enum Search {
     #[cfg(feature = "meilisearch")]
     Meilisearch(MeiliSearchService),
     Noop(NoopSearchService),
@@ -112,8 +112,9 @@ pub enum SearchIndex {
     Post,
 }
 
-#[derive(Clone, Copy, Deserialize, Serialize)]
+#[derive(Clone, Copy)]
 pub struct SearchResult {
+    pub index: SearchIndex,
     pub id: Uuid,
 }
 
@@ -135,7 +136,7 @@ pub trait SearchBackend: Send + Sync {
     async fn search(
         &self,
         index: SearchIndex,
-        query: String,
+        query: &str,
         max_results: u64,
         offset: u64,
         min_id: Option<Uuid>,
@@ -168,7 +169,7 @@ impl SearchBackend for NoopSearchService {
     async fn search(
         &self,
         _index: SearchIndex,
-        _query: String,
+        _query: &str,
         _max_results: u64,
         _offset: u64,
         _min_id: Option<Uuid>,

--- a/crates/kitsune-search/src/meilisearch.rs
+++ b/crates/kitsune-search/src/meilisearch.rs
@@ -1,4 +1,4 @@
-use super::{Result, SearchBackend, SearchIndex, SearchItem, SearchResult};
+use super::{Result, SearchBackend, SearchIndex, SearchItem, SearchResultReference};
 use async_trait::async_trait;
 use meilisearch_sdk::{indexes::Index, settings::Settings, Client};
 use serde::Deserialize;
@@ -103,7 +103,7 @@ impl SearchBackend for MeiliSearchService {
         offset: u64,
         min_id: Option<Uuid>,
         max_id: Option<Uuid>,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<Vec<SearchResultReference>> {
         let min_timestamp = min_id.map_or(u64::MIN, |id| {
             let (created_at_secs, _) = id.get_timestamp().unwrap().to_unix();
             created_at_secs
@@ -129,7 +129,7 @@ impl SearchBackend for MeiliSearchService {
         Ok(results
             .hits
             .into_iter()
-            .map(|item| SearchResult {
+            .map(|item| SearchResultReference {
                 index,
                 id: item.result.id,
             })

--- a/crates/kitsune-search/src/meilisearch.rs
+++ b/crates/kitsune-search/src/meilisearch.rs
@@ -1,8 +1,14 @@
 use super::{Result, SearchBackend, SearchIndex, SearchItem, SearchResult};
 use async_trait::async_trait;
 use meilisearch_sdk::{indexes::Index, settings::Settings, Client};
+use serde::Deserialize;
 use speedy_uuid::Uuid;
 use strum::IntoEnumIterator;
+
+#[derive(Deserialize)]
+struct MeilisearchResult {
+    id: Uuid,
+}
 
 #[derive(Clone)]
 pub struct MeiliSearchService {
@@ -92,7 +98,7 @@ impl SearchBackend for MeiliSearchService {
     async fn search(
         &self,
         index: SearchIndex,
-        query: String,
+        query: &str,
         max_results: u64,
         offset: u64,
         min_id: Option<Uuid>,
@@ -112,15 +118,22 @@ impl SearchBackend for MeiliSearchService {
         let results = self
             .get_index(index)
             .search()
-            .with_query(&query)
+            .with_query(query)
             .with_filter(&filter)
             .with_sort(&["id:desc"])
             .with_offset(offset as usize)
             .with_limit(max_results as usize)
-            .execute::<SearchResult>()
+            .execute::<MeilisearchResult>()
             .await?;
 
-        Ok(results.hits.into_iter().map(|item| item.result).collect())
+        Ok(results
+            .hits
+            .into_iter()
+            .map(|item| SearchResult {
+                index,
+                id: item.result.id,
+            })
+            .collect())
     }
 
     #[instrument(skip_all)]

--- a/crates/kitsune-search/src/sql.rs
+++ b/crates/kitsune-search/src/sql.rs
@@ -1,4 +1,4 @@
-use super::{Result, SearchBackend, SearchIndex, SearchItem, SearchResult};
+use super::{Result, SearchBackend, SearchIndex, SearchItem, SearchResultReference};
 use async_trait::async_trait;
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::{scoped_futures::ScopedFutureExt, RunQueryDsl};
@@ -49,7 +49,7 @@ impl SearchBackend for SearchService {
         offset: u64,
         min_id: Option<Uuid>,
         max_id: Option<Uuid>,
-    ) -> Result<Vec<SearchResult>> {
+    ) -> Result<Vec<SearchResultReference>> {
         let query_lang = kitsune_language::detect_language(DetectionBackend::default(), query);
         let query_fn_call = websearch_to_tsquery_with_search_config(
             iso_code_to_language(LanguageIsoCode::from(query_lang)),
@@ -79,7 +79,7 @@ impl SearchBackend for SearchService {
                                 .select(accounts::id)
                                 .load_stream(db_conn)
                                 .await?
-                                .map_ok(|id| SearchResult { index, id })
+                                .map_ok(|id| SearchResultReference { index, id })
                                 .try_collect()
                                 .await
                         }
@@ -115,7 +115,7 @@ impl SearchBackend for SearchService {
                                 .select(posts::id)
                                 .load_stream(db_conn)
                                 .await?
-                                .map_ok(|id| SearchResult { index, id })
+                                .map_ok(|id| SearchResultReference { index, id })
                                 .try_collect()
                                 .await
                         }

--- a/crates/kitsune-search/src/sql.rs
+++ b/crates/kitsune-search/src/sql.rs
@@ -44,13 +44,13 @@ impl SearchBackend for SearchService {
     async fn search(
         &self,
         index: SearchIndex,
-        query: String,
+        query: &str,
         max_results: u64,
         offset: u64,
         min_id: Option<Uuid>,
         max_id: Option<Uuid>,
     ) -> Result<Vec<SearchResult>> {
-        let query_lang = kitsune_language::detect_language(DetectionBackend::default(), &query);
+        let query_lang = kitsune_language::detect_language(DetectionBackend::default(), query);
         let query_fn_call = websearch_to_tsquery_with_search_config(
             iso_code_to_language(LanguageIsoCode::from(query_lang)),
             &query,
@@ -79,7 +79,7 @@ impl SearchBackend for SearchService {
                                 .select(accounts::id)
                                 .load_stream(db_conn)
                                 .await?
-                                .map_ok(|id| SearchResult { id })
+                                .map_ok(|id| SearchResult { index, id })
                                 .try_collect()
                                 .await
                         }
@@ -115,7 +115,7 @@ impl SearchBackend for SearchService {
                                 .select(posts::id)
                                 .load_stream(db_conn)
                                 .await?
-                                .map_ok(|id| SearchResult { id })
+                                .map_ok(|id| SearchResult { index, id })
                                 .try_collect()
                                 .await
                         }

--- a/crates/kitsune-type/Cargo.toml
+++ b/crates/kitsune-type/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 [dependencies]
 iso8601-timestamp = "0.2.12"
 serde = { version = "1.0.190", features = ["derive"] }
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 smol_str = { version = "0.2.0", features = ["serde"] }
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["serde"] }
 utoipa = { version = "4.0.0", features = ["chrono", "uuid"] }

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -62,7 +62,7 @@ oxide-auth-axum = "0.3.0"
 scoped-futures = "0.1.3"
 serde = { version = "1.0.190", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 speedy-uuid = { path = "../lib/speedy-uuid" }
 strum = { version = "0.25.0", features = ["derive", "phf"] }
 tempfile = "3.8.1"

--- a/kitsune/src/http/handler/mastodon/api/v2/search.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/search.rs
@@ -14,7 +14,7 @@ use kitsune_db::{
     model::{account::Account, post::Post},
     schema::{accounts, posts},
 };
-use kitsune_search::{SearchBackend, SearchIndex, SearchService};
+use kitsune_search::{Search, SearchBackend, SearchIndex};
 use kitsune_type::mastodon::SearchResult;
 use scoped_futures::ScopedFutureExt;
 use serde::Deserialize;
@@ -60,7 +60,7 @@ struct SearchQuery {
 )]
 async fn get(
     State(state): State<Zustand>,
-    State(search): State<SearchService>,
+    State(search): State<Search>,
     AuthExtractor(user_data): MastodonAuthExtractor,
     Query(query): Query<SearchQuery>,
 ) -> Result<Either<Json<SearchResult>, StatusCode>> {
@@ -82,7 +82,7 @@ async fn get(
         let results = search
             .search(
                 index,
-                query.query.clone(),
+                &query.query,
                 min(query.limit, API_MAX_LIMIT as u64),
                 query.offset,
                 query.min_id,

--- a/kitsune/src/http/handler/users/inbox.rs
+++ b/kitsune/src/http/handler/users/inbox.rs
@@ -87,7 +87,7 @@ async fn create_activity(state: &Zustand, author: Account, activity: Activity) -
             .embed_client(state.embed_client())
             .fetcher(state.fetcher())
             .object(Box::new(object))
-            .search_service(&state.service().search)
+            .search_backend(state.service().search.backend())
             .build();
         let new_post = process_new_object(process_data).await?;
 
@@ -315,7 +315,7 @@ async fn update_activity(state: &Zustand, author: Account, activity: Activity) -
             .embed_client(state.embed_client())
             .fetcher(state.fetcher())
             .object(Box::new(object))
-            .search_service(&state.service().search)
+            .search_backend(state.service().search.backend())
             .build();
         let modified_post = update_object(process_data).await?;
 

--- a/kitsune/src/state.rs
+++ b/kitsune/src/state.rs
@@ -14,7 +14,7 @@ use kitsune_core::{
 };
 use kitsune_db::PgPool;
 use kitsune_embed::Client as EmbedClient;
-use kitsune_search::SearchService;
+use kitsune_search::Search;
 
 #[cfg(feature = "mastodon-api")]
 use kitsune_core::mapping::MastodonMapper;
@@ -60,7 +60,7 @@ impl_from_ref! {
         JobService => |input: &Zustand| input.core.service.job.clone(),
         NotificationService => |input: &Zustand| input.core.service.notification.clone(),
         PostService => |input: &Zustand| input.core.service.post.clone(),
-        SearchService => |input: &Zustand| input.core.service.search.clone(),
+        Search => |input: &Zustand| input.core.service.search.clone(),
         InstanceService => |input: &Zustand| input.core.service.instance.clone(),
         TimelineService => |input: &Zustand| input.core.service.timeline.clone(),
         UrlService => |input: &Zustand| input.core.service.url.clone(),

--- a/kitsune/src/state.rs
+++ b/kitsune/src/state.rs
@@ -7,14 +7,13 @@ use kitsune_core::{
     service::{
         account::AccountService, attachment::AttachmentService,
         federation_filter::FederationFilterService, instance::InstanceService, job::JobService,
-        notification::NotificationService, post::PostService, timeline::TimelineService,
-        url::UrlService, user::UserService,
+        notification::NotificationService, post::PostService, search::SearchService,
+        timeline::TimelineService, url::UrlService, user::UserService,
     },
     state::{EventEmitter, Service as CoreServiceState, State as CoreState},
 };
 use kitsune_db::PgPool;
 use kitsune_embed::Client as EmbedClient;
-use kitsune_search::Search;
 
 #[cfg(feature = "mastodon-api")]
 use kitsune_core::mapping::MastodonMapper;
@@ -60,7 +59,7 @@ impl_from_ref! {
         JobService => |input: &Zustand| input.core.service.job.clone(),
         NotificationService => |input: &Zustand| input.core.service.notification.clone(),
         PostService => |input: &Zustand| input.core.service.post.clone(),
-        Search => |input: &Zustand| input.core.service.search.clone(),
+        SearchService => |input: &Zustand| input.core.service.search.clone(),
         InstanceService => |input: &Zustand| input.core.service.instance.clone(),
         TimelineService => |input: &Zustand| input.core.service.timeline.clone(),
         UrlService => |input: &Zustand| input.core.service.url.clone(),

--- a/lib/athena/Cargo.toml
+++ b/lib/athena/Cargo.toml
@@ -23,7 +23,7 @@ redis = { version = "0.23.3", default-features = false, features = [
 ] }
 retry-policies = "0.2.1"
 serde = { version = "1.0.190", features = ["derive"] }
-simd-json = "0.13.3"
+simd-json = "0.13.4"
 smol_str = "0.2.0"
 speedy-uuid = { path = "../speedy-uuid", features = ["redis", "serde"] }
 thiserror = "1.0.50"


### PR DESCRIPTION
This PR restructures the search service in the following way:

- `kitsune_search` is now considered a *search backend* abstraction
- `kitsune_core` gets a new service: `SearchService`
    - This new service is only there to query the service and to do some resolving
    - It resolves posts and accounts by their URLs

The new structure should also enable some nicer query pipelining and will make it easier to keep the feature parity between the Mastodon and (eventual) GraphQL search on the same level.