### PR TITLE
Add tests for the keeper

### DIFF
--- a/lib/athena/tests/keeper.rs
+++ b/lib/athena/tests/keeper.rs
@@ -1,0 +1,34 @@
+use athena::{Keepable, KeeperOfTheSecrets};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+struct CustomStruct {
+    number: u32,
+}
+
+#[typetag::serde]
+impl Keepable for CustomStruct {}
+
+#[test]
+fn roundtrip() {
+    let original = CustomStruct { number: 1312 };
+
+    let keeper = KeeperOfTheSecrets::new(original.clone());
+    let value = keeper.get::<CustomStruct>().unwrap();
+
+    assert_eq!(original, *value);
+}
+
+#[test]
+fn downcasting_into_other() {
+    let keeper = KeeperOfTheSecrets::new(CustomStruct { number: 161 });
+
+    assert_eq!(
+        keeper.get::<CustomStruct>(),
+        Some(CustomStruct { number: 161 }).as_ref()
+    );
+
+    assert!(keeper.get::<()>().is_none());
+    assert!(keeper.get::<u32>().is_none());
+    assert!(keeper.get::<String>().is_none());
+}

--- a/lib/athena/tests/keeper.rs
+++ b/lib/athena/tests/keeper.rs
@@ -21,12 +21,10 @@ fn roundtrip() {
 
 #[test]
 fn downcasting_into_other() {
-    let keeper = KeeperOfTheSecrets::new(CustomStruct { number: 161 });
+    let value = CustomStruct { number: 161 };
+    let keeper = KeeperOfTheSecrets::new(value.clone());
 
-    assert_eq!(
-        keeper.get::<CustomStruct>(),
-        Some(CustomStruct { number: 161 }).as_ref()
-    );
+    assert_eq!(keeper.get::<CustomStruct>(), Some(&value));
 
     assert!(keeper.get::<()>().is_none());
     assert!(keeper.get::<u32>().is_none());


### PR DESCRIPTION
Since this is kinda vital to the job scheduler and a section where we use unsafe code, I feel like we should test this better.