### PR TITLE
Clock mocking for `http-signatures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2680,6 +2680,7 @@ dependencies = [
  "ring 0.17.8",
  "scoped-futures",
  "thiserror",
+ "tick-tock-mock",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6849,7 +6849,6 @@ dependencies = [
 name = "tick-tock-mock"
 version = "0.0.1-pre.5"
 dependencies = [
- "arc-swap",
  "criterion",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,9 +178,9 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "arc-swap"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+checksum = "7b3d0060af21e8d11a926981cc00c6c1541aa91dd64b9f881985c3da1094425f"
 
 [[package]]
 name = "argh"
@@ -6843,6 +6843,14 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tick-tock-mock"
+version = "0.0.1-pre.5"
+dependencies = [
+ "arc-swap",
+ "criterion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ members = [
     "lib/multiplex-pool",
     "lib/post-process",
     "lib/speedy-uuid",
+    "lib/tick-tock-mock",
     "lib/tower-http-digest",
     "lib/tower-stop-using-brave",
     "lib/tower-x-clacks-overhead",

--- a/lib/http-signatures/Cargo.toml
+++ b/lib/http-signatures/Cargo.toml
@@ -32,6 +32,7 @@ pkcs8 = { version = "0.10.2", features = ["pem", "std"] }
 ring = { version = "0.17.8", features = ["std"] }
 scoped-futures = { version = "0.1.3", default-features = false }
 thiserror = "1.0.57"
+tick-tock-mock = { path = "../tick-tock-mock" }
 tracing = { version = "0.1.40", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/lib/http-signatures/src/cavage/easy.rs
+++ b/lib/http-signatures/src/cavage/easy.rs
@@ -4,8 +4,10 @@
 //! Integrates with async and offers an incredibly simplistic interface for signing and verifying HTTP signatures
 //!
 
-use super::SafetyCheckError;
-use crate::{cavage::SignatureHeader, BoxError, SIGNATURE_HEADER};
+use crate::{
+    cavage::{SafetyCheckError, SignatureHeader},
+    BoxError, SIGNATURE_HEADER,
+};
 use http::{header::DATE, HeaderValue, Method};
 use miette::Diagnostic;
 use scoped_futures::ScopedFutureWrapper;

--- a/lib/http-signatures/src/cavage/easy.rs
+++ b/lib/http-signatures/src/cavage/easy.rs
@@ -9,7 +9,7 @@ use crate::{cavage::SignatureHeader, BoxError, SIGNATURE_HEADER};
 use http::{header::DATE, HeaderValue, Method};
 use miette::Diagnostic;
 use scoped_futures::ScopedFutureWrapper;
-use std::{future::Future, time::SystemTime};
+use std::future::Future;
 use thiserror::Error;
 use tracing::{debug, instrument};
 
@@ -74,7 +74,7 @@ pub async fn sign<B>(
 ) -> Result<http::Request<B>, Error> {
     // First, set/overwrite the `Date` header
     let date_header_value =
-        HeaderValue::from_str(&httpdate::fmt_http_date(SystemTime::now())).unwrap();
+        HeaderValue::from_str(&httpdate::fmt_http_date(tick_tock_mock::now())).unwrap();
     req.headers_mut().insert(DATE, date_header_value);
 
     let headers = match *req.method() {

--- a/lib/http-signatures/src/cavage/safety_check.rs
+++ b/lib/http-signatures/src/cavage/safety_check.rs
@@ -87,13 +87,13 @@ where
     }
 
     // Move all of the timestamps a minute into the future to compensate for our local clock maybe lagging behind a bit
-    let now = SystemTime::now() + CLOCK_SKEW_ADJUSTMENT;
+    let now = tick_tock_mock::now() + CLOCK_SKEW_ADJUSTMENT;
     let signature_valid_duration = if let Some(expires) = signature_header.expires {
         let expiration_timestamp =
             SystemTime::UNIX_EPOCH + Duration::from_secs(expires) + CLOCK_SKEW_ADJUSTMENT;
 
         min(
-            expiration_timestamp.duration_since(SystemTime::now())?,
+            expiration_timestamp.duration_since(tick_tock_mock::now())?,
             MAX_ACCEPTED_SIGNATURE_AGE,
         )
     } else {

--- a/lib/tick-tock-mock/Cargo.toml
+++ b/lib/tick-tock-mock/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "tick-tock-mock"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+license = "MIT OR Apache-2.0"
+
+[[bench]]
+name = "simple_now"
+harness = false
+
+[dependencies]
+arc-swap = "1.7.0"
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+criterion = "0.5.1"

--- a/lib/tick-tock-mock/Cargo.toml
+++ b/lib/tick-tock-mock/Cargo.toml
@@ -11,8 +11,8 @@ harness = false
 
 [dependencies]
 
-[lints]
-workspace = true
-
 [dev-dependencies]
 criterion = "0.5.1"
+
+[lints]
+workspace = true

--- a/lib/tick-tock-mock/Cargo.toml
+++ b/lib/tick-tock-mock/Cargo.toml
@@ -10,7 +10,6 @@ name = "simple_now"
 harness = false
 
 [dependencies]
-arc-swap = "1.7.0"
 
 [lints]
 workspace = true

--- a/lib/tick-tock-mock/LICENSE-APACHE-2.0
+++ b/lib/tick-tock-mock/LICENSE-APACHE-2.0
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE-2.0

--- a/lib/tick-tock-mock/LICENSE-MIT
+++ b/lib/tick-tock-mock/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/lib/tick-tock-mock/README.md
+++ b/lib/tick-tock-mock/README.md
@@ -1,0 +1,5 @@
+# tick-tock-mock
+
+![SM64 Tick Tock Clock](https://mario.wiki.gallery/images/6/67/SM64_TickTockClock.png)
+
+Small time mocking library over `std::time::SystemTime`

--- a/lib/tick-tock-mock/benches/simple_now.rs
+++ b/lib/tick-tock-mock/benches/simple_now.rs
@@ -1,0 +1,33 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::{
+    hint::black_box,
+    time::{Duration, SystemTime},
+};
+use tick_tock_mock::{Clock, DeltaDirection};
+
+fn simple_now_mock(c: &mut Criterion) {
+    let clock = Clock::new();
+    c.bench_function("simple_now_mock", |b| {
+        b.iter(|| black_box(clock.now()));
+    });
+
+    c.bench_function("simple_now_mock_tl", |b| {
+        b.iter(|| black_box(tick_tock_mock::now()));
+    });
+
+    let (clock, mock) = Clock::mockable();
+    mock.adjust(DeltaDirection::Add, Duration::from_secs(1));
+
+    c.bench_function("simple_now_mock_adjust", |b| {
+        b.iter(|| black_box(clock.now()));
+    });
+}
+
+fn simple_now_std(c: &mut Criterion) {
+    c.bench_function("simple_now_std", |b| {
+        b.iter(|| black_box(SystemTime::now()));
+    });
+}
+
+criterion_group!(simple_now, simple_now_mock, simple_now_std);
+criterion_main!(simple_now);

--- a/lib/tick-tock-mock/src/lib.rs
+++ b/lib/tick-tock-mock/src/lib.rs
@@ -1,0 +1,155 @@
+#![doc = include_str!("../README.md")]
+#![deny(missing_docs)]
+
+use arc_swap::ArcSwap;
+use std::{
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
+    time::{Duration, SystemTime},
+};
+
+thread_local! {
+    /// Thread-local clock
+    ///
+    /// Defaults to a default [`Clock`], not to a `None` since clocks are cheap to instantiate
+    static THREAD_CLOCK: ArcSwap<Clock> = ArcSwap::new(Arc::new(Clock::default()));
+}
+
+/// Duration the delta should be adjusted in
+#[derive(Clone, Copy, PartialEq)]
+pub enum DeltaDirection {
+    /// Add to the delta
+    Add,
+
+    /// Subtract from the delta
+    Sub,
+}
+
+/// Handle to adjust the delta of the clock
+#[derive(Clone)]
+pub struct MockHandle {
+    delta: Arc<AtomicI64>,
+}
+
+impl MockHandle {
+    /// Adjust the delta by the duration in the direction specified
+    pub fn adjust(&self, direction: DeltaDirection, delta: Duration) {
+        let mut delta = delta.as_nanos() as i64;
+        if direction == DeltaDirection::Sub {
+            delta = -delta;
+        }
+
+        self.delta.fetch_add(delta, Ordering::AcqRel);
+    }
+
+    /// Set the delta to the absolute value
+    pub fn set_delta(&self, delta: i64) {
+        self.delta.store(delta, Ordering::Release);
+    }
+}
+
+/// Guard which will reset the thread-local upon drop
+pub struct ClockGuard {
+    old_clock: Arc<Clock>,
+}
+
+impl Drop for ClockGuard {
+    fn drop(&mut self) {
+        THREAD_CLOCK.with(|clock| clock.store(Arc::clone(&self.old_clock)));
+    }
+}
+
+/// Clock with an optional adjustable delta
+#[derive(Clone, Default)]
+pub struct Clock {
+    delta: Option<Arc<AtomicI64>>,
+}
+
+impl Clock {
+    /// Construct a new clock without an internal delta
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Construct a mockable clock
+    ///
+    /// This clock returns a handle which you can use to adjust the delta
+    #[must_use]
+    pub fn mockable() -> (Self, MockHandle) {
+        let delta = Arc::new(AtomicI64::default());
+
+        let mock_handle = MockHandle {
+            delta: Arc::clone(&delta),
+        };
+        let clock = Self { delta: Some(delta) };
+
+        (clock, mock_handle)
+    }
+
+    /// Enter a context where this clock is installed into the thread-local context
+    ///
+    /// As long as the guard is kept live, the [`now`] function will read the time of this clock
+    #[must_use]
+    pub fn enter(&self) -> ClockGuard {
+        let old_clock = THREAD_CLOCK.with(|clock| clock.swap(Arc::new(self.clone())));
+        ClockGuard { old_clock }
+    }
+
+    /// Read the current time from the system clock and apply the delta
+    #[must_use]
+    pub fn now(&self) -> SystemTime {
+        let mut now = SystemTime::now();
+
+        if let Some(ref delta) = self.delta {
+            let ns_delta = delta.load(Ordering::Acquire);
+            if ns_delta.is_positive() {
+                now += Duration::from_nanos(ns_delta as u64);
+            } else {
+                now -= Duration::from_nanos(ns_delta.unsigned_abs());
+            }
+        }
+
+        now
+    }
+}
+
+/// Read the current time from the thread-local clock
+#[must_use]
+pub fn now() -> SystemTime {
+    THREAD_CLOCK.with(|clock| clock.load().now())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{Clock, DeltaDirection};
+    use std::time::Duration;
+
+    #[test]
+    fn can_forward() {
+        let (clock, mock) = Clock::mockable();
+        let _clock_guard = clock.enter();
+
+        let now = crate::now();
+        mock.adjust(DeltaDirection::Add, Duration::from_secs(1));
+        let after = crate::now();
+
+        let delta = after.duration_since(now).unwrap();
+        assert_eq!(delta.as_secs_f32().round() as u8, 1);
+    }
+
+    #[test]
+    fn can_rewind() {
+        let (clock, mock) = Clock::mockable();
+        let _clock_guard = clock.enter();
+
+        let now = crate::now();
+        mock.adjust(DeltaDirection::Sub, Duration::from_secs(1));
+        let after = crate::now();
+
+        let delta = now.duration_since(after).unwrap();
+        assert_eq!(delta.as_secs_f32().round() as u8, 1);
+    }
+}


### PR DESCRIPTION
This PR adds a new crate (`tick-tock-mock`), allowing for intercepting and mocking `SystemTime::now()` and uses the crate throughout `http-signatures`.

It also adds a new test which is a proof-of-concept.  
In the future we can use this to rewind the time to let the tests for RFC test vectors succeed.