### PR TITLE
Revert back to Rust stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ dependencies = [
  "criterion-plot",
  "futures",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits 0.2.17",
  "once_cell",
  "oorandom",
@@ -1345,7 +1345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2994,6 +2994,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3056,6 +3065,7 @@ dependencies = [
  "http 1.0.0",
  "http-body-util",
  "iso8601-timestamp",
+ "itertools 0.12.0",
  "kitsune-activitypub",
  "kitsune-blocking",
  "kitsune-cache",
@@ -3378,6 +3388,7 @@ dependencies = [
  "base64-simd",
  "derive_builder",
  "http 1.0.0",
+ "itertools 0.12.0",
  "kitsune-blocking",
  "pem",
  "pkcs8",
@@ -4550,7 +4561,7 @@ dependencies = [
  "ed25519-dalek",
  "hmac",
  "http 0.2.11",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "oauth2",
  "p256",
@@ -4587,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.98"
+version = "0.9.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1665caf8ab2dc9aef43d1c0023bd904633a6a05cb30b0ad59bec2ae986e57a7"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
 dependencies = [
  "cc",
  "libc",
@@ -5266,7 +5277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6327,9 +6338,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9511d2aa0b26dce65ea3860321cd680a8daeb6808b04f1e94429e0389ad952"
+checksum = "2faf8f101b9bc484337a6a6b0409cf76c139f2fb70a9e3aee6b6774be7bfbf76"
 dependencies = [
  "getrandom 0.2.12",
  "halfbrown",
@@ -6402,9 +6413,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smawk"
@@ -6614,9 +6625,9 @@ dependencies = [
 
 [[package]]
 name = "supports-unicode"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6c2cb240ab5dd21ed4906895ee23fe5a48acdbd15a3ce388e7b62a9b66baf7"
+checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
 dependencies = [
  "is-terminal",
 ]
@@ -7138,6 +7149,7 @@ version = "0.0.1-pre.5"
 dependencies = [
  "futures",
  "http 1.0.0",
+ "itertools 0.12.0",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -7443,9 +7455,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "atomic",
  "getrandom 0.2.12",
@@ -7961,7 +7973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "103fa851fff70ea29af380e87c25c48ff7faac5c530c70bd0e65366d4e0c94e4"
 dependencies = [
  "fancy-regex",
- "itertools",
+ "itertools 0.10.5",
  "js-sys",
  "lazy_static",
  "quick-error",

--- a/crates/kitsune-activitypub/Cargo.toml
+++ b/crates/kitsune-activitypub/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 [dependencies]
 async-trait = "0.1.77"
 autometrics = { version = "1.0.0", default-features = false }
-base64-simd = { version = "0.8.0", features = ["unstable"] }
+base64-simd = "0.8.0"
 diesel = "2.1.4"
 diesel-async = "0.4.1"
 futures-util = "0.3.30"
@@ -33,7 +33,7 @@ rsa = "0.9.6"
 scoped-futures = "0.1.3"
 serde = "1.0.195"
 sha2 = "0.10.8"
-simd-json = { version = "0.13.7", features = ["hints"] }
+simd-json = "0.13.8"
 speedy-uuid = { path = "../../lib/speedy-uuid" }
 thiserror = "1.0.56"
 tracing = "0.1.40"

--- a/crates/kitsune-cache/Cargo.toml
+++ b/crates/kitsune-cache/Cargo.toml
@@ -10,7 +10,7 @@ enum_dispatch = "0.3.12"
 moka = { version = "0.12.3", features = ["sync"] }
 redis = "0.24.0"
 serde = "1.0.195"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 thiserror = "1.0.56"
 tracing = "0.1.40"
 typed-builder = "0.18.1"

--- a/crates/kitsune-captcha/Cargo.toml
+++ b/crates/kitsune-captcha/Cargo.toml
@@ -10,7 +10,7 @@ http = "1.0.0"
 kitsune-http-client = { path = "../kitsune-http-client" }
 serde = { version = "1.0.195", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.56"
 typed-builder = "0.18.1"

--- a/crates/kitsune-db/Cargo.toml
+++ b/crates/kitsune-db/Cargo.toml
@@ -6,7 +6,7 @@ edition.workspace = true
 build = "build.rs"
 
 [dependencies]
-diesel = { version = "2.1.4", features = ["nightly-error-messages", "uuid"] }
+diesel = { version = "2.1.4", features = ["uuid"] }
 diesel-async = { version = "0.4.1", features = [
     "async-connection-wrapper",
     "deadpool",
@@ -23,7 +23,7 @@ miette = "5.10.0"
 num-derive = "0.4.1"
 num-traits = "0.2.17"
 serde = { version = "1.0.195", features = ["derive"] }
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["diesel"] }
 thiserror = "1.0.56"
 tracing-log = "0.2.0"

--- a/crates/kitsune-http-client/Cargo.toml
+++ b/crates/kitsune-http-client/Cargo.toml
@@ -25,7 +25,7 @@ kitsune-http-signatures = { path = "../kitsune-http-signatures" }
 kitsune-type = { path = "../kitsune-type" }
 pin-project = "1.1.3"
 serde = "1.0.195"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 tower = { version = "0.4.13", features = ["util"] }
 tower-http = { version = "0.5.1", features = [
     # Explicitly exclude `zstd`

--- a/crates/kitsune-http-signatures/Cargo.toml
+++ b/crates/kitsune-http-signatures/Cargo.toml
@@ -5,10 +5,11 @@ authors.workspace = true
 edition.workspace = true
 
 [dependencies]
-base64-simd = { version = "0.8.0", features = ["unstable"] }
+base64-simd = "0.8.0"
 derive_builder = "0.12.0"
 http = "1.0.0"
 kitsune-blocking = { path = "../kitsune-blocking" }
+itertools = { version = "0.12.0", default-features = false }
 ring = { version = "0.17.7", features = ["std"] }
 time = { version = "0.3.31", default-features = false, features = [
     "formatting",

--- a/crates/kitsune-http-signatures/src/header.rs
+++ b/crates/kitsune-http-signatures/src/header.rs
@@ -118,12 +118,14 @@ impl TryFrom<SignatureHeader<'_>> for String {
 
     fn try_from(value: SignatureHeader<'_>) -> Result<Self, Self::Error> {
         let signature = base64_simd::STANDARD.encode_to_string(value.signature);
-        let headers = value
-            .signature_components
-            .iter()
-            .map(SignatureComponent::as_str)
-            .intersperse(" ")
-            .collect::<String>();
+        let headers = itertools::intersperse(
+            value
+                .signature_components
+                .iter()
+                .map(SignatureComponent::as_str),
+            " ",
+        )
+        .collect::<String>();
 
         let mut signature_header = format!(
             "keyId=\"{}\",signature=\"{signature}\",headers=\"{headers}\"",

--- a/crates/kitsune-http-signatures/src/lib.rs
+++ b/crates/kitsune-http-signatures/src/lib.rs
@@ -4,7 +4,6 @@
 //! Only supports asymmetric signing schemes (aka. no HMAC and such)
 //!
 
-#![feature(iter_intersperse)]
 #![deny(missing_docs)]
 
 use crate::{header::SignatureHeader, util::UnixTimestampExt};

--- a/crates/kitsune-mastodon/Cargo.toml
+++ b/crates/kitsune-mastodon/Cargo.toml
@@ -21,7 +21,7 @@ kitsune-util = { path = "../kitsune-util" }
 mime = "0.3.17"
 scoped-futures = "0.1.3"
 serde = "1.0.195"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 smol_str = "0.2.1"
 speedy-uuid = { path = "../../lib/speedy-uuid" }
 thiserror = "1.0.56"

--- a/crates/kitsune-messaging/Cargo.toml
+++ b/crates/kitsune-messaging/Cargo.toml
@@ -16,7 +16,7 @@ redis = { version = "0.24.0", features = [
     "tokio-rustls-comp",
 ] }
 serde = "1.0.195"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 tokio = { version = "1.35.1", features = ["macros", "rt", "sync"] }
 tokio-stream = { version = "0.1.14", features = ["sync"] }
 tracing = "0.1.40"

--- a/crates/kitsune-oidc/Cargo.toml
+++ b/crates/kitsune-oidc/Cargo.toml
@@ -21,7 +21,7 @@ openidconnect = { version = "3.4.0", default-features = false, features = [
 ] }
 redis = "0.24.0"
 serde = { version = "1.0.195", features = ["derive"] }
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["serde"] }
 thiserror = "1.0.56"
 url = "2.5.0"

--- a/crates/kitsune-service/Cargo.toml
+++ b/crates/kitsune-service/Cargo.toml
@@ -52,7 +52,7 @@ rsa = "0.9.6"
 rusty-s3 = { version = "0.5.0", default-features = false }
 scoped-futures = "0.1.3"
 serde = "1.0.195"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 smol_str = "0.2.1"
 speedy-uuid = { path = "../../lib/speedy-uuid" }
 thiserror = "1.0.56"
@@ -66,7 +66,7 @@ zxcvbn = { version = "2.2.2", default-features = false }
 meilisearch = ["kitsune-search/meilisearch"]
 
 [dev-dependencies]
-hex-simd = { version = "0.8.0", features = ["unstable"] }
+hex-simd = "0.8.0"
 http-body-util = "0.1.0"
 hyper = "1.1.0"
 kitsune-activitypub = { path = "../kitsune-activitypub" }

--- a/crates/kitsune-type/Cargo.toml
+++ b/crates/kitsune-type/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 [dependencies]
 iso8601-timestamp = "0.2.16"
 serde = { version = "1.0.195", features = ["derive"] }
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 smol_str = { version = "0.2.1", features = ["serde"] }
 speedy-uuid = { path = "../../lib/speedy-uuid", features = ["serde"] }
 utoipa = { version = "4.2.0", features = ["chrono", "uuid"] }

--- a/crates/kitsune-util/src/lib.rs
+++ b/crates/kitsune-util/src/lib.rs
@@ -22,6 +22,13 @@ pub fn generate_secret() -> String {
         .collect()
 }
 
+const _: () = {
+    assert!(
+        std::mem::size_of::<CowBox<'_, [u8; 1024]>>() <= std::mem::size_of::<usize>() * 2,
+        "Size guarantee violated (should have the size of two or less machine words)",
+    );
+};
+
 #[derive(Clone, Debug)]
 pub enum CowBox<'a, T> {
     Borrowed(&'a T),

--- a/crates/kitsune-webfinger/Cargo.toml
+++ b/crates/kitsune-webfinger/Cargo.toml
@@ -21,7 +21,7 @@ tracing = "0.1.40"
 http-body-util = "0.1.0"
 hyper = "1.1.0"
 pretty_assertions = "1.4.0"
-simd-json = { version = "0.13.7", features = ["hints"] }
+simd-json = "0.13.8"
 tokio = { version = "1.35.1", features = ["macros"] }
 tower = { version = "0.4.13", default-features = false, features = ["util"] }
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,8 @@
             inherit overlays system;
           };
           rustPlatform = pkgs.makeRustPlatform {
-            cargo = pkgs.rust-bin.nightly.latest.minimal;
-            rustc = pkgs.rust-bin.nightly.latest.minimal;
+            cargo = pkgs.rust-bin.stable.latest.minimal;
+            rustc = pkgs.rust-bin.stable.latest.minimal;
           };
           baseDependencies = with pkgs; [
             openssl
@@ -128,7 +128,7 @@
                   packages = with pkgs; [
                     cargo-insta
                     diesel-cli
-                    rust-bin.nightly.latest.default
+                    rust-bin.stable.latest.default
                   ]
                   ++
                   baseDependencies;

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -42,6 +42,7 @@ headers = "0.4.0"
 http = "1.0.0"
 http-body-util = "0.1.0"
 iso8601-timestamp = "0.2.16"
+itertools = { version = "0.12.0", default-features = false }
 kitsune-activitypub = { path = "../crates/kitsune-activitypub" }
 kitsune-blocking = { path = "../crates/kitsune-blocking" }
 kitsune-cache = { path = "../crates/kitsune-cache" }
@@ -79,7 +80,7 @@ rust-embed = { version = "8.2.0", features = ["include-exclude"] }
 scoped-futures = "0.1.3"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_urlencoded = "0.7.1"
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 speedy-uuid = { path = "../lib/speedy-uuid" }
 strum = { version = "0.25.0", features = ["derive", "phf"] }
 tempfile = "3.9.0"

--- a/kitsune/src/http/pagination.rs
+++ b/kitsune/src/http/pagination.rs
@@ -23,12 +23,13 @@ where
     type Error = Error;
 
     fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
-        let value = self
-            .0
-            .into_iter()
-            .map(|(key, value)| Cow::Owned(format!("<{value}>; rel=\"{key}\"")))
-            .intersperse(Cow::Borrowed(", "))
-            .collect::<String>();
+        let value = itertools::intersperse(
+            self.0
+                .into_iter()
+                .map(|(key, value)| Cow::Owned(format!("<{value}>; rel=\"{key}\""))),
+            Cow::Borrowed(", "),
+        )
+        .collect::<String>();
 
         res.headers_mut().insert(
             "Link",

--- a/kitsune/src/lib.rs
+++ b/kitsune/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(iter_intersperse)]
-
 #[macro_use]
 extern crate metrics;
 

--- a/kitsune/src/oauth2/registrar.rs
+++ b/kitsune/src/oauth2/registrar.rs
@@ -79,8 +79,7 @@ impl Registrar for OAuthRegistrar {
             if valid_scopes.peek().is_none() {
                 OAuthScope::Read.as_ref().parse().unwrap()
             } else {
-                valid_scopes
-                    .intersperse(" ")
+                itertools::intersperse(valid_scopes, " ")
                     .collect::<String>()
                     .parse()
                     .unwrap()

--- a/lib/athena/Cargo.toml
+++ b/lib/athena/Cargo.toml
@@ -23,7 +23,7 @@ redis = { version = "0.24.0", default-features = false, features = [
 ] }
 retry-policies = "0.2.1"
 serde = { version = "1.0.195", features = ["derive"] }
-simd-json = "0.13.7"
+simd-json = "0.13.8"
 smol_str = "0.2.1"
 speedy-uuid = { path = "../speedy-uuid", features = ["redis", "serde"] }
 thiserror = "1.0.56"

--- a/lib/masto-id-convert/Cargo.toml
+++ b/lib/masto-id-convert/Cargo.toml
@@ -13,7 +13,7 @@ atoi_radix10 = "0.0.1"
 nanorand = { version = "0.7.0", default-features = false, features = [
     "wyrand",
 ] }
-uuid = { version = "1.6.1", default-features = false }
+uuid = { version = "1.7.0", default-features = false }
 
 [features]
 default = ["std"]
@@ -22,7 +22,7 @@ std = []
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }
 time = "0.3.31"
-uuid = { version = "1.6.1", features = ["v7"] }
+uuid = { version = "1.7.0", features = ["v7"] }
 
 [lints]
 workspace = true

--- a/lib/speedy-uuid/Cargo.toml
+++ b/lib/speedy-uuid/Cargo.toml
@@ -13,8 +13,8 @@ diesel = { version = "2.1.4", features = [
 redis = { version = "0.24.0", default-features = false, optional = true }
 serde = { version = "1.0.195", optional = true }
 thiserror = "1.0.56"
-uuid = { version = "1.6.1", features = ["fast-rng", "v7"] }
-uuid-simd = { version = "0.8.0", features = ["unstable", "uuid"] }
+uuid = { version = "1.7.0", features = ["fast-rng", "v7"] }
+uuid-simd = { version = "0.8.0", features = ["uuid"] }
 
 [lints]
 workspace = true

--- a/lib/tower-x-clacks-overhead/Cargo.toml
+++ b/lib/tower-x-clacks-overhead/Cargo.toml
@@ -6,6 +6,7 @@ version.workspace = true
 
 [dependencies]
 http = "1.0.0"
+itertools = { version = "0.12.0", default-features = false }
 pin-project-lite = "0.2.13"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"

--- a/lib/tower-x-clacks-overhead/src/lib.rs
+++ b/lib/tower-x-clacks-overhead/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(iter_intersperse)]
-
 use http::{header::InvalidHeaderValue, HeaderName, HeaderValue, Response};
 use pin_project_lite::pin_project;
 use std::{
@@ -20,7 +18,7 @@ where
 {
     let names = format!(
         "GNU {}",
-        names.into_iter().intersperse(", ").collect::<String>()
+        itertools::intersperse(names, ", ").collect::<String>()
     )
     .parse()?;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["clippy", "rustfmt"]
 profile = "default"


### PR DESCRIPTION
Not really required anymore. Our biggest reason was the usage of "async fn in trait" before it officially released.  
Now that that's landed, we can go back.

Those few improved branch hints we are missing out on won't affect codegen that much for most users.