### PR TITLE
Use a faster crate for ASCII representation parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi_radix10"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6970a22a33d6a8f862aac371bac48505a1bfaa230ecb268c7b86fa4ac6e7121"
+
+[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3733,8 +3739,8 @@ dependencies = [
 name = "masto-id-convert"
 version = "0.0.1-pre.4"
 dependencies = [
+ "atoi_radix10",
  "criterion",
- "lexical-parse-integer",
  "nanorand",
  "time",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,15 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atoi"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
-dependencies = [
- "num-traits 0.2.17",
-]
-
-[[package]]
 name = "atomic"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3742,8 +3733,8 @@ dependencies = [
 name = "masto-id-convert"
 version = "0.0.1-pre.4"
 dependencies = [
- "atoi",
  "criterion",
+ "lexical-parse-integer",
  "nanorand",
  "time",
  "uuid",

--- a/lib/masto-id-convert/Cargo.toml
+++ b/lib/masto-id-convert/Cargo.toml
@@ -9,7 +9,7 @@ name = "process"
 harness = false
 
 [dependencies]
-atoi = { version = "2.0.0", default-features = false }
+lexical-parse-integer = { version = "0.8.6", default-features = false }
 nanorand = { version = "0.7.0", default-features = false, features = [
     "wyrand",
 ] }

--- a/lib/masto-id-convert/Cargo.toml
+++ b/lib/masto-id-convert/Cargo.toml
@@ -9,7 +9,7 @@ name = "process"
 harness = false
 
 [dependencies]
-lexical-parse-integer = { version = "0.8.6", default-features = false }
+atoi_radix10 = "0.0.1"
 nanorand = { version = "0.7.0", default-features = false, features = [
     "wyrand",
 ] }

--- a/lib/masto-id-convert/src/lib.rs
+++ b/lib/masto-id-convert/src/lib.rs
@@ -3,7 +3,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use core::fmt;
-use lexical_parse_integer::FromLexical;
 use nanorand::{Rng, WyRand};
 use uuid::Uuid;
 
@@ -11,7 +10,7 @@ use uuid::Uuid;
 #[derive(Debug)]
 pub enum Error {
     /// Number parsing error
-    NumberParse(lexical_parse_integer::Error),
+    NumberParse(atoi_radix10::ParseIntErrorPublic),
 }
 
 impl fmt::Display for Error {
@@ -20,8 +19,8 @@ impl fmt::Display for Error {
     }
 }
 
-impl From<lexical_parse_integer::Error> for Error {
-    fn from(value: lexical_parse_integer::Error) -> Self {
+impl From<atoi_radix10::ParseIntErrorPublic> for Error {
+    fn from(value: atoi_radix10::ParseIntErrorPublic) -> Self {
         Self::NumberParse(value)
     }
 }
@@ -61,6 +60,6 @@ pub fn process<T>(masto_id: T) -> Result<Uuid, Error>
 where
     T: AsRef<[u8]>,
 {
-    let result = u64::from_lexical(masto_id.as_ref())?;
+    let result = atoi_radix10::parse(masto_id.as_ref())?;
     Ok(process_u64(result))
 }

--- a/lib/masto-id-convert/src/lib.rs
+++ b/lib/masto-id-convert/src/lib.rs
@@ -2,8 +2,8 @@
 #![forbid(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use atoi::FromRadix10;
 use core::fmt;
+use lexical_parse_integer::FromLexical;
 use nanorand::{Rng, WyRand};
 use uuid::Uuid;
 
@@ -11,12 +11,18 @@ use uuid::Uuid;
 #[derive(Debug)]
 pub enum Error {
     /// Number parsing error
-    NumberParse,
+    NumberParse(lexical_parse_integer::Error),
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{self:?}")
+    }
+}
+
+impl From<lexical_parse_integer::Error> for Error {
+    fn from(value: lexical_parse_integer::Error) -> Self {
+        Self::NumberParse(value)
     }
 }
 
@@ -55,10 +61,6 @@ pub fn process<T>(masto_id: T) -> Result<Uuid, Error>
 where
     T: AsRef<[u8]>,
 {
-    let (result, index) = u64::from_radix_10(masto_id.as_ref());
-    if index == 0 {
-        return Err(Error::NumberParse);
-    }
-
+    let result = u64::from_lexical(masto_id.as_ref())?;
     Ok(process_u64(result))
 }


### PR DESCRIPTION
After:

```
process ASCII 110368129515784116
                        time:   [8.4860 ns 8.5083 ns 8.5317 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
```

Before:

```
process ASCII 110368129515784116
                        time:   [10.923 ns 10.946 ns 10.990 ns]
                        change: [+27.961% +28.231% +28.525%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```