### PR TITLE
Add option to redirect Brave browsers to article

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
+ "tower-stop-using-brave",
  "tower-x-clacks-overhead",
  "tracing",
  "typed-builder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7094,6 +7094,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
+name = "tower-stop-using-brave"
+version = "0.0.1-pre.4"
+dependencies = [
+ "either",
+ "futures",
+ "http 1.0.0",
+ "once_cell",
+ "regex",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-x-clacks-overhead"
 version = "0.0.1-pre.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ members = [
     "lib/masto-id-convert",
     "lib/post-process",
     "lib/speedy-uuid",
+    "lib/tower-stop-using-brave",
     "lib/tower-x-clacks-overhead",
     "xtask",
 ]

--- a/config.example.toml
+++ b/config.example.toml
@@ -160,6 +160,14 @@ type = "in-process"
 #
 # This configuration changes the general behaviour that you'd mostly attribute to the underlying HTTP server
 [server]
+# Setting to deny browsers with the Brave User-Agent
+#
+# Brave is a company financed by cryptocurrency scams, founded by a queerphobic bigot
+# All the "privacy advantages" of Brave, you can get by getting a Firefox + uBlock Origin + DuckDuckGo installation
+#
+# When this setting is enabled, all browsers with the Brave User-Agent are redirected to an article
+# explaining the hateful background of Brave Inc.
+deny-brave-browsers = true
 # Values for the `X-Clacks-Overhead` header
 # You can use this as a sort of silent memorial
 # clacks-overhead = ["Natalie Nguyen", "John \"Soap\" MacTavish"]

--- a/crates/kitsune-config/src/server.rs
+++ b/crates/kitsune-config/src/server.rs
@@ -7,6 +7,7 @@ use smol_str::SmolStr;
 pub struct Configuration {
     #[serde(default)]
     pub clacks_overhead: Vec<SmolStr>,
+    pub deny_brave_browsers: bool,
     pub frontend_dir: SmolStr,
     pub max_upload_size: usize,
     pub media_proxy_enabled: bool,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
     - [Captcha](./configuring/captcha.md)
     - [Clacks Overhead](./configuring/clacks-overhead.md)
     - [Database](./configuring/database.md)
+    - [Deny Brave Browsers](./configuring/deny-brave-browsers.md)
     - [Emailing](./configuring/email.md)
     - [Federation filter](./configuring/federation-filter.md)
     - [Instance](./configuring/instance.md)

--- a/docs/src/configuring/deny-brave-browsers.md
+++ b/docs/src/configuring/deny-brave-browsers.md
@@ -1,0 +1,21 @@
+# Deny Brave Browsers
+
+Brave is a company founded by a queerphobic bigot, funded by people such as Peter Thiel.
+You can get pretty much all of Brave's "privacy advantages" with a Firefox + uBlock Origin + DuckDuckGo installation. 
+
+(Plus, Brave is another Chromium-based browsers. Using Firefox helps diversify the browser landscape at least a little bit)
+
+When this setting is enabled, all browsers with the Brave User-Agent are redirected to an article explaining the hateful and problematic background of Brave Inc.  
+
+Since Kitsune is about choice, we give you the ability to simply toggle this functionality off.  
+While we give you that option, you maybe want to keep this option on.
+
+The reasoning behind this is simple:
+
+- If people aren't aware and care, they can switch browsers. Switching a browser isn't a herculean task.  
+- If people are aware and don't care, I'm not sure if you want them on your service.
+
+```toml
+[server]
+deny-brave-browsers = true
+```

--- a/docs/src/configuring/deny-brave-browsers.md
+++ b/docs/src/configuring/deny-brave-browsers.md
@@ -5,7 +5,7 @@ You can get pretty much all of Brave's "privacy advantages" with a Firefox + uBl
 
 (Plus, Brave is another Chromium-based browsers. Using Firefox helps diversify the browser landscape at least a little bit)
 
-When this setting is enabled, all browsers with the Brave User-Agent are redirected to an article explaining the hateful and problematic background of Brave Inc.  
+When this setting is enabled, all browsers with the Brave User-Agent are redirected to an [article explaining the hateful and problematic background of Brave](https://www.spacebar.news/stop-using-brave-browser/).  
 
 Since Kitsune is about choice, we give you the ability to simply toggle this functionality off.  
 While we give you that option, you maybe want to keep this option on.

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -87,6 +87,7 @@ thiserror = "1.0.56"
 time = "0.3.31"
 tokio = { version = "1.35.1", features = ["full"] }
 tokio-util = { version = "0.7.10", features = ["compat"] }
+tower-stop-using-brave = { path = "../lib/tower-stop-using-brave" }
 tower-x-clacks-overhead = { path = "../lib/tower-x-clacks-overhead" }
 tower-http = { version = "0.5.0", features = [
     "catch-panic",

--- a/kitsune/src/http/mod.rs
+++ b/kitsune/src/http/mod.rs
@@ -18,6 +18,7 @@ use tower_http::{
     timeout::TimeoutLayer,
     trace::TraceLayer,
 };
+use tower_stop_using_brave::StopUsingBraveLayer;
 use tower_x_clacks_overhead::XClacksOverheadLayer;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -88,6 +89,10 @@ pub fn create_router(
                 .wrap_err("Invalid clacks overhead values")?;
 
         router = router.layer(clacks_overhead_layer);
+    }
+
+    if server_config.deny_brave_browsers {
+        router = router.layer(StopUsingBraveLayer::default());
     }
 
     Ok(router

--- a/lib/tower-stop-using-brave/Cargo.toml
+++ b/lib/tower-stop-using-brave/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "tower-stop-using-brave"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+
+[dependencies]
+either = "1.9.0"
+http = "1.0.0"
+once_cell = "1.19.0"
+regex = "1.10.2"
+tower-layer = "0.3.2"
+tower-service = "0.3.2"
+
+[dev-dependencies]
+futures = { version = "0.3.30", default-features = false, features = [
+    "executor",
+] }
+tower = { version = "0.4.13", default-features = false, features = ["util"] }
+
+[lints]
+workspace = true

--- a/lib/tower-stop-using-brave/src/lib.rs
+++ b/lib/tower-stop-using-brave/src/lib.rs
@@ -1,0 +1,157 @@
+use either::Either;
+use http::{header::USER_AGENT, HeaderValue, Request, Response, StatusCode};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::{
+    future::{self, Ready},
+    task::{self, Poll},
+};
+use tower_layer::Layer;
+use tower_service::Service;
+
+static REDIRECT_URL: &str = "https://www.spacebar.news/stop-using-brave-browser/";
+static USER_AGENT_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(^|\s)Brave(/|\s)").expect("[Bug] Failed to compile User-Agent regex")
+});
+
+#[derive(Clone)]
+pub struct StopUsingBraveService<S> {
+    inner: S,
+}
+
+impl<S> StopUsingBraveService<S> {
+    pub fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+impl<S, ReqBody, ResBody> Service<Request<ReqBody>> for StopUsingBraveService<S>
+where
+    S: Service<Request<ReqBody>, Response = Response<ResBody>>,
+    ResBody: Default,
+{
+    type Error = S::Error;
+    type Response = S::Response;
+    type Future = Either<S::Future, Ready<Result<S::Response, S::Error>>>;
+
+    fn poll_ready(&mut self, cx: &mut task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        if let Some(Ok(user_agent)) = req.headers().get(USER_AGENT).map(HeaderValue::to_str) {
+            if USER_AGENT_REGEX.is_match(user_agent) {
+                let response = Response::builder()
+                    .status(StatusCode::FOUND)
+                    .header("Location", REDIRECT_URL)
+                    .body(Default::default())
+                    .unwrap();
+
+                return Either::Right(future::ready(Ok(response)));
+            }
+        }
+
+        Either::Left(self.inner.call(req))
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct StopUsingBraveLayer {
+    _priv: (),
+}
+
+impl<S> Layer<S> for StopUsingBraveLayer {
+    type Service = StopUsingBraveService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        StopUsingBraveService::new(inner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use futures::executor;
+    use http::{
+        header::{LOCATION, USER_AGENT},
+        Request, Response, StatusCode,
+    };
+    use std::convert::Infallible;
+    use tower::{service_fn, Layer, Service, ServiceExt};
+
+    use crate::{StopUsingBraveLayer, REDIRECT_URL};
+
+    const BRAVE_USER_AGENTS: &[&str] = &[
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Brave/120.0.0.0",
+        "Mozilla/5.0 (Android 13.0.0; ) AppleWebKit/537.36 (KHTML, like Gecko) Brave/120 Chrome/120 Not_A Brand/8 Mobile Safari/537.36",
+        "Mozilla/5.0 (Linux; Android 14; SM-S918U1) AppleWebKit/606.2.15 (KHTML, like Gecko) Brave/119.0.6045.134 Mobile Safari/606.2.15",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.38 Safari/537.36 Brave/75",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.38 Safari/537.36 Brave/75",
+        "Mozilla/5.0 (iPad; CPU OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Brave/1.33.81 Mobile Safari/605.1.15",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_4 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Brave/1.2.11 Mobile/13G35 Safari/601.1.46 _id/000002",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Brave Chrome/86.0.4240.198 Safari/537.36",
+    ];
+
+    const OTHER_USER_AGENTS: &[&str] = &[
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/121.0",
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.2; rv:109.0) Gecko/20100101 Firefox/121.0",
+        "Mozilla/5.0 (X11; Linux i686; rv:109.0) Gecko/20100101 Firefox/121.0",
+        "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0",
+        "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/121.0",
+    ];
+
+    #[test]
+    fn matches_brave_agents() {
+        for user_agent in BRAVE_USER_AGENTS {
+            let mut service =
+                StopUsingBraveLayer::default().layer(service_fn(|_req: Request<()>| async move {
+                    // The "unreachable" expression provides type annotations for the compiler to figure out the response and error types
+                    #[allow(unreachable_code)]
+                    {
+                        panic!("Shouldn't have reached the handler!")
+                            as Result<Response<()>, Infallible>
+                    }
+                }));
+
+            let response = executor::block_on(async move {
+                let request = Request::builder()
+                    .header(USER_AGENT, *user_agent)
+                    .body(())
+                    .unwrap();
+
+                service.ready().await.unwrap().call(request).await.unwrap()
+            });
+
+            assert_eq!(response.status(), StatusCode::FOUND);
+            assert_eq!(
+                response.headers().get(LOCATION).unwrap().as_bytes(),
+                REDIRECT_URL.as_bytes()
+            );
+        }
+    }
+
+    #[test]
+    fn doesnt_match_other_agents() {
+        for user_agent in OTHER_USER_AGENTS {
+            let mut service =
+                StopUsingBraveLayer::default().layer(service_fn(|_req: Request<()>| async move {
+                    Ok::<_, Infallible>(
+                        Response::builder().status(StatusCode::OK).body(()).unwrap(),
+                    )
+                }));
+
+            let response = executor::block_on(async move {
+                let request = Request::builder()
+                    .header(USER_AGENT, *user_agent)
+                    .body(())
+                    .unwrap();
+
+                service.ready().await.unwrap().call(request).await.unwrap()
+            });
+
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+    }
+}


### PR DESCRIPTION
To quote the documentation of the option:

> Brave is a company founded by a queerphobic bigot, funded by people such as Peter Thiel.
> You can get pretty much all of Brave's "privacy advantages" with a Firefox + uBlock Origin + DuckDuckGo installation. 
> 
> (Plus, Brave is another Chromium-based browsers. Using Firefox helps diversify the browser landscape at least a little bit)
> 
> When this setting is enabled, all browsers with the Brave User-Agent are redirected to an article explaining the hateful and problematic background of Brave Inc.  
> 
> Since Kitsune is about choice, we give you the ability to simply toggle this functionality off.  
> While we give you that option, you maybe want to keep this option on.
> 
> The reasoning behind this is simple:
> 
> - If people aren't aware and care, they can switch browsers. Switching a browser isn't a herculean task.  
> - If people are aware and don't care, I'm not sure if you want them on your service.

This PR adds an option to redirect users that have a User-Agent that matches the Brave user agent to the following article: <https://www.spacebar.news/stop-using-brave-browser/>

Since the option could theoretically break the software for some people, the option has no default value and Kitsune will refuse to start up without explicitly setting a value.

---

Tech isn't apolitical. Nor am I. 