### PR TITLE
JSON handling abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3289,6 +3289,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9028f49264629065d057f340a86acb84867925865f73bbf8d47b4d149a7e88b8"
 
 [[package]]
+name = "jason"
+version = "0.0.1-pre.6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "sonic-rs",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "lib/geomjeungja",
     "lib/http-signatures",
     "lib/http-signatures-cli",
+    "lib/jason",
     "lib/just-retry",
     "lib/komainu",
     "lib/masto-id-convert",
@@ -413,6 +414,7 @@ cursiv = { path = "lib/cursiv", features = ["axum"] }
 fast-cjson = { path = "lib/fast-cjson" }
 flashy = { path = "lib/flashy", features = ["axum"] }
 http-signatures = { path = "lib/http-signatures" }
+jason = { path = "lib/jason" }
 just-retry = { path = "lib/just-retry" }
 komainu = { path = "lib/komainu" }
 mrf-manifest = { path = "lib/mrf-manifest", features = [

--- a/lib/jason/Cargo.toml
+++ b/lib/jason/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "jason"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+serde.workspace = true
+serde_json.workspace = true
+
+[target.'cfg(target_pointer_width = "64")'.dependencies]
+sonic-rs.workspace = true
+
+[lints]
+workspace = true

--- a/lib/jason/src/lib.rs
+++ b/lib/jason/src/lib.rs
@@ -1,0 +1,16 @@
+#[cfg(target_pointer_width = "64")]
+pub use sonic_rs::{from_reader, from_slice, from_str, to_string, Result};
+
+#[inline]
+pub fn to_writer<W, T>(writer: W, value: &T) -> Result<()>
+where
+    W: std::io::Write,
+    T: ?Sized + serde::Serialize,
+{
+    use sonic_rs::writer::BufferedWriter;
+
+    sonic_rs::to_writer(BufferedWriter::new(writer), value)
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+pub use serde_json::{from_reader, from_slice, from_str, to_string, to_writer, Result};


### PR DESCRIPTION
`sonic-rs` indicated that it only intends to support 64-bit architectures, but I want to enable cursed and weird deployment environments, so 32-bit support is kinda necessary here ("running Kitsune on an Xperia Tipo in a plastic bag hanging from my balcony"-ahhh deployments)

The library should abstract between `sonic-rs` and `serde-json` without issues, and only compile `sonic-rs` on 64-bit platforms.