### PR TITLE
Move router creation into one file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,7 +1551,7 @@ dependencies = [
  "http",
  "pin-project-lite",
  "rand 0.8.5",
- "tower 0.5.0",
+ "tower 0.5.1",
  "triomphe",
  "zeroize",
 ]
@@ -2007,11 +2007,11 @@ dependencies = [
 
 [[package]]
 name = "enum-as-inner"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.77",
@@ -2961,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3472,7 +3472,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-util",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tower-http",
  "tower-http-digest",
  "tower-stop-using-brave",
@@ -3523,7 +3523,7 @@ dependencies = [
  "sonic-rs",
  "speedy-uuid",
  "tokio",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
  "triomphe",
  "typed-builder",
@@ -3760,7 +3760,7 @@ dependencies = [
  "simdutf8",
  "sonic-rs",
  "tokio",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tower-http",
 ]
 
@@ -4002,7 +4002,7 @@ dependencies = [
  "speedy-uuid",
  "tempfile",
  "tokio",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
  "triomphe",
  "typed-builder",
@@ -4137,7 +4137,7 @@ dependencies = [
  "pretty_assertions",
  "sonic-rs",
  "tokio",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tracing",
  "triomphe",
  "urlencoding",
@@ -6068,9 +6068,9 @@ checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7291,9 +7291,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b837f86b25d7c0d7988f00a54e74739be6477f2aac6201b8f429a7569991b7"
+checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -7348,7 +7348,7 @@ dependencies = [
  "pin-project-lite",
  "sha2",
  "subtle",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -7374,7 +7374,7 @@ dependencies = [
  "futures-test",
  "http",
  "regex",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
 ]
@@ -7387,7 +7387,7 @@ dependencies = [
  "http",
  "itertools 0.13.0",
  "pin-project-lite",
- "tower 0.5.0",
+ "tower 0.5.1",
  "tower-layer",
  "tower-service",
  "triomphe",
@@ -7885,7 +7885,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
 dependencies = [
  "leb128",
- "wasmparser 0.215.0",
 ]
 
 [[package]]
@@ -7895,13 +7894,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c23aebea22c8a75833ae08ed31ccc020835b12a41999e58c31464271b94a88"
 dependencies = [
  "leb128",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6bb07c5576b608f7a2a9baa2294c1a3584a249965d695a9814a496cb6d232f"
+checksum = "47c8154d703a6b0e45acf6bd172fa002fc3c7058a9f7615e517220aeca27c638"
 dependencies = [
  "anyhow",
  "indexmap 2.5.0",
@@ -7909,8 +7909,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.215.0",
- "wasmparser 0.215.0",
+ "wasm-encoder 0.216.0",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]
@@ -8022,7 +8022,7 @@ dependencies = [
  "syn 2.0.77",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser",
+ "wit-parser 0.215.0",
 ]
 
 [[package]]
@@ -8194,7 +8194,7 @@ dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap 2.5.0",
- "wit-parser",
+ "wit-parser 0.215.0",
 ]
 
 [[package]]
@@ -8527,9 +8527,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4bac478334a647374ff24a74b66737a4cb586dc8288bc3080a93252cd1105c"
+checksum = "88145227b8174b979eb2795ae1ea222ba7dad24a2bdfbed2ff9dc958119e9547"
 dependencies = [
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
@@ -8537,29 +8537,29 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7e3df01cd43cfa1cb52602e4fc05cb2b62217655f6705639b6953eb0a3fed2"
+checksum = "175a2edcf18d1efd1412cb560b895dd09903f4fe73c3a597fbb0075ad86a03e8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2de7a3b06b9725d129b5cbd1beca968feed919c433305a23da46843185ecdd6"
+checksum = "b907dbaa3afaccdf1c89c4197b0f376c867009fae9c6092937f308cfc450a129"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a767d1a8eb4e908bfc53febc48b87ada545703b16fe0148ee7736a29a01417"
+checksum = "5a1c119b99edc4fc44ebfd3c461337b18f9db35388358344750b4fcfc788986b"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -8573,9 +8573,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b185c342d0d27bd83d4080f5a66cf3b4f247fa49d679bceb66e11cc7eb58b99"
+checksum = "5c2f86e4fa1b2b4034670fd57fabe7365210fc6e33c522f4f34f582a0dbe95ca"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -8588,9 +8588,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.215.0"
+version = "0.216.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f725e3885fc5890648be5c5cbc1353b755dc932aa5f1aa7de968b912a3280743"
+checksum = "7e2ca3ece38ea2447a9069b43074ba73d96dde1944cba276c54e41371745f9dc"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -8599,10 +8599,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.215.0",
+ "wasm-encoder 0.216.0",
  "wasm-metadata",
- "wasmparser 0.215.0",
- "wit-parser",
+ "wasmparser 0.216.0",
+ "wit-parser 0.216.0",
 ]
 
 [[package]]
@@ -8621,6 +8621,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.216.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d108165c1167a4ccc8a803dcf5c28e0a51d6739fd228cc7adce768632c764c"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.5.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.216.0",
 ]
 
 [[package]]

--- a/crates/kitsune-activitypub/Cargo.toml
+++ b/crates/kitsune-activitypub/Cargo.toml
@@ -51,7 +51,7 @@ kitsune-test = { workspace = true }
 kitsune-webfinger = { workspace = true }
 pretty_assertions = "1.4.0"
 tokio = { version = "1.40.0", features = ["macros"] }
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [lints]
 workspace = true

--- a/crates/kitsune-http-client/Cargo.toml
+++ b/crates/kitsune-http-client/Cargo.toml
@@ -15,7 +15,7 @@ http-body = "1.0.1"
 http-body-util = "0.1.2"
 http-signatures = { workspace = true }
 hyper = "1.4.1"
-hyper-util = { version = "0.1.7", features = [
+hyper-util = { version = "0.1.8", features = [
     "client-legacy",
     "http1",
     "http2",
@@ -34,7 +34,7 @@ pin-project = "1.1.5"
 serde = "1.0.210"
 simdutf8 = { workspace = true }
 sonic-rs = { workspace = true }
-tower = { version = "0.5.0", features = ["util"] }
+tower = { version = "0.5.1", features = ["util"] }
 tower-http = { version = "0.5.2", features = [
     # Explicitly exclude `zstd`
     # It's not widely adopted and takes a long time to build

--- a/crates/kitsune-service/Cargo.toml
+++ b/crates/kitsune-service/Cargo.toml
@@ -67,7 +67,7 @@ kitsune-test = { workspace = true }
 kitsune-webfinger = { workspace = true }
 pretty_assertions = "1.4.0"
 tempfile = "3.12.0"
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [lints]
 workspace = true

--- a/crates/kitsune-wasm-mrf/example-mrf/Cargo.toml
+++ b/crates/kitsune-wasm-mrf/example-mrf/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rand = "0.8.5"
-wit-bindgen = "0.30.0"
+wit-bindgen = "0.31.0"
 
 [lints]
 workspace = true

--- a/crates/kitsune-webfinger/Cargo.toml
+++ b/crates/kitsune-webfinger/Cargo.toml
@@ -26,7 +26,7 @@ hyper = "1.4.1"
 pretty_assertions = "1.4.0"
 sonic-rs = { workspace = true }
 tokio = { version = "1.40.0", features = ["macros"] }
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [lints]
 workspace = true

--- a/kitsune/Cargo.toml
+++ b/kitsune/Cargo.toml
@@ -85,7 +85,7 @@ tempfile = "3.12.0"
 time = "0.3.36"
 tokio = { version = "1.40.0", features = ["full"] }
 tokio-util = { version = "0.7.12", features = ["io"] }
-tower = { version = "0.5.0", features = ["util"] }
+tower = { version = "0.5.1", features = ["util"] }
 tower-stop-using-brave = { workspace = true }
 tower-x-clacks-overhead = { workspace = true }
 tower-http = { version = "0.5.2", features = [

--- a/kitsune/src/http/handler/confirm_account.rs
+++ b/kitsune/src/http/handler/confirm_account.rs
@@ -2,19 +2,18 @@ use crate::state::Zustand;
 use axum::{
     debug_handler,
     extract::{Path, State},
-    routing, Router,
 };
 use kitsune_email::MailingService;
 use kitsune_error::Result;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-struct GetPath {
+pub struct GetPath {
     confirmation_token: String,
 }
 
 #[debug_handler(state = Zustand)]
-async fn get(
+pub async fn get(
     State(mailing_service): State<MailingService>,
     Path(path): Path<GetPath>,
 ) -> Result<&'static str> {
@@ -23,8 +22,4 @@ async fn get(
         .await?;
 
     Ok("Account confirmed successfully! You can log in now")
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/:confirmation_token", routing::get(get))
 }

--- a/kitsune/src/http/handler/custom_emojis.rs
+++ b/kitsune/src/http/handler/custom_emojis.rs
@@ -1,5 +1,5 @@
 use crate::{http::responder::ActivityPubJson, state::Zustand};
-use axum::{debug_handler, extract::Path, extract::State, routing, Router};
+use axum::{debug_handler, extract::Path, extract::State};
 use kitsune_activitypub::mapping::IntoObject;
 use kitsune_error::Result;
 use kitsune_service::custom_emoji::CustomEmojiService;
@@ -7,7 +7,7 @@ use kitsune_type::ap::emoji::Emoji;
 use speedy_uuid::Uuid;
 
 #[debug_handler(state = Zustand)]
-async fn get(
+pub async fn get(
     State(state): State<Zustand>,
     State(emoji_service): State<CustomEmojiService>,
     Path(id): Path<Uuid>,
@@ -17,8 +17,4 @@ async fn get(
     Ok(ActivityPubJson(
         custom_emoji.into_object(state.ap_state()).await?,
     ))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/:id", routing::get(get))
 }

--- a/kitsune/src/http/handler/mastodon/api/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/mod.rs
@@ -1,11 +1,2 @@
-use crate::state::Zustand;
-use axum::Router;
-
 pub mod v1;
 pub mod v2;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .nest("/v1", v1::routes())
-        .nest("/v2", v2::routes())
-}

--- a/kitsune/src/http/handler/mastodon/api/v1/accounts/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/accounts/mod.rs
@@ -1,7 +1,6 @@
-use crate::state::Zustand;
 use axum::{
     extract::{Path, State},
-    routing, Json, Router,
+    Json,
 };
 use kitsune_error::{kitsune_error, ErrorType, Result};
 use kitsune_mastodon::MastodonMapper;
@@ -17,7 +16,7 @@ pub mod unfollow;
 pub mod update_credentials;
 pub mod verify_credentials;
 
-async fn get(
+pub async fn get(
     State(account_service): State<AccountService>,
     State(mastodon_mapper): State<MastodonMapper>,
     Path(id): Path<Uuid>,
@@ -28,19 +27,4 @@ async fn get(
         .ok_or_else(|| kitsune_error!(type = ErrorType::NotFound, "account not found"))?;
 
     Ok(Json(mastodon_mapper.map(account).await?))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/:id", routing::get(get))
-        .route("/:id/follow", routing::post(follow::post))
-        .route("/:id/statuses", routing::get(statuses::get))
-        .route("/:id/unfollow", routing::post(unfollow::post))
-        .route("/lookup", routing::get(lookup::get))
-        .route("/relationships", routing::get(relationships::get))
-        .route(
-            "/update_credentials",
-            routing::patch(update_credentials::patch),
-        )
-        .route("/verify_credentials", routing::get(verify_credentials::get))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/apps.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/apps.rs
@@ -1,9 +1,8 @@
-use crate::state::Zustand;
 use crate::{
     http::extractor::AgnosticForm,
     oauth2::{CreateApp, OAuth2Service},
 };
-use axum::{extract::State, routing, Json, Router};
+use axum::{extract::State, Json};
 use kitsune_error::Result;
 use kitsune_type::mastodon::App;
 use serde::Deserialize;
@@ -14,7 +13,7 @@ pub struct AppForm {
     redirect_uris: String,
 }
 
-async fn post(
+pub async fn post(
     State(oauth2): State<OAuth2Service>,
     AgnosticForm(form): AgnosticForm<AppForm>,
 ) -> Result<Json<App>> {
@@ -31,8 +30,4 @@ async fn post(
         client_id: application.id,
         client_secret: application.secret,
     }))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::post(post))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/custom_emojis.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/custom_emojis.rs
@@ -1,5 +1,5 @@
-use crate::{http::extractor::MastodonAuthExtractor, state::Zustand};
-use axum::{debug_handler, extract::State, routing, Json, Router};
+use crate::http::extractor::MastodonAuthExtractor;
+use axum::{debug_handler, extract::State, Json};
 use futures_util::{TryFutureExt, TryStreamExt};
 use kitsune_error::{Error, Result};
 use kitsune_mastodon::MastodonMapper;
@@ -25,8 +25,4 @@ pub async fn get(
         .await?;
 
     Ok(Json(custom_emojis))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::get(get))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/follow_requests/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/follow_requests/mod.rs
@@ -4,12 +4,11 @@ use crate::{
         extractor::{AuthExtractor, MastodonAuthExtractor},
         pagination::{LinkHeader, PaginatedJsonResponse},
     },
-    state::Zustand,
 };
 use axum::{
     debug_handler,
     extract::{OriginalUri, State},
-    routing, Json, Router,
+    Json,
 };
 use axum_extra::extract::Query;
 use futures_util::{TryFutureExt, TryStreamExt};
@@ -65,11 +64,4 @@ pub async fn get(
     );
 
     Ok((link_header, Json(accounts)))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/", routing::get(get))
-        .route("/:id/authorize", routing::post(accept::post))
-        .route("/:id/reject", routing::post(reject::post))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/instance.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/instance.rs
@@ -1,5 +1,4 @@
-use crate::state::Zustand;
-use axum::{extract::State, routing, Json, Router};
+use axum::{extract::State, Json};
 use kitsune_core::consts::VERSION;
 use kitsune_error::Result;
 use kitsune_service::instance::InstanceService;
@@ -9,7 +8,7 @@ use kitsune_type::mastodon::{
 };
 use kitsune_url::UrlService;
 
-async fn get(
+pub async fn get(
     State(instance_service): State<InstanceService>,
     State(url_service): State<UrlService>,
 ) -> Result<Json<Instance>> {
@@ -34,8 +33,4 @@ async fn get(
             domain_count,
         },
     }))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::get(get))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/media.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/media.rs
@@ -8,7 +8,7 @@ use crate::{
 use axum::{
     debug_handler,
     extract::{Multipart, Path, State},
-    routing, Json, Router,
+    Json,
 };
 use futures_util::TryFutureExt;
 use kitsune_error::{kitsune_error, Error, ErrorType, Result};
@@ -90,10 +90,4 @@ pub async fn put(
         .and_then(|model| mastodon_mapper.map(model).map_err(Error::from))
         .map_ok(Json)
         .await
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/", routing::post(post))
-        .route("/:id", routing::get(get).put(put))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/mod.rs
@@ -1,6 +1,3 @@
-use crate::state::Zustand;
-use axum::Router;
-
 pub mod accounts;
 pub mod apps;
 pub mod custom_emojis;
@@ -10,16 +7,3 @@ pub mod media;
 pub mod notifications;
 pub mod statuses;
 pub mod timelines;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .nest("/apps", apps::routes())
-        .nest("/accounts", accounts::routes())
-        .nest("/custom_emojis", custom_emojis::routes())
-        .nest("/follow_requests", follow_requests::routes())
-        .nest("/instance", instance::routes())
-        .nest("/media", media::routes())
-        .nest("/notifications", notifications::routes())
-        .nest("/statuses", statuses::routes())
-        .nest("/timelines", timelines::routes())
-}

--- a/kitsune/src/http/handler/mastodon/api/v1/notifications/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/notifications/mod.rs
@@ -9,7 +9,7 @@ use crate::{
 use axum::{
     debug_handler,
     extract::{OriginalUri, Path, State},
-    routing, Json, Router,
+    Json,
 };
 use axum_extra::extract::Query;
 use futures_util::{TryFutureExt, TryStreamExt};
@@ -101,12 +101,4 @@ pub async fn get_by_id(
         .ok_or_else(|| kitsune_error!(type = ErrorType::NotFound, "notification not found"))?;
 
     Ok(Json(mastodon_mapper.map(notification).await?))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/", routing::get(get))
-        .route("/:id", routing::get(get_by_id))
-        .route("/:id/dismiss", routing::post(dismiss::post))
-        .route("/clear", routing::post(clear::post))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/statuses/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/statuses/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use axum::{
     debug_handler,
     extract::{Path, State},
-    routing, Json, Router,
+    Json,
 };
 use http::StatusCode;
 use kitsune_error::Result;
@@ -50,7 +50,7 @@ pub struct UpdateForm {
 }
 
 #[debug_handler(state = Zustand)]
-async fn delete(
+pub async fn delete(
     State(post): State<PostService>,
     AuthExtractor(user_data): MastodonAuthExtractor,
     Path(id): Path<Uuid>,
@@ -67,7 +67,7 @@ async fn delete(
 }
 
 #[debug_handler(state = Zustand)]
-async fn get(
+pub async fn get(
     State(mastodon_mapper): State<MastodonMapper>,
     State(post): State<PostService>,
     user_data: Option<MastodonAuthExtractor>,
@@ -86,7 +86,7 @@ async fn get(
 }
 
 #[debug_handler(state = Zustand)]
-async fn post(
+pub async fn post(
     State(mastodon_mapper): State<MastodonMapper>,
     State(post_service): State<PostService>,
     AuthExtractor(user_data): MastodonAuthExtractor,
@@ -108,7 +108,7 @@ async fn post(
 }
 
 #[debug_handler(state = Zustand)]
-async fn put(
+pub async fn put(
     State(mastodon_mapper): State<MastodonMapper>,
     State(post): State<PostService>,
     AuthExtractor(user_data): MastodonAuthExtractor,
@@ -127,18 +127,4 @@ async fn put(
     let status = mastodon_mapper.map(post.update(update_post).await?).await?;
 
     Ok(Json(status))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/", routing::post(post))
-        .route("/:id", routing::get(get).delete(delete).put(put))
-        .route("/:id/context", routing::get(context::get))
-        .route("/:id/favourite", routing::post(favourite::post))
-        .route("/:id/favourited_by", routing::get(favourited_by::get))
-        .route("/:id/reblog", routing::post(reblog::post))
-        .route("/:id/reblogged_by", routing::get(reblogged_by::get))
-        .route("/:id/source", routing::get(source::get))
-        .route("/:id/unfavourite", routing::post(unfavourite::post))
-        .route("/:id/unreblog", routing::post(unreblog::post))
 }

--- a/kitsune/src/http/handler/mastodon/api/v1/timelines/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v1/timelines/mod.rs
@@ -1,11 +1,2 @@
-use crate::state::Zustand;
-use axum::{routing, Router};
-
 pub mod home;
 pub mod public;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/home", routing::get(home::get))
-        .route("/public", routing::get(public::get))
-}

--- a/kitsune/src/http/handler/mastodon/api/v2/media.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/media.rs
@@ -1,9 +1,0 @@
-use crate::http::handler::mastodon::api::v1::media::{get, post, put};
-use crate::state::Zustand;
-use axum::{routing, Router};
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/", routing::post(post))
-        .route("/:id", routing::get(get).put(put))
-}

--- a/kitsune/src/http/handler/mastodon/api/v2/mod.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/mod.rs
@@ -1,11 +1,1 @@
-use crate::state::Zustand;
-use axum::Router;
-
-pub mod media;
 pub mod search;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .nest("/media", media::routes())
-        .nest("/search", search::routes())
-}

--- a/kitsune/src/http/handler/mastodon/api/v2/search.rs
+++ b/kitsune/src/http/handler/mastodon/api/v2/search.rs
@@ -3,7 +3,7 @@ use crate::{
     http::extractor::{AuthExtractor, MastodonAuthExtractor},
     state::Zustand,
 };
-use axum::{debug_handler, extract::State, routing, Json, Router};
+use axum::{debug_handler, extract::State, Json};
 use axum_extra::{either::Either, extract::Query};
 use http::StatusCode;
 use kitsune_core::consts::API_MAX_LIMIT;
@@ -25,7 +25,7 @@ pub enum SearchType {
 }
 
 #[derive(Deserialize)]
-struct SearchQuery {
+pub struct SearchQuery {
     #[serde(rename = "q")]
     query: String,
     r#type: Option<SearchType>,
@@ -40,7 +40,7 @@ struct SearchQuery {
 }
 
 #[debug_handler(state = Zustand)]
-async fn get(
+pub async fn get(
     State(search_service): State<SearchService>,
     State(mastodon_mapper): State<MastodonMapper>,
     AuthExtractor(user_data): MastodonAuthExtractor,
@@ -81,8 +81,4 @@ async fn get(
     }
 
     Ok(Either::E1(Json(search_result)))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::get(get))
 }

--- a/kitsune/src/http/handler/mastodon/mod.rs
+++ b/kitsune/src/http/handler/mastodon/mod.rs
@@ -1,8 +1,1 @@
-use crate::state::Zustand;
-use axum::Router;
-
 pub mod api;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().nest("/api", api::routes())
-}

--- a/kitsune/src/http/handler/media.rs
+++ b/kitsune/src/http/handler/media.rs
@@ -1,16 +1,14 @@
-use crate::state::Zustand;
 use axum::{
     body::Body,
     extract::{Path, State},
     response::{IntoResponse, Response},
-    routing, Router,
 };
 use http::header::CONTENT_TYPE;
 use kitsune_error::Result;
 use kitsune_service::attachment::AttachmentService;
 use speedy_uuid::Uuid;
 
-async fn get(
+pub async fn get(
     State(attachment_service): State<AttachmentService>,
     Path(id): Path<Uuid>,
 ) -> Result<Response> {
@@ -22,8 +20,4 @@ async fn get(
         Body::from_stream(stream),
     )
         .into_response())
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/:id", routing::get(get))
 }

--- a/kitsune/src/http/handler/nodeinfo/mod.rs
+++ b/kitsune/src/http/handler/nodeinfo/mod.rs
@@ -1,8 +1,1 @@
-use crate::state::Zustand;
-use axum::Router;
-
 pub mod two_one;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().nest("/2.1", two_one::routes())
-}

--- a/kitsune/src/http/handler/nodeinfo/two_one.rs
+++ b/kitsune/src/http/handler/nodeinfo/two_one.rs
@@ -1,5 +1,4 @@
-use crate::state::Zustand;
-use axum::{debug_handler, extract::State, routing, Json, Router};
+use axum::{debug_handler, extract::State, Json};
 use diesel::{ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use kitsune_core::consts::VERSION;
@@ -16,7 +15,7 @@ use kitsune_util::try_join;
 use sonic_rs::Value;
 
 #[debug_handler(state = crate::state::Zustand)]
-async fn get(
+pub async fn get(
     State(db_pool): State<PgPool>,
     State(user_service): State<UserService>,
 ) -> Result<Json<TwoOne>> {
@@ -55,8 +54,4 @@ async fn get(
         },
         metadata: Value::new(),
     }))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::get(get))
 }

--- a/kitsune/src/http/handler/oauth/mod.rs
+++ b/kitsune/src/http/handler/oauth/mod.rs
@@ -2,17 +2,5 @@
 //! Standard-compliant OAuth2 flows
 //!
 
-use crate::state::Zustand;
-use axum::{
-    routing::{get, post},
-    Router,
-};
-
 pub mod authorize;
 pub mod token;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/authorize", get(authorize::get).post(authorize::post))
-        .route("/token", post(token::post))
-}

--- a/kitsune/src/http/handler/oidc/mod.rs
+++ b/kitsune/src/http/handler/oidc/mod.rs
@@ -1,8 +1,1 @@
-use crate::state::Zustand;
-use axum::{routing, Router};
-
 pub mod callback;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/callback", routing::get(callback::get))
-}

--- a/kitsune/src/http/handler/posts/mod.rs
+++ b/kitsune/src/http/handler/posts/mod.rs
@@ -1,25 +1,19 @@
 use crate::{http::responder::ActivityPubJson, state::Zustand};
-use axum::{debug_handler, extract::Path, extract::State, routing, Router};
+use axum::{debug_handler, extract::Path, extract::State};
 use kitsune_activitypub::mapping::IntoObject;
 use kitsune_error::Result;
 use kitsune_service::post::PostService;
 use kitsune_type::ap::Object;
 use speedy_uuid::Uuid;
 
-mod activity;
+pub mod activity;
 
 #[debug_handler(state = Zustand)]
-async fn get(
+pub async fn get(
     State(state): State<Zustand>,
     State(post): State<PostService>,
     Path(id): Path<Uuid>,
 ) -> Result<ActivityPubJson<Object>> {
     let post = post.get_by_id(id, None).await?;
     Ok(ActivityPubJson(post.into_object(state.ap_state()).await?))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/:id", routing::get(get))
-        .route("/:id/activity", routing::get(activity::get))
 }

--- a/kitsune/src/http/handler/public.rs
+++ b/kitsune/src/http/handler/public.rs
@@ -1,4 +1,4 @@
-use axum::{extract::Path, routing, Router};
+use axum::extract::Path;
 use axum_extra::{either::Either, TypedHeader};
 use headers::ContentType;
 use http::StatusCode;
@@ -11,7 +11,7 @@ use std::borrow::Cow;
 struct AssetsDir;
 
 #[allow(clippy::unused_async)]
-async fn get(
+pub async fn get(
     Path(path): Path<String>,
 ) -> Either<(TypedHeader<ContentType>, Cow<'static, [u8]>), StatusCode> {
     let Some(file) = AssetsDir::get(&path) else {
@@ -20,11 +20,4 @@ async fn get(
     let mime_type = mime_guess::from_path(&path).first_or_octet_stream();
 
     Either::E1((TypedHeader(ContentType::from(mime_type)), file.data))
-}
-
-pub fn routes<T>() -> Router<T>
-where
-    T: Clone + Send + Sync + 'static,
-{
-    Router::new().route("/*path", routing::get(get))
 }

--- a/kitsune/src/http/handler/users/mod.rs
+++ b/kitsune/src/http/handler/users/mod.rs
@@ -1,21 +1,17 @@
 use crate::{http::responder::ActivityPubJson, state::Zustand};
-use axum::{
-    extract::{Path, State},
-    routing, Router,
-};
+use axum::extract::{Path, State};
 use kitsune_activitypub::mapping::IntoObject;
 use kitsune_error::{kitsune_error, ErrorType, Result};
 use kitsune_service::account::AccountService;
 use kitsune_type::ap::actor::Actor;
 use speedy_uuid::Uuid;
-use tower_http_digest::VerifyDigestLayer;
 
-mod followers;
-mod following;
-mod inbox;
-mod outbox;
+pub mod followers;
+pub mod following;
+pub mod inbox;
+pub mod outbox;
 
-async fn get(
+pub async fn get(
     State(state): State<Zustand>,
     State(account_service): State<AccountService>,
     Path(account_id): Path<Uuid>,
@@ -28,16 +24,4 @@ async fn get(
     Ok(ActivityPubJson(
         account.into_object(state.ap_state()).await?,
     ))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .route("/:user_id", routing::get(get))
-        .route("/:user_id/followers", routing::get(followers::get))
-        .route("/:user_id/following", routing::get(following::get))
-        .route(
-            "/:user_id/inbox",
-            routing::post(inbox::post).layer(VerifyDigestLayer::default()),
-        )
-        .route("/:user_id/outbox", routing::get(outbox::get))
 }

--- a/kitsune/src/http/handler/well_known/mod.rs
+++ b/kitsune/src/http/handler/well_known/mod.rs
@@ -1,11 +1,2 @@
-use crate::state::Zustand;
-use axum::Router;
-
 pub mod nodeinfo;
 pub mod webfinger;
-
-pub fn routes() -> Router<Zustand> {
-    Router::new()
-        .nest("/nodeinfo", nodeinfo::routes())
-        .nest("/webfinger", webfinger::routes())
-}

--- a/kitsune/src/http/handler/well_known/nodeinfo.rs
+++ b/kitsune/src/http/handler/well_known/nodeinfo.rs
@@ -1,10 +1,9 @@
-use crate::state::Zustand;
-use axum::{extract::State, routing, Json, Router};
+use axum::{extract::State, Json};
 use kitsune_type::nodeinfo::well_known::{Link, WellKnown};
 use kitsune_url::UrlService;
 
 #[allow(clippy::unused_async)]
-async fn get(State(url_service): State<UrlService>) -> Json<WellKnown> {
+pub async fn get(State(url_service): State<UrlService>) -> Json<WellKnown> {
     let href = format!("{}/nodeinfo/2.1", url_service.base_url());
 
     Json(WellKnown {
@@ -13,8 +12,4 @@ async fn get(State(url_service): State<UrlService>) -> Json<WellKnown> {
             href,
         }],
     })
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::get(get))
 }

--- a/kitsune/src/http/handler/well_known/webfinger.rs
+++ b/kitsune/src/http/handler/well_known/webfinger.rs
@@ -1,7 +1,6 @@
-use crate::state::Zustand;
 use axum::{
     extract::{Query, State},
-    routing, Json, Router,
+    Json,
 };
 use axum_extra::either::Either;
 use http::StatusCode;
@@ -12,11 +11,11 @@ use kitsune_url::UrlService;
 use serde::Deserialize;
 
 #[derive(Deserialize)]
-struct WebfingerQuery {
+pub struct WebfingerQuery {
     resource: String,
 }
 
-async fn get(
+pub async fn get(
     State(account_service): State<AccountService>,
     State(url_service): State<UrlService>,
     Query(query): Query<WebfingerQuery>,
@@ -48,10 +47,6 @@ async fn get(
             href: Some(account_url),
         }],
     })))
-}
-
-pub fn routes() -> Router<Zustand> {
-    Router::new().route("/", routing::get(get))
 }
 
 #[cfg(test)]

--- a/kitsune/src/http/mod.rs
+++ b/kitsune/src/http/mod.rs
@@ -1,32 +1,20 @@
-use self::handler::{
-    confirm_account, custom_emojis, media, nodeinfo, oauth, posts, public, users, well_known,
-};
 use crate::state::Zustand;
 use axum::{
     body::HttpBody,
-    extract::DefaultBodyLimit,
     response::{Html, IntoResponse},
-    Router,
 };
 use bytes::Bytes;
-use color_eyre::eyre::{self, Context};
-use cursiv::CsrfLayer;
+use color_eyre::eyre;
 use http::{HeaderName, StatusCode};
 use http_body_util::Either;
 use kitsune_config::server;
-use std::{convert::Infallible, time::Duration};
+use std::convert::Infallible;
 use tokio::net::TcpListener;
 use tower::{BoxError, Service, ServiceExt};
 use tower_http::{
-    catch_panic::CatchPanicLayer,
-    cors::CorsLayer,
-    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
     services::{ServeDir, ServeFile},
-    timeout::TimeoutLayer,
     trace::{HttpMakeClassifier, MakeSpan, TraceLayer},
 };
-use tower_stop_using_brave::StopUsingBraveLayer;
-use tower_x_clacks_overhead::XClacksOverheadLayer;
 
 const FALLBACK_FALLBACK_INDEX: &str = include_str!("../../templates/fallback-fallback.html");
 
@@ -42,6 +30,7 @@ mod responder;
 mod util;
 
 pub mod extractor;
+pub mod router;
 
 #[inline]
 fn serve_frontend<B>(
@@ -93,73 +82,13 @@ fn trace_layer<B>() -> TraceLayer<HttpMakeClassifier, impl MakeSpan<B> + Clone> 
     })
 }
 
-pub fn create_router(
-    state: Zustand,
-    server_config: &server::Configuration,
-) -> eyre::Result<Router> {
-    let router = Router::new()
-        .nest("/confirm-account", confirm_account::routes())
-        .nest("/emojis", custom_emojis::routes())
-        .nest("/media", media::routes())
-        .nest("/nodeinfo", nodeinfo::routes())
-        .nest(
-            "/oauth",
-            oauth::routes().layer(axum::middleware::from_fn(middleware::json_to_urlencoded)),
-        )
-        .nest("/posts", posts::routes())
-        .nest("/users", users::routes())
-        .nest("/.well-known", well_known::routes())
-        .nest("/public", public::routes());
-
-    #[cfg(feature = "oidc")]
-    let router = router.nest("/oidc", handler::oidc::routes());
-
-    #[cfg(feature = "graphql-api")]
-    let router = router.merge(graphql::routes(state.clone()));
-
-    #[cfg(feature = "mastodon-api")]
-    let router = router.merge(handler::mastodon::routes());
-
-    let mut router = router.fallback_service(serve_frontend(server_config));
-
-    if !server_config.clacks_overhead.is_empty() {
-        let clacks_overhead_layer =
-            XClacksOverheadLayer::new(server_config.clacks_overhead.iter().map(AsRef::as_ref))
-                .wrap_err("Invalid clacks overhead values")?;
-
-        router = router.layer(clacks_overhead_layer);
-    }
-
-    if server_config.deny_brave_browsers {
-        router = router.layer(StopUsingBraveLayer::default());
-    }
-
-    Ok(router
-        .layer(CatchPanicLayer::new())
-        .layer(CorsLayer::permissive())
-        .layer(CsrfLayer::generate()) // TODO: Make this configurable instead of random
-        .layer(DefaultBodyLimit::max(
-            server_config.max_upload_size.to_bytes() as usize,
-        ))
-        .layer(TimeoutLayer::new(Duration::from_secs(
-            server_config.request_timeout_secs,
-        )))
-        .layer(trace_layer())
-        .layer(PropagateRequestIdLayer::new(X_REQUEST_ID.clone()))
-        .layer(SetRequestIdLayer::new(
-            X_REQUEST_ID.clone(),
-            MakeRequestUuid,
-        ))
-        .with_state(state))
-}
-
 #[instrument(skip_all, fields(port = %server_config.port))]
 pub async fn run(
     state: Zustand,
     server_config: server::Configuration,
     shutdown_signal: crate::signal::Receiver,
 ) -> eyre::Result<()> {
-    let router = create_router(state, &server_config)?;
+    let router = router::create(state, &server_config)?;
     let listener = TcpListener::bind(("0.0.0.0", server_config.port)).await?;
 
     axum::serve(listener, router)

--- a/kitsune/src/http/router.rs
+++ b/kitsune/src/http/router.rs
@@ -1,0 +1,339 @@
+use super::{graphql, handler, middleware, serve_frontend, trace_layer, X_REQUEST_ID};
+use crate::state::Zustand;
+use axum::{extract::DefaultBodyLimit, routing, Extension, Router};
+use color_eyre::eyre::{self, Context};
+use cursiv::CsrfLayer;
+use kitsune_config::server;
+use std::time::Duration;
+use tower_http::{
+    catch_panic::CatchPanicLayer,
+    cors::CorsLayer,
+    request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
+    timeout::TimeoutLayer,
+};
+use tower_http_digest::VerifyDigestLayer;
+use tower_stop_using_brave::StopUsingBraveLayer;
+use tower_x_clacks_overhead::XClacksOverheadLayer;
+
+pub fn create(state: Zustand, server_config: &server::Configuration) -> eyre::Result<Router> {
+    let router = Router::new()
+        .route(
+            "/confirm-account/:confirmation_token",
+            routing::get(handler::confirm_account::get),
+        )
+        .route("/emojis/:id", routing::get(handler::custom_emojis::get))
+        .route("/media/:id", routing::get(handler::media::get))
+        .route(
+            "/nodeinfo/2.1",
+            routing::get(handler::nodeinfo::two_one::get),
+        )
+        .nest(
+            "/oauth",
+            Router::new()
+                .route(
+                    "/authorize",
+                    routing::get(handler::oauth::authorize::get)
+                        .post(handler::oauth::authorize::post),
+                )
+                .route("/token", routing::post(handler::oauth::token::post))
+                .layer(axum::middleware::from_fn(middleware::json_to_urlencoded)),
+        )
+        .nest(
+            "/posts",
+            Router::new()
+                .route("/:id", routing::get(handler::posts::get))
+                .route("/:id/activity", routing::get(handler::posts::activity::get)),
+        )
+        .nest(
+            "/users",
+            Router::new()
+                .route("/:user_id", routing::get(handler::users::get))
+                .route(
+                    "/:user_id/followers",
+                    routing::get(handler::users::followers::get),
+                )
+                .route(
+                    "/:user_id/following",
+                    routing::get(handler::users::following::get),
+                )
+                .route(
+                    "/:user_id/inbox",
+                    routing::post(handler::users::inbox::post).layer(VerifyDigestLayer::default()),
+                )
+                .route(
+                    "/:user_id/outbox",
+                    routing::get(handler::users::outbox::get),
+                ),
+        )
+        .nest(
+            "/.well-known",
+            Router::new()
+                .route(
+                    "/nodeinfo",
+                    routing::get(handler::well_known::nodeinfo::get),
+                )
+                .route(
+                    "/webfinger",
+                    routing::get(handler::well_known::webfinger::get),
+                ),
+        )
+        .route("/public/*path", routing::get(handler::public::get));
+
+    #[cfg(feature = "oidc")]
+    let router = router.route("/oidc/callback", routing::get(handler::oidc::callback::get));
+
+    #[cfg(feature = "graphql-api")]
+    let router = router.merge(
+        Router::new()
+            .route("/graphql", routing::any(graphql::graphql))
+            .route("/graphiql", routing::get(graphql::graphiql))
+            .layer(Extension(graphql::schema(state.clone()))),
+    );
+
+    #[cfg(feature = "mastodon-api")]
+    let router = router.nest(
+        "/api",
+        Router::new()
+            .nest(
+                "/v1",
+                Router::new()
+                    .nest(
+                        "/accounts",
+                        Router::new()
+                            .route(
+                                "/:id",
+                                routing::get(handler::mastodon::api::v1::accounts::get),
+                            )
+                            .route(
+                                "/:id/follow",
+                                routing::post(handler::mastodon::api::v1::accounts::follow::post),
+                            )
+                            .route(
+                                "/:id/statuses",
+                                routing::get(handler::mastodon::api::v1::accounts::statuses::get),
+                            )
+                            .route(
+                                "/:id/unfollow",
+                                routing::post(handler::mastodon::api::v1::accounts::unfollow::post),
+                            )
+                            .route(
+                                "/lookup",
+                                routing::get(handler::mastodon::api::v1::accounts::lookup::get),
+                            )
+                            .route(
+                                "/relationships",
+                                routing::get(
+                                    handler::mastodon::api::v1::accounts::relationships::get,
+                                ),
+                            )
+                            .route(
+                                "/update_credentials",
+                                routing::patch(
+                                    handler::mastodon::api::v1::accounts::update_credentials::patch,
+                                ),
+                            )
+                            .route(
+                                "/verify_credentials",
+                                routing::get(
+                                    handler::mastodon::api::v1::accounts::verify_credentials::get,
+                                ),
+                            ),
+                    )
+                    .route(
+                        "/apps",
+                        routing::post(handler::mastodon::api::v1::apps::post),
+                    )
+                    .route(
+                        "/custom_emojis",
+                        routing::get(handler::mastodon::api::v1::custom_emojis::get),
+                    )
+                    .nest(
+                        "/follow_requests",
+                        Router::new()
+                            .route(
+                                "/",
+                                routing::get(handler::mastodon::api::v1::follow_requests::get),
+                            )
+                            .route(
+                                "/:id/authorize",
+                                routing::post(
+                                    handler::mastodon::api::v1::follow_requests::accept::post,
+                                ),
+                            )
+                            .route(
+                                "/:id/reject",
+                                routing::post(
+                                    handler::mastodon::api::v1::follow_requests::reject::post,
+                                ),
+                            ),
+                    )
+                    .route(
+                        "/instance",
+                        routing::get(handler::mastodon::api::v1::instance::get),
+                    )
+                    .nest(
+                        "/media",
+                        Router::new()
+                            .route(
+                                "/",
+                                routing::post(handler::mastodon::api::v1::media::post).layer(
+                                    DefaultBodyLimit::max(
+                                        server_config.max_upload_size.to_bytes() as usize
+                                    ),
+                                ),
+                            )
+                            .route(
+                                "/:id",
+                                routing::get(handler::mastodon::api::v1::media::get)
+                                    .put(handler::mastodon::api::v1::media::put),
+                            ),
+                    )
+                    .nest(
+                        "/notifications",
+                        Router::new()
+                            .route(
+                                "/",
+                                routing::get(handler::mastodon::api::v1::notifications::get),
+                            )
+                            .route(
+                                "/:id",
+                                routing::get(handler::mastodon::api::v1::notifications::get_by_id),
+                            )
+                            .route(
+                                "/:id/dismiss",
+                                routing::post(
+                                    handler::mastodon::api::v1::notifications::dismiss::post,
+                                ),
+                            )
+                            .route(
+                                "/clear",
+                                routing::post(
+                                    handler::mastodon::api::v1::notifications::clear::post,
+                                ),
+                            ),
+                    )
+                    .nest(
+                        "/statuses",
+                        Router::new()
+                            .route(
+                                "/",
+                                routing::post(handler::mastodon::api::v1::statuses::post),
+                            )
+                            .route(
+                                "/:id",
+                                routing::delete(handler::mastodon::api::v1::statuses::delete)
+                                    .get(handler::mastodon::api::v1::statuses::get)
+                                    .put(handler::mastodon::api::v1::statuses::put),
+                            )
+                            .route(
+                                "/:id/context",
+                                routing::get(handler::mastodon::api::v1::statuses::context::get),
+                            )
+                            .route(
+                                "/:id/favourite",
+                                routing::post(
+                                    handler::mastodon::api::v1::statuses::favourite::post,
+                                ),
+                            )
+                            .route(
+                                "/:id/favourited_by",
+                                routing::get(
+                                    handler::mastodon::api::v1::statuses::favourited_by::get,
+                                ),
+                            )
+                            .route(
+                                "/:id/reblog",
+                                routing::post(handler::mastodon::api::v1::statuses::reblog::post),
+                            )
+                            .route(
+                                "/:id/reblogged_by",
+                                routing::get(
+                                    handler::mastodon::api::v1::statuses::reblogged_by::get,
+                                ),
+                            )
+                            .route(
+                                "/:id/source",
+                                routing::get(handler::mastodon::api::v1::statuses::source::get),
+                            )
+                            .route(
+                                "/:id/unfavourite",
+                                routing::post(
+                                    handler::mastodon::api::v1::statuses::unfavourite::post,
+                                ),
+                            )
+                            .route(
+                                "/:id/unreblog",
+                                routing::post(handler::mastodon::api::v1::statuses::unreblog::post),
+                            ),
+                    )
+                    .nest(
+                        "/timelines",
+                        Router::new()
+                            .route(
+                                "/home",
+                                routing::get(handler::mastodon::api::v1::timelines::home::get),
+                            )
+                            .route(
+                                "/public",
+                                routing::get(handler::mastodon::api::v1::timelines::public::get),
+                            ),
+                    ),
+            )
+            .nest(
+                "/v2",
+                Router::new()
+                    .nest(
+                        "/media",
+                        Router::new()
+                            .route(
+                                "/",
+                                routing::post(handler::mastodon::api::v1::media::post).layer(
+                                    DefaultBodyLimit::max(
+                                        server_config.max_upload_size.to_bytes() as usize
+                                    ),
+                                ),
+                            )
+                            .route(
+                                "/:id",
+                                routing::get(handler::mastodon::api::v1::media::get)
+                                    .put(handler::mastodon::api::v1::media::put),
+                            ),
+                    )
+                    .route(
+                        "/search",
+                        routing::get(handler::mastodon::api::v2::search::get),
+                    ),
+            ),
+    );
+
+    let mut router = router.fallback_service(serve_frontend(server_config));
+
+    if !server_config.clacks_overhead.is_empty() {
+        let clacks_overhead_layer =
+            XClacksOverheadLayer::new(server_config.clacks_overhead.iter().map(AsRef::as_ref))
+                .wrap_err("Invalid clacks overhead values")?;
+
+        router = router.layer(clacks_overhead_layer);
+    }
+
+    if server_config.deny_brave_browsers {
+        router = router.layer(StopUsingBraveLayer::default());
+    }
+
+    let router = router
+        .layer(CatchPanicLayer::new())
+        .layer(CorsLayer::permissive())
+        .layer(CsrfLayer::generate()) // TODO: Make this configurable instead of random
+        .layer(TimeoutLayer::new(Duration::from_secs(
+            server_config.request_timeout_secs,
+        )))
+        .layer(trace_layer())
+        .layer(PropagateRequestIdLayer::new(X_REQUEST_ID.clone()))
+        .layer(SetRequestIdLayer::new(
+            X_REQUEST_ID.clone(),
+            MakeRequestUuid,
+        ))
+        .with_state(state);
+
+    Ok(router)
+}

--- a/lib/cursiv/Cargo.toml
+++ b/lib/cursiv/Cargo.toml
@@ -13,7 +13,7 @@ hex-simd = "0.8.0"
 http = "1.1.0"
 pin-project-lite = "0.2.14"
 rand = "0.8.5"
-tower = { version = "0.5.0", default-features = false }
+tower = { version = "0.5.1", default-features = false }
 triomphe = { workspace = true }
 zeroize = { version = "1.8.1", features = ["derive"] }
 
@@ -23,7 +23,7 @@ axum-core = { version = "0.4.3", optional = true }
 
 [dev-dependencies]
 futures-test = "0.3.30"
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [features]
 axum = ["dep:async-trait", "dep:axum-core"]

--- a/lib/tower-http-digest/Cargo.toml
+++ b/lib/tower-http-digest/Cargo.toml
@@ -23,7 +23,7 @@ tracing = { version = "0.1.40", default-features = false }
 bytes = "1.7.1"
 futures-test = "0.3.30"
 http-body-util = "0.1.2"
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [lints]
 workspace = true

--- a/lib/tower-stop-using-brave/Cargo.toml
+++ b/lib/tower-stop-using-brave/Cargo.toml
@@ -14,7 +14,7 @@ tower-service = "0.3.3"
 
 [dev-dependencies]
 futures-test = "0.3.30"
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [lints]
 workspace = true

--- a/lib/tower-x-clacks-overhead/Cargo.toml
+++ b/lib/tower-x-clacks-overhead/Cargo.toml
@@ -15,7 +15,7 @@ triomphe = { workspace = true }
 
 [dev-dependencies]
 futures-test = "0.3.30"
-tower = { version = "0.5.0", default-features = false, features = ["util"] }
+tower = { version = "0.5.1", default-features = false, features = ["util"] }
 
 [lints]
 workspace = true


### PR DESCRIPTION
I prefer this style since it makes it easier for us to wrap specific routes into layers (such as the media upload routes into the modified max body size), and makes it pretty easy to keep track of all routes.

That's similar to how Phoenix handles its routes, too, and it makes sense.