### PR TITLE
fix(docs): fix config example for max-upload-size.

### DIFF
--- a/docs/src/running/basic-configuration.md
+++ b/docs/src/running/basic-configuration.md
@@ -40,7 +40,7 @@ type = "in-process"
 
 [server]
 frontend-dir = "./kitsune-fe/dist"
-max-upload-size = 20242880          # 5MB
+max-upload-size = "5MiB"
 media-proxy-enabled = false
 port = 5000
 request-timeout-secs = 60


### PR DESCRIPTION
The format was changed to parse sizes instead of integer number of bytes.